### PR TITLE
css: add font style hover classes

### DIFF
--- a/assets/css/romo/base.scss
+++ b/assets/css/romo/base.scss
@@ -143,6 +143,13 @@ h3 { @include text1; }
 .romo-text2 { @include text2(!important); @include font-weight2; }
 .romo-text3 { @include text3(!important); @include font-weight3; }
 
+.romo-text-small-hover:hover,
+.romo-text0-hover:hover { @include text0(!important); @include font-weight0; }
+.romo-text1-hover:hover { @include text1(!important); @include font-weight1; }
+.romo-text-large-hover:hover,
+.romo-text2-hover:hover { @include text2(!important); @include font-weight2; }
+.romo-text3-hover:hover { @include text3(!important); @include font-weight3; }
+
 .romo-text-inline-small,
 .romo-text-inline0 { @include line-height0(!important); }
 .romo-text-inline1 { @include line-height1(!important); }
@@ -165,6 +172,20 @@ h3 { @include text1; }
 .romo-text-700     { @include font-weight(700,     !important); }
 .romo-text-800     { @include font-weight(800,     !important); }
 .romo-text-900     { @include font-weight(900,     !important); }
+
+.romo-text-normal-hover:hover  { @include font-weight(normal,  !important); }
+.romo-text-lighter-hover:hover { @include font-weight(lighter, !important); }
+.romo-text-bold-hover:hover    { @include font-weight(bold,    !important); }
+.romo-text-bolder-hover:hover  { @include font-weight(bolder,  !important); }
+.romo-text-100-hover:hover     { @include font-weight(100,     !important); }
+.romo-text-200-hover:hover     { @include font-weight(200,     !important); }
+.romo-text-300-hover:hover     { @include font-weight(300,     !important); }
+.romo-text-400-hover:hover     { @include font-weight(400,     !important); }
+.romo-text-500-hover:hover     { @include font-weight(500,     !important); }
+.romo-text-600-hover:hover     { @include font-weight(600,     !important); }
+.romo-text-700-hover:hover     { @include font-weight(700,     !important); }
+.romo-text-800-hover:hover     { @include font-weight(800,     !important); }
+.romo-text-900-hover:hover     { @include font-weight(900,     !important); }
 
 /* text decoration */
 

--- a/gh-pages/view_handlers/css/typography.md
+++ b/gh-pages/view_handlers/css/typography.md
@@ -78,7 +78,25 @@ Or, use these natural-size style classes for the more common sizing needs.
 <div class="romo-text-large">...</div>
 ```
 
-## Line decoration classes
+Or only set a specific size on hover.
+
+<div class="romo-text0 romo-text1-hover">.romo-text0.romo-text1-hover</div>
+<div class="romo-text1 romo-text2-hover">.romo-text1.romo-text2-hover</div>
+<div class="romo-text2 romo-text3-hover">.romo-text2.romo-text3-hover</div>
+<div class="romo-text3 romo-text1-hover">.romo-text3.romo-text1-hover</div>
+<div class="romo-text-small romo-text-large-hover">.romo-text-small.romo-text-large-hover</div>
+<div class="romo-text-large romo-text-small-hover">.romo-text-large.romo-text-small-hover</div>
+
+```html
+<div class="romo-text0 romo-text1-hover">...</div>
+<div class="romo-text1 romo-text2-hover">...</div>
+<div class="romo-text2 romo-text3-hover">...</div>
+<div class="romo-text3 romo-text1-hover">...</div>
+<div class="romo-text-small romo-text-large-hover">...</div>
+<div class="romo-text-large romo-text-small-hover">...</div>
+```
+
+## Text decoration classes
 
 Use style classes to set text decoration.
 
@@ -188,6 +206,38 @@ Use style classes to set font weight.
 <div class="romo-text-700">...</div>
 <div class="romo-text-800">...</div>
 <div class="romo-text-900">...</div>
+```
+
+Or only set a font weight on hover.
+
+<div class="romo-text-normal-hover">.romo-text-normal-hover</div>
+<div class="romo-text-lighter-hover">.romo-text-lighter-hover</div>
+<div class="romo-text-bold-hover">.romo-text-bold-hover</div>
+<div class="romo-text-bolder-hover">.romo-text-bolder-hover</div>
+<div class="romo-text-100-hover">.romo-text-100-hover</div>
+<div class="romo-text-200-hover">.romo-text-200-hover</div>
+<div class="romo-text-300-hover">.romo-text-300-hover</div>
+<div class="romo-text-400-hover">.romo-text-400-hover</div>
+<div class="romo-text-500-hover">.romo-text-500-hover</div>
+<div class="romo-text-600-hover">.romo-text-600-hover</div>
+<div class="romo-text-700-hover">.romo-text-700-hover</div>
+<div class="romo-text-800-hover">.romo-text-800-hover</div>
+<div class="romo-text-900-hover">.romo-text-900-hover</div>
+
+```html
+<div class="romo-text-normal-hover">...</div>
+<div class="romo-text-lighter-hover">...</div>
+<div class="romo-text-bold-hover">...</div>
+<div class="romo-text-bolder-hover">...</div>
+<div class="romo-text-100-hover">...</div>
+<div class="romo-text-200-hover">...</div>
+<div class="romo-text-300-hover">...</div>
+<div class="romo-text-400-hover">...</div>
+<div class="romo-text-500-hover">...</div>
+<div class="romo-text-600-hover">...</div>
+<div class="romo-text-700-hover">...</div>
+<div class="romo-text-800-hover">...</div>
+<div class="romo-text-900-hover">...</div>
 ```
 
 ## Color emphasis classes


### PR DESCRIPTION
These classes alter the font size/weight on hover.  They compliment
the font decoration hover classes previously added.

Closes #30.

@jcredding ready for review.
