### PR TITLE
css: add style classes for grab-related cursors

### DIFF
--- a/assets/css/romo/base.scss
+++ b/assets/css/romo/base.scss
@@ -87,7 +87,9 @@ a.romo-text {
   color: $baseColor;
   text-decoration: none;
 }
-.romo-pointer { cursor: pointer; }
+.romo-pointer  { cursor: pointer; }
+.romo-grab     { @include cursor-grab; }
+.romo-grabbing { @include cursor-grabbing; }
 
 /* images */
 

--- a/gh-pages/view_handlers/css/globals.md
+++ b/gh-pages/view_handlers/css/globals.md
@@ -36,3 +36,5 @@ Romo uses <a href="http://www.paulirish.com/2012/box-sizing-border-box-ftw/" tar
 * Set the global link color with `$linkColor` and `$linkColorHover` and only apply link underlines on `:hover`
 * Remove any link color and styling by adding the `romo-text` class to any link
 * Add a pointer cursor to any element by adding the `romo-pointer` class
+* Add a grab cursor to any element by adding the `romo-grab` class
+* Add a grabing cursor to any element by adding the `romo-grabbing` class


### PR DESCRIPTION
This is to compliment the existin pointer cursor style class.  This
is handy when doing drag related behavior and want to give cursor
feedback.

@jcredding ready for review.
