### PR TITLE
dropdown js: set offset if setting position fixed

### DIFF
--- a/assets/js/romo/dropdown.js
+++ b/assets/js/romo/dropdown.js
@@ -260,6 +260,7 @@ RomoDropdown.prototype.onResizeWindow = function(e) {
 RomoDropdown.prototype.doPlacePopupElem = function() {
   if (this.elem.parents('.romo-modal-popup').size() !== 0) {
     this.popupElem.css({'position': 'fixed'});
+    this.popupElem.offset(this.elem.offset());
   }
 
   var pos = $.extend({}, this.elem[0].getBoundingClientRect(), this.elem.offset());


### PR DESCRIPTION
This fixes a bug in Chrome where it doesn't properly honor the offset
it the dropdown element is dynamically changed to position: fixed.
This comes up when using dropdowns (for example select dropdowns)
in modals (ie model forms).  The initial opening of the dropdown
sets position fixed and calculates the offset.

It seems the calculating the offset the first time "resets" how
chrome determines the offset (ie honor postion fixed) b/c subsequent
offset calcs are done correctly.

This is somewhat a "hack" in that this behavior is not exhibited
in Firefox.  It is less of a hack though because we only apply it
when setting position fixed dropdowns (ie only when it is needed).

@jcredding ready for review.  Let me know if you have any better suggestion or if this is "too hacky" for you.
