### PR TITLE
form js: add `submitCompleted` event

### DIFF
--- a/assets/js/romo/form.js
+++ b/assets/js/romo/form.js
@@ -68,8 +68,8 @@ RomoForm.prototype.onSubmitClick = function(e) {
 }
 
 RomoForm.prototype.doSubmit = function() {
-  this.elem.trigger('form:beforeSubmit', [this]);
   this.indicatorElems.trigger('indicator:triggerStart');
+  this.elem.trigger('form:beforeSubmit', [this]);
 
   if (this.elem.attr('method').toUpperCase() === 'GET') {
     this._doGetSubmit();
@@ -81,6 +81,7 @@ RomoForm.prototype.doSubmit = function() {
 RomoForm.prototype.onSubmitSuccess = function(data, status, xhr) {
   this.elem.trigger('form:clearMsgs');
   this.elem.trigger('form:submitSuccess', [data, this]);
+  this.elem.trigger('form:submitComplete', [this]);
 }
 
 RomoForm.prototype.onSubmitError = function(xhr, errorType, error) {
@@ -92,6 +93,7 @@ RomoForm.prototype.onSubmitError = function(xhr, errorType, error) {
     this.elem.trigger('form:submitXhrError', [xhr, this]);
   }
   this.elem.trigger('form:submitError', [xhr, this]);
+  this.elem.trigger('form:submitComplete', [this]);
   this.indicatorElems.trigger('indicator:triggerStop');
 }
 

--- a/assets/js/romo/indicator.js
+++ b/assets/js/romo/indicator.js
@@ -56,9 +56,7 @@ RomoIndicator.prototype.onStart = function(e) {
     e.preventDefault();
   }
 
-  if (this.elem.hasClass('disabled') === false) {
-    this.doStart();
-  }
+  this.doStart();
 }
 
 RomoIndicator.prototype.onStop = function(e) {
@@ -66,9 +64,7 @@ RomoIndicator.prototype.onStop = function(e) {
     e.preventDefault();
   }
 
-  if (this.elem.hasClass('disabled') === false) {
-    this.doStop();
-  }
+  this.doStop();
 }
 
 RomoIndicator.prototype.doStart = function() {


### PR DESCRIPTION
This event will fire when the submit is finished, whether it was
successful or errored.  This is to make the API and feature set
more rich and so you can trigger behavior once the submit completes.

This also cleans up the indicator handling.  First it moves to triggering
the indicator before firing the before submit event.  This ensures
the very first and very last things done in the submit cylcle it
to start/stop the indicator.  This also updates the indicator logic
to run even if the element is disabled.  This is necessary as users
may wish to disable the indicator but still stop it later on.

@jcredding ready for review.
