### PR TITLE
add style class for centering using margin

### DIFF
--- a/assets/css/romo/base.scss
+++ b/assets/css/romo/base.scss
@@ -435,6 +435,8 @@ h3 { @include text1; }
 .romo-push-none-left,
 .romo-rm-push-left { @include rm-push-left(!important); }
 
+.romo-push-center { margin: 0 auto !important; }
+
 /* other helpers */
 
 .romo-full-width  { width: 100%; }

--- a/gh-pages/view_handlers/css/helpers.md
+++ b/gh-pages/view_handlers/css/helpers.md
@@ -194,6 +194,18 @@ Remove from just specific sides.
 </div>
 ```
 
+Use margin to center (only works on fixed width elems)
+
+<div class="romo-border">
+  <div class="romo-border romo-push-center" style="width: 150px">.romo-push-center</div>
+</div>
+
+```html
+<div class="romo-border">
+  <div class="romo-border romo-push-center">...</div>
+</div>
+```
+
 ## Display
 
 Use style classes to set specific display values.


### PR DESCRIPTION
This only works with fixed width elems, but can be used as an
alternate for `romo-align-center` that won't affect text alignment.

Closes #21.

@jcredding ready for review.
