### PR TITLE
dropdown bugfix: properly position 'right' aligned dropdowns

### DIFF
--- a/assets/js/romo/dropdown.js
+++ b/assets/js/romo/dropdown.js
@@ -309,7 +309,7 @@ RomoDropdown.prototype.doPlacePopupElem = function() {
       $.extend(offset, { left: pos.left });
       break;
     case 'right':
-      $.extend(offset, { left: pos.right - w });
+      $.extend(offset, { left: pos.left + pos.width - w });
       break;
   }
 


### PR DESCRIPTION
The previous implementation used the 'right' attr from the calculated
pos object.  However this attr is not absolute to the page - it
is relative to the view port.  That is b/c it is coming from
`.getBoundingClientRect()` which is relative to the view port.
The `top` and `left` attrs are absolute as they are coming from
`.offset()`.

Why are we even using `.getBoundingClientRect()` you ask?  This is
because it also includes width, height, etc that offset does not.
The goal was to merge these objects and get more rich positioning
data.  However, I forgot that `right` and `bottom` in this case
are viewport-relative numbers.

This switches to using the `left` attr plus the `width` attr to
calculate right align position.

@jcredding ready for review.
