### PR TITLE
form js: detect keypress submit elems and submit on keypress trigger

### DIFF
--- a/assets/js/romo/form.js
+++ b/assets/js/romo/form.js
@@ -11,8 +11,10 @@ var RomoForm = function(element, givenSubmitElement, givenIndicatorElements) {
   this.defaultIndicatorElems = this.elem.find('[data-romo-indicator-auto="true"]');
   this.indicatorElems = $(givenIndicatorElements || this.defaultIndicatorElems);
   this.changeSubmitElems = this.elem.find('[data-romo-form-change-submit="true"]');
+  this.keypressSubmitElems = this.elem.find('[data-romo-form-keypress-submit="true"]');
 
   this.defaultListValuesDelim = ',';
+  this.keypressSubmitDelay = 300;  // 0.3 secs
   this.submitQueued  = false;
   this.submitRunning = false;
 
@@ -43,6 +45,12 @@ RomoForm.prototype.doBindForm = function() {
 
   this.changeSubmitElems.on('change', $.proxy(function(e) {
     this.elem.trigger('form:triggerSubmit');
+  }, this));
+  this.keypressSubmitElems.on('keypress:trigger', $.proxy(function(e) {
+    clearTimeout(this.keypressSubmitTimeout);
+    this.keypressSubmitTimeout = setTimeout($.proxy(function() {
+      this.elem.trigger('form:triggerSubmit');
+    }, this), this.keypressSubmitDelay);
   }, this));
   this.elem.on('form:triggerSubmit', $.proxy(this.onSubmitClick, this));
 


### PR DESCRIPTION
This updates forms to detect any elements that have been marked as
keypress submit elements.  It binds the keypress trigger event to
submitting the form.

Note: this adds a minimal delay timeout on the event binding.  This
avoids submitting the form on _every_ keypress.  Instead this behaves
more like "submit the form when there is any pause in typing".

@jcredding ready for review.  Feedback on the timeout value.  I just tried to choose the minimal value that didn't spam-submit as you typed.
