### PR TITLE
add style class for display none

### DIFF
--- a/assets/css/romo/base.scss
+++ b/assets/css/romo/base.scss
@@ -440,6 +440,7 @@ h3 { @include text1; }
 .romo-inline-flex  { @include display-inline-flex(!important); }
 .romo-flex         { @include display-flex(!important); }
 .romo-block        { display: block !important; }
+.romo-display-none { display: none !important;}
 
 .romo-relative { position: relative !important; }
 .romo-absolute { position: absolute !important; }

--- a/gh-pages/view_handlers/css/helpers.md
+++ b/gh-pages/view_handlers/css/helpers.md
@@ -201,11 +201,13 @@ Use style classes to set specific display values.
 <div class="romo-inline">-.romo-inline-</div>
 <div class="romo-inline-block">-.romo-inline-block-</div>
 <div class="romo-block">-.romo-block-</div>
+<div class="romo-display-none">-.romo-display-none-</div>
 
 ```html
 <div class="romo-inline">...</div>
 <div class="romo-inline-block">...</div>
 <div class="romo-block">...</div>
+<div class="romo-display-none">...</div>
 ```
 
 ## Position


### PR DESCRIPTION
This is to augment the other display classes.  This was missing and
there isn't really a good reason to not have it.

Closes #16.

@jcredding ready for review.
