### PR TITLE
form js: add an elem data option to disable keypress behavior

### DIFF
--- a/assets/js/romo/form.js
+++ b/assets/js/romo/form.js
@@ -65,11 +65,13 @@ RomoForm.prototype.doBindForm = function() {
 }
 
 RomoForm.prototype.onFormKeyPress = function(e) {
-  var target = $(e.target);
+  if (this.elem.data('romo-form-disable-keypress') !== true) {
+    var target = $(e.target);
 
-  if(target.is(':not(TEXTAREA)') && e.keyCode === 13 /* Enter */) {
-    e.preventDefault();
-    this.onSubmitClick();
+    if (target.is(':not(TEXTAREA)') && e.keyCode === 13 /* Enter */) {
+      e.preventDefault();
+      this.onSubmitClick();
+    }
   }
 }
 


### PR DESCRIPTION
The keypress behavior may not always be desired or it may be handled
by another set of logic.  This allows you to disable it on a per-form
basis.

Specifically this came up when integrating a romo form with a wysiwyg
and hitting 'Enter' in the wysiwyg caused the form to submit instead
of add a newline (oops).

@jcredding ready for review.
