### PR TITLE
add style classes to set to full width/height

### DIFF
--- a/assets/css/romo/base.scss
+++ b/assets/css/romo/base.scss
@@ -427,6 +427,8 @@ h3 { @include text1; }
 
 /* other helpers */
 
+.romo-full-width  { width: 100%; }
+.romo-full-height { width: 100%; }
 .romo-match-line-height { line-height: 1 !important; }
 
 .romo-nowrap        { white-space: nowrap !important; }


### PR DESCRIPTION
This is a helper for setting width/height to 100%.  Handy for elems
that aren't 100% by default but need to be in special cases.

Closes #15.

@jcredding ready for review.
