### PR TITLE
romo tables/grid-tables without any borders

### DIFF
--- a/assets/css/romo/grid_table.scss
+++ b/assets/css/romo/grid_table.scss
@@ -57,19 +57,22 @@ ol.romo-grid-table { @include list-unstyled(!important); }
 .romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-inverse:not(:first-child):hover { @include bg-inverse-hover; }
 
 .romo-grid-table-border,
-.romo-grid-table-border1 { @include border1; }
-.romo-grid-table-border0 { @include border0; }
-.romo-grid-table-border2 { @include border2; }
+.romo-grid-table-border1     { @include border1; }
+.romo-grid-table-border0     { @include border0; }
+.romo-grid-table-border2     { @include border2; }
+.romo-grid-table-border-none { @include border-style(none); }
 
-.romo-grid-table.romo-grid-table-border  > .romo-row,
-.romo-grid-table.romo-grid-table-border1 > .romo-row { @include border1-bottom; }
-.romo-grid-table.romo-grid-table-border0 > .romo-row { @include border0-bottom; }
-.romo-grid-table.romo-grid-table-border2 > .romo-row { @include border2-bottom; }
+.romo-grid-table.romo-grid-table-border      > .romo-row,
+.romo-grid-table.romo-grid-table-border1     > .romo-row { @include border1-bottom; }
+.romo-grid-table.romo-grid-table-border0     > .romo-row { @include border0-bottom; }
+.romo-grid-table.romo-grid-table-border2     > .romo-row { @include border2-bottom; }
+.romo-grid-table.romo-grid-table-border-none > .romo-row { @include border-style(none); }
 
-.romo-grid-table.romo-grid-table-border  > .romo-row > .romo-span,
-.romo-grid-table.romo-grid-table-border1 > .romo-row > .romo-span { @include border1-right; white-space: nowrap; overflow: hidden; }
-.romo-grid-table.romo-grid-table-border0 > .romo-row > .romo-span { @include border0-right; white-space: nowrap; overflow: hidden; }
-.romo-grid-table.romo-grid-table-border2 > .romo-row > .romo-span { @include border2-right; white-space: nowrap; overflow: hidden; }
+.romo-grid-table.romo-grid-table-border      > .romo-row > .romo-span,
+.romo-grid-table.romo-grid-table-border1     > .romo-row > .romo-span { @include border1-right;      white-space: nowrap; overflow: hidden; }
+.romo-grid-table.romo-grid-table-border0     > .romo-row > .romo-span { @include border0-right;      white-space: nowrap; overflow: hidden; }
+.romo-grid-table.romo-grid-table-border2     > .romo-row > .romo-span { @include border2-right;      white-space: nowrap; overflow: hidden; }
+.romo-grid-table.romo-grid-table-border-none > .romo-row > .romo-span { @include border-style(none); white-space: nowrap; overflow: hidden; }
 
 .romo-grid-table[class*="romo-grid-table-border"] > .romo-row > .romo-span:last-child { @include rm-border-right; }
 .romo-grid-table[class*="romo-grid-table-border"] > .romo-row:last-child { @include rm-border-bottom; }

--- a/assets/css/romo/table.scss
+++ b/assets/css/romo/table.scss
@@ -40,17 +40,20 @@
 .romo-table-border,
 .romo-table-border0,
 .romo-table-border1,
-.romo-table-border2 { border-collapse: collapse; *border-collapse: collapse; }
+.romo-table-border2,
+.romo-table-border-none { border-collapse: collapse; *border-collapse: collapse; }
 
 .romo-table-border,
-.romo-table-border1 { @include border1-top; @include border1-left; }
-.romo-table-border0 { @include border0-top; @include border0-left; }
-.romo-table-border2 { @include border2-top; @include border2-left; }
+.romo-table-border1     { @include border1-top; @include border1-left; }
+.romo-table-border0     { @include border0-top; @include border0-left; }
+.romo-table-border2     { @include border2-top; @include border2-left; }
+.romo-table-border-none { @include border-style(none); }
 
-.romo-table-border  th, .romo-table-border  td,
-.romo-table-border1 th, .romo-table-border1 td { @include border1-bottom; @include border1-right; }
-.romo-table-border0 th, .romo-table-border0 td { @include border0-bottom; @include border0-right; }
-.romo-table-border2 th, .romo-table-border2 td { @include border2-bottom; @include border2-right; }
+.romo-table-border      th, .romo-table-border      td,
+.romo-table-border1     th, .romo-table-border1     td { @include border1-bottom; @include border1-right; }
+.romo-table-border0     th, .romo-table-border0     td { @include border0-bottom; @include border0-right; }
+.romo-table-border2     th, .romo-table-border2     td { @include border2-bottom; @include border2-right; }
+.romo-table-border-none th, .romo-table-border-none td { @include border-style(none); }
 
 .romo-table-border-muted   { @include border-muted; }
 .romo-table-border-warning { @include border-warning; }

