### PR TITLE
fixed table layout style class

### DIFF
--- a/assets/css/romo/table.scss
+++ b/assets/css/romo/table.scss
@@ -1,7 +1,8 @@
 @import 'css/romo/vars';
 @import 'css/romo/mixins';
 
-.romo-table { width: 100%; }
+.romo-table       { width: 100%; }
+.romo-table-fixed { table-layout: fixed; }
 
 .romo-table th,
 .romo-table td {

--- a/gh-pages/view_handlers/css/tables.md
+++ b/gh-pages/view_handlers/css/tables.md
@@ -47,6 +47,49 @@ For basic styling with horizontal dividers, add the base class `.romo-table`.
 
 ## Optional classes
 
+### `.romo-table-fixed`
+
+Use the "fixed" table layout algorithm.
+
+<div>
+  <table class="romo-table romo-table-fixed">
+    <thead>
+      <tr>
+        <th>#</th>
+        <th>Name</th>
+        <th>Slug</th>
+        <th>Count</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>1</td>
+        <td>Joe Test</td>
+        <td>joe-test</td>
+        <td>10</td>
+      </tr>
+      <tr>
+        <td>2</td>
+        <td>Jane Doe</td>
+        <td>jane-doe</td>
+        <td>18</td>
+      </tr>
+      <tr>
+        <td>3</td>
+        <td>Good Corp. with really really long content that would normally cause the layout to adjust to fit it.</td>
+        <td>good-corp</td>
+        <td>5</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+```html
+<table class="romo-table">
+  ...
+</table>
+```
+
 ### `{th|td}.romo-N-N`
 
 Add grid column size classes to set table cell widths.


### PR DESCRIPTION
This adds a style class to force table layout fixed.  This is used
when you don't want the size of the table cols to adjust to their
content size.

Closes #17.

![tables romo 2015-04-15 15-55-06](https://cloud.githubusercontent.com/assets/82110/7169082/d67b5336-e387-11e4-9782-890a71ad44ab.png)

@jcredding ready for review.
