### PR TITLE
css: line decoration style classes

### DIFF
--- a/assets/css/romo/_mixins.scss
+++ b/assets/css/romo/_mixins.scss
@@ -120,6 +120,13 @@
 @mixin text2($i:"") { @include font-size2($i); @include line-height2($i); }
 @mixin text3($i:"") { @include font-size3($i); @include line-height3($i); }
 
+/* text decoration */
+
+@mixin text-decoration-underline($i:"")    { text-decoration: underline #{$i};    }
+@mixin text-decoration-overline($i:"")     { text-decoration: overline #{$i};     }
+@mixin text-decoration-line-through($i:"") { text-decoration: line-through #{$i}; }
+@mixin text-decoration-none($i:"")         { text-decoration: none #{$i};         }
+
 /* text alignment */
 
 @mixin align-left($i:"")   { text-align: left #{$i}; }

--- a/assets/css/romo/base.scss
+++ b/assets/css/romo/base.scss
@@ -159,6 +159,20 @@ h3 { @include text1; }
 .romo-text-800     { @include font-weight(800,     !important); }
 .romo-text-900     { @include font-weight(900,     !important); }
 
+/* text decoration */
+
+.romo-text-underline     { @include text-decoration-underline(!important); }
+.romo-text-overline      { @include text-decoration-overline(!important); }
+.romo-text-line-through,
+.romo-text-strikethrough { @include text-decoration-line-through(!important); }
+.romo-text-no-line       { @include text-decoration-none(!important); }
+
+.romo-text-underline-hover:hover     { @include text-decoration-underline(!important); }
+.romo-text-overline-hover:hover      { @include text-decoration-overline(!important); }
+.romo-text-line-through-hover:hover,
+.romo-text-strikethrough-hover:hover { @include text-decoration-line-through(!important); }
+.romo-text-no-line-hover:hover       { @include text-decoration-none(!important); }
+
 /* alignment */
 
 .romo-align-left   { @include align-left(!important); }

--- a/gh-pages/view_handlers/css/typography.md
+++ b/gh-pages/view_handlers/css/typography.md
@@ -78,6 +78,40 @@ Or, use these natural-size style classes for the more common sizing needs.
 <div class="romo-text-large">...</div>
 ```
 
+## Line decoration classes
+
+Use style classes to set text decoration.
+
+<p class="romo-text-underline">.romo-text-underline</p>
+<p class="romo-text-overline">.romo-text-overline</p>
+<p class="romo-text-line-through">.romo-text-line-through</p>
+<p class="romo-text-strikethrough">.romo-text-strikethrough</p>
+<p class="romo-text-no-line">.romo-text-no-line</p>
+
+```html
+<p class="romo-text-underline">...</p>
+<p class="romo-text-overline">...</p>
+<p class="romo-text-line-through">...</p>
+<p class="romo-text-strikethrough">...</p>
+<p class="romo-text-no-line">...</p>
+```
+
+Or only set text decoration on hover.
+
+<p class="romo-text-underline-hover">.romo-text-underline-hover</p>
+<p class="romo-text-overline-hover">.romo-text-overline-hover</p>
+<p class="romo-text-line-through-hover">.romo-text-line-through-hover</p>
+<p class="romo-text-strikethrough-hover">.romo-text-strikethrough-hover</p>
+<p class="romo-text-no-line-hover">.romo-text-no-line-hover</p>
+
+```html
+<p class="romo-text-underline-hover">...</p>
+<p class="romo-text-overline-hover">...</p>
+<p class="romo-text-line-through-hover">...</p>
+<p class="romo-text-strikethrough-hover">...</p>
+<p class="romo-text-no-line-hover">...</p>
+```
+
 ## Alignment classes
 
 Use style classes to align text.


### PR DESCRIPTION
This adds style classes to control text line decoration.  This included
adding the different decoration options and removing any decoration.
This also includes `-hover` classes to only add decoration on hover.

Closes #14.

@jcredding ready for review.