--- a/gh-pages/view_handlers/css/grid_tables.md
+++ b/gh-pages/view_handlers/css/grid_tables.md
@@ -8,12 +8,14 @@ You **won't** get:
 
 * semantic header, body, footer, etc.
 * auto sizing columns based on their content
-* consistant cell heights across rows.
+* consistent cell heights across rows.
 
 You **will** get:
 
 * raw markup that can be more easily manipulated (ie drag n drop, etc).
 * more flexible styling control
+
+**Also note**: Romo grid tables aren't designed to be nested in one another.  Doing so causes the styles of the parent grid table to be forced on the child grid table.
 
 ### Default styles
 
@@ -610,7 +612,7 @@ Add hover state to rows
 
 Adds sized borders to the grid table.
 
-**Note**: This makes all cells hide any overflow.  Since grid tables don't keep all cell heights the same (like normal tables do), uneven grid heights break the borders.  If you need cells to overflow with borders, use a normal table.
+**Note**: This makes all cells hide any overflow.  Since grid tables don't keep all cell heights the same (like normal tables do), uneven grid heights break the borders.  If you need cells to overflow with borders, use a standard romo table.
 
 <div class="romo-pad2-bottom">
   <ul class="romo-grid-table romo-grid-table-header romo-grid-table-border">
@@ -730,6 +732,47 @@ Adds sized borders to the grid table.
 
 ```html
 <ul class="romo-grid-table romo-grid-table-border{0-2}">
+  ...
+</ul>
+```
+
+### `.romo-grid-table-border-none`
+
+Remove all borders from the grid table.
+
+**Note**: This makes all cells hide any overflow.  Since grid tables don't keep all cell heights the same (like normal tables do), uneven grid heights break the borders.  If you need cells to overflow with borders, use a standard romo table.
+
+<div class="romo-pad2-bottom">
+  <ul class="romo-grid-table romo-grid-table-header romo-grid-table-border-none">
+    <li class="romo-row">
+      <span class="romo-span romo-1-12">#</span>
+      <span class="romo-span romo-5-12">Name</span>
+      <span class="romo-span romo-5-12">Slug</span>
+      <span class="romo-span romo-1-12">Count</span>
+    </li>
+    <li class="romo-row">
+      <span class="romo-span romo-1-12">1</span>
+      <span class="romo-span romo-5-12">Joe Test</span>
+      <span class="romo-span romo-5-12">joe-test</span>
+      <span class="romo-span romo-1-12">10</span>
+    </li>
+    <li class="romo-row">
+      <span class="romo-span romo-1-12">2</span>
+      <span class="romo-span romo-5-12">Jane Doe</span>
+      <span class="romo-span romo-5-12">jane-doe</span>
+      <span class="romo-span romo-1-12">18</span>
+    </li>
+    <li class="romo-row">
+      <span class="romo-span romo-1-12">3</span>
+      <span class="romo-span romo-5-12">Good Corp.</span>
+      <span class="romo-span romo-5-12">good-corp</span>
+      <span class="romo-span romo-1-12">overflow: 1234567890</span>
+    </li>
+  </ul>
+</div>
+
+```html
+<ul class="romo-grid-table romo-grid-table-border-none">
   ...
 </ul>
 ```

--- a/gh-pages/view_handlers/css/tables.md
+++ b/gh-pages/view_handlers/css/tables.md
@@ -1,3 +1,7 @@
+## Notes
+
+*   Romo tables aren't designed to be nested in one another.  Doing so causes the styles of the parent table to be forced on the child table.
+
 ## Default styles
 
 For basic styling with horizontal dividers, add the base class `.romo-table`.
@@ -670,6 +674,52 @@ Adds sized borders to the table.
 
 ```html
 <table class="romo-table romo-table-border{0-2}">
+  ...
+</table>
+```
+
+### `.romo-table-border-none`
+
+Remove all borders from the table.
+
+<div class="romo-push2-bottom">
+  <table class="romo-table romo-table-border-none">
+    <thead>
+      <tr>
+        <th>#</th>
+        <th>Name</th>
+        <th>Slug</th>
+        <th>Count</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td rowspan="2">1</td>
+        <td>Joe Test</td>
+        <td>joe-test</td>
+        <td>10</td>
+      </tr>
+      <tr>
+        <td>Joe Test</td>
+        <td>joe-test</td>
+        <td>0</td>
+      </tr>
+      <tr>
+        <td>2</td>
+        <td>Jane Doe</td>
+        <td>jane-doe</td>
+        <td rowspan="2">18</td>
+      </tr>
+      <tr>
+        <td>3</td>
+        <td colspan="2">Good Corp.</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+```html
+<table class="romo-table romo-table-border-none">
   ...
 </table>
 ```


### PR DESCRIPTION
This adds `.romo-table-border-none` and `.romo-grid-table-border-none`
style classes to remove all borders from their respective components.

Previously, because these components forced row bottom borders by
default, there was no way to use these components without any borders.

@jcredding ready for review.  This keeps consistent with the generic `.romo-border-none` style class.
