### PR TITLE
Add browser submit to forms

### DIFF
--- a/assets/js/romo/dropdown_form.js
+++ b/assets/js/romo/dropdown_form.js
@@ -84,6 +84,9 @@ RomoDropdownForm.prototype.doBindForm = function() {
   formElem.on('form:submitError', $.proxy(function(e, xhr, form) {
     this.elem.trigger('dropdownForm:form:submitError', [xhr, form, this]);
   }, this));
+  formElem.on('form:browserSubmit', $.proxy(function(e, form) {
+    this.elem.trigger('dropdownForm:form:browserSubmit', [form, this]);
+  }, this));
 
   var submitElement = this.dropdown.popupElem.find('[data-romo-form-submit="true"]')[0];
   var indicatorElements = this.dropdown.popupElem.find('[data-romo-indicator-auto="true"]');

--- a/assets/js/romo/form.js
+++ b/assets/js/romo/form.js
@@ -126,14 +126,21 @@ RomoForm.prototype._doSubmit = function() {
   this.indicatorElems.trigger('indicator:triggerStart');
   this.elem.trigger('form:beforeSubmit', [this]);
 
-  if (this.elem.attr('method').toUpperCase() === 'GET') {
-    this._doGetSubmit();
+  if(this.elem.data('romo-form-browser-submit') === true) {
+    this._doBrowserSubmit();
+  } else if (this.elem.attr('method').toUpperCase() === 'GET') {
+    this._doNonBrowserGetSubmit();
   } else {
-    this._doNonGetSubmit();
+    this._doNonBrowserNonGetSubmit();
   }
 }
 
-RomoForm.prototype._doGetSubmit = function() {
+RomoForm.prototype._doBrowserSubmit = function() {
+  this.elem.submit();
+  this.elem.trigger('form:browserSubmit', [this]);
+}
+
+RomoForm.prototype._doNonBrowserGetSubmit = function() {
   var data = this._getSerializeObj();
 
   if (this.elem.data('romo-form-redirect-page') === true) {
@@ -152,7 +159,7 @@ RomoForm.prototype._doGetSubmit = function() {
   }
 }
 
-RomoForm.prototype._doNonGetSubmit = function() {
+RomoForm.prototype._doNonBrowserNonGetSubmit = function() {
   this._doAjaxSubmit(this._getFormData(), false);
 }
 

--- a/assets/js/romo/modal_form.js
+++ b/assets/js/romo/modal_form.js
@@ -93,6 +93,9 @@ RomoModalForm.prototype.doBindForm = function() {
   formElem.on('form:submitError', $.proxy(function(e, xhr, form) {
     this.elem.trigger('modalForm:form:submitError', [xhr, form, this]);
   }, this));
+  formElem.on('form:browserSubmit', $.proxy(function(e, form) {
+    this.elem.trigger('modalForm:form:browserSubmit', [form, this]);
+  }, this));
 
   var submitElement = this.modal.popupElem.find('[data-romo-form-submit="true"]')[0];
   var indicatorElements = this.modal.popupElem.find('[data-romo-indicator-auto="true"]');


### PR DESCRIPTION
This updates forms to allow submitting using the browser instead
of Romos custom logic. This will call the `submit` method on the
form element and trigger standard form behavior. This is an option
that allows mixing standard form behavior (`target` attribute,
non-ajax request) with other Romo form features (submit on change,
loading indicator, form event).

Forms will now look for a browser submit option and, if set to
true, `submit` will be called on the form. Since this is submitting
the form, many of the events that are triggered will not be. The
form cannot tell if the submit was successful, it failed or when
it even completes. Instead of these events, the form will trigger
a browser submit event after it calls `submit`. This can be used
to bind behavior "after submit".

Finally, this proxies the new browser submit event through the
modal and dropdown form components.

@kellyredding - Ready for review.
