### PR TITLE
js: kepress component

### DIFF
--- a/assets/js/romo/keypress.js
+++ b/assets/js/romo/keypress.js
@@ -1,0 +1,35 @@
+$.fn.romoKeypress = function() {
+  return $.map(this, function(element) {
+    return new RomoKeypress(element);
+  });
+}
+
+var RomoKeypress = function(element) {
+  this.elem = $(element);
+  this.defaultTriggerOn = 'keydown';
+
+  this.doInit();
+
+  this.triggerOn = this.elem.data('romo-keypress-on') || this.defaultTriggerOn;
+  this.elem.on(this.triggerOn, $.proxy(this.onTrigger, this));
+
+  this.elem.trigger('keypress:ready', [this]);
+}
+
+RomoKeypress.prototype.doInit = function() {
+  // override as needed
+}
+
+RomoKeypress.prototype.onTrigger = function(e) {
+  if (this.elem.hasClass('disabled') === false) {
+    this.doTrigger(e);
+  }
+}
+
+RomoKeypress.prototype.doTrigger = function(triggerEvent) {
+  this.elem.trigger('keypress:trigger', [triggerEvent, this]);
+}
+
+Romo.onInitUI(function(e) {
+  Romo.initUIElems(e, '[data-romo-keypress-auto="true"]').romoKeypress();
+});

--- a/lib/romo/dassets.rb
+++ b/lib/romo/dassets.rb
@@ -43,6 +43,7 @@ module Romo::Dassets
       c.combination "js/romo.js", [
         'js/romo/base.js',
         'js/romo/invoke.js',
+        'js/romo/keypress.js',
         'js/romo/form.js',
         'js/romo/dropdown.js',
         'js/romo/dropdown_form.js',

--- a/test/unit/dassets_tests.rb
+++ b/test/unit/dassets_tests.rb
@@ -45,6 +45,7 @@ module Romo::Dassets
       exp_js_sources = [
         'js/romo/base.js',
         'js/romo/invoke.js',
+        'js/romo/keypress.js',
         'js/romo/form.js',
         'js/romo/dropdown.js',
         'js/romo/dropdown_form.js',


### PR DESCRIPTION
This component binds to an element and detects and publishes trigger
events on keypress events.  It is auto-invoked like other romo
components, publishes events and generally behaves like other romo
components.

This is a utility component.  It is designed to be used as a part
of bigger js components or behavior.  For example:
- submit-as-you-type form input
- pickers that search as you type
- keyboard shortcut handlers
- etc

@jcredding ready for review.  Please feedback on my naming choices and overall design.  Does it seem like this _could_ be integrated into the examples I mention above?  Thanks.
