### PR TITLE
style class to crop with ellipsis

### DIFF
--- a/assets/css/romo/base.scss
+++ b/assets/css/romo/base.scss
@@ -415,8 +415,9 @@ h3 { @include text1; }
 
 .romo-match-line-height { line-height: 1 !important; }
 
-.romo-nowrap { white-space: nowrap !important; }
-.romo-crop   { white-space: nowrap !important; overflow: hidden !important; }
+.romo-nowrap        { white-space: nowrap !important; }
+.romo-crop          { white-space: nowrap !important; overflow: hidden !important; }
+.romo-crop-ellipsis { white-space: nowrap !important; overflow: hidden !important; text-overflow: ellipsis !important; }
 
 .romo-inline       { display: inline !important; }
 .romo-inline-block { display: inline-block !important; }

--- a/gh-pages/view_handlers/css/helpers.md
+++ b/gh-pages/view_handlers/css/helpers.md
@@ -252,12 +252,16 @@ Use style classes to float elements.
 
 Use style classes to handle common overflow cases.
 
+<div style="width: 150px" class="romo-border romo-inline-block romo-nowrap">.romo-nowrap: content that will overflow</div>
+<div></div>
 <div style="width: 150px" class="romo-border romo-inline-block romo-crop">.romo-crop: content that will overflow</div>
 <div></div>
-<div style="width: 150px" class="romo-border romo-inline-block romo-nowrap">.romo-nowrap: content that will overflow</div>
+<div style="width: 150px" class="romo-border romo-inline-block romo-crop-ellipsis">.romo-crop-ellipsis: content that will overflow</div>
 
 ```html
+<div style="width: 150px" class="romo-border romo-inline-block romo-nowrap">...</div>
+<div></div>
 <div style="width: 150px" class="romo-border romo-inline-block romo-crop">...</div>
 <div></div>
-<div style="width: 150px" class="romo-border romo-inline-block romo-nowrap">...</div>
+<div style="width: 150px" class="romo-border romo-inline-block romo-crop-ellipsis">...</div>
 ```


### PR DESCRIPTION
This adds `.romo-crop-ellipsis`, which as it name implies, will crop
content just like `.romo-crop` but will also add ellipsis.  This
is done using `text-overflow: ellipsis`.

@jcredding ready for review.  You cool with this name (as opposed to `.romo-ellipsis` or something)?  I wanted to keep crop in there b/c this is about more than just adding the text overflow style.  You have to have the others with it or it won't work.  For reference:
- http://css-tricks.com/snippets/css/truncate-string-with-ellipsis/
- http://html5hub.com/ellipse-my-text/ (text-overflow: ellipsis section)
