### PR TITLE
indicator js: add option for disabling stop on pageshow

### DIFF
--- a/assets/js/romo/indicator.js
+++ b/assets/js/romo/indicator.js
@@ -40,9 +40,11 @@ var RomoIndicator = function(element) {
   this.elem.on('indicator:triggerStart', $.proxy(this.onStart, this));
   this.elem.on('indicator:triggerStop', $.proxy(this.onStop, this));
 
-  $(window).on("pageshow", $.proxy(function(e) {
-    this.elem.trigger('indicator:triggerStop');
-  }, this));
+  if (this.elem.data('romo-indicator-stop-on-pageshow') !== false) {
+    $(window).on("pageshow", $.proxy(function(e) {
+      this.elem.trigger('indicator:triggerStop');
+    }, this));
+  }
 
   this.elem.trigger('indicator:ready', [this]);
 }


### PR DESCRIPTION
This stop on pageshow behavior was originally added back in
20bc6cf56eab1cac5e9243587a81d499edf7b00b to make sure indicators
are stopped when hitting the back button.

This scenario occurs when you an indicated action invokes a new
page load.  This is only a subset of uses for the indicator component
though.  This option is being added for cases where an indicator
is not being used to indicate a new page being loaded

This is handy for cases where you want to fire an indicator just
after the page is rendered to maybe indicate some asynchronous
data is being loaded or whatever.  With the pageshow hook enabled,
your indicator may be turned off unintentionally depending on
event timing, etc.  This option allows you to just enable it in
cases where you know the behavior isn't necessary.

@jcredding ready for review.
