### PR TITLE
update select and datepicker js to properly bind hover behavior

### DIFF
--- a/assets/js/romo/datepicker.js
+++ b/assets/js/romo/datepicker.js
@@ -150,7 +150,7 @@ RomoDatepicker.prototype.doRefreshUI = function(date) {
   this._refreshCalendar(rDate);
   this.elem.trigger('datepicker:refresh', [rDate, this]);
 
-  this.calTable.find(this.itemSelector).on('hover', $.proxy(this.onItemHover, this));
+  this.calTable.find(this.itemSelector).on('mouseenter', $.proxy(this.onItemEnter, this));
   this.calTable.find(this.itemSelector).on('click', $.proxy(this.onItemClick, this));
 
   this.romoDropdown.popupElem.on('mousedown', $.proxy(this.onPopupMouseDown, this));
@@ -228,7 +228,7 @@ RomoDatepicker.prototype.onPopupClose = function(e) {
   this._highlightItem($());
 }
 
-RomoDatepicker.prototype.onItemHover = function(e) {
+RomoDatepicker.prototype.onItemEnter = function(e) {
   if (e !== undefined) {
     e.preventDefault();
     e.stopPropagation();

--- a/assets/js/romo/select_dropdown.js
+++ b/assets/js/romo/select_dropdown.js
@@ -80,7 +80,7 @@ RomoSelectDropdown.prototype.doBindDropdown = function() {
   this.romoDropdown.bodyElem.html('');
   this.romoDropdown.bodyElem.append(this.optionList);
 
-  this.romoDropdown.bodyElem.find(this.itemSelector).on('hover', $.proxy(this.onItemHover, this));
+  this.romoDropdown.bodyElem.find(this.itemSelector).on('mouseenter', $.proxy(this.onItemEnter, this));
   this.romoDropdown.bodyElem.find(this.itemSelector).on('click', $.proxy(this.onItemClick, this));
 
   this.romoDropdown.popupElem.on('mousedown', $.proxy(this.onPopupMouseDown, this));
@@ -113,7 +113,7 @@ RomoSelectDropdown.prototype.onPopupClose = function(e) {
   $('body').off('keydown', $.proxy(this.onPopupOpenBodyKeyDown, this));
 }
 
-RomoSelectDropdown.prototype.onItemHover = function(e) {
+RomoSelectDropdown.prototype.onItemEnter = function(e) {
   if (e !== undefined) {
     e.preventDefault();
     e.stopPropagation();


### PR DESCRIPTION
The 'hover' event name is deprecated in jQuery.  This switches to
the more formal (and more appropriate) `mouseenter` event name for
binding the behavior.

I discovered this when I upgraded jQuery on an app and suddenly
select value hovering broke.

@jcredding ready for review.
