### PR TITLE
modal/dropdown js: clear content on close option

### DIFF
--- a/assets/js/romo/dropdown.js
+++ b/assets/js/romo/dropdown.js
@@ -210,6 +210,11 @@ RomoDropdown.prototype.doPopupClose = function() {
   $('body').off('keyup', $.proxy(this.onWindowBodyKeyUp, this));
   $(window).off('resize', $.proxy(this.onResizeWindow, this));
 
+  // clear the content elem markup if configured to
+  if (this.elem.data('romo-dropdown-clear-content') === true) {
+    this.contentElem.html('');
+  }
+
   this.elem.trigger('dropdown:popupClose', [this]);
 }
 

--- a/assets/js/romo/dropdown_form.js
+++ b/assets/js/romo/dropdown_form.js
@@ -30,6 +30,10 @@ RomoDropdownForm.prototype.doInit = function() {
 }
 
 RomoDropdownForm.prototype.doBindDropdown = function() {
+if (this.elem.data('romo-dropdown-clear-content') === undefined) {
+    this.elem.attr('data-romo-dropdown-clear-content', 'true');
+  }
+
   this.elem.on('dropdown:ready', $.proxy(function(e, dropdown) {
     this.elem.trigger('dropdownForm:dropdown:ready', [dropdown, this]);
   }, this));

--- a/assets/js/romo/modal.js
+++ b/assets/js/romo/modal.js
@@ -195,6 +195,11 @@ RomoModal.prototype.doPopupClose = function() {
   // unbind window resizes reposition modal
   $(window).off('resize', $.proxy(this.onResizeWindow, this));
 
+  // clear the content elem markup if configured to
+  if (this.elem.data('romo-modal-clear-content') === true) {
+    this.contentElem.html('');
+  }
+
   this.elem.trigger('modal:popupClose', [this]);
 }
 

--- a/assets/js/romo/modal_form.js
+++ b/assets/js/romo/modal_form.js
@@ -30,6 +30,10 @@ RomoModalForm.prototype.doInit = function() {
 }
 
 RomoModalForm.prototype.doBindModal = function() {
+  if (this.elem.data('romo-modal-clear-content') === undefined) {
+    this.elem.attr('data-romo-modal-clear-content', 'true');
+  }
+
   this.elem.on('modal:ready', $.proxy(function(e, modal) {
     this.elem.trigger('modalForm:modal:ready', [modal, this]);
   }, this));


### PR DESCRIPTION
This adds an option to make modals and dropdowns clear their contents
on close.  This is useful when many elems (maybe each on a row of
a list) all render the same markup.  A common example is each row of
a list having an edit modal form that contains identical markup
(submitting to unique urls).  If any elements of the form are referenced
with IDs they will be duplicated in the DOM once more than one modal
is invoked.  This allows you to clear the content on close to prevent
the duplication (since no two modals/dropdowns can be open at the
same time).

This also updates the modal/dropdown form components to default this
option to true if not already set.

@jcredding ready for review.
