### PR TITLE
css: add 'base' and 'alt' text/bg colors

### DIFF
--- a/assets/css/romo/_mixins.scss
+++ b/assets/css/romo/_mixins.scss
@@ -139,15 +139,23 @@
 
 /* color emphasis */
 
-@mixin bg-base($i:"")    { background-color: $baseBackground #{$i}; }
-@mixin bg-alt($i:"")     { background-color: $altBackground #{$i}; }
-@mixin bg-striped($i:"") { background-color: $stripedBackground #{$i}; }
-@mixin bg-hover($i:"")   { background-color: $backgroundHover #{$i}; }
+@mixin bg-striped($i:"") { background-color: $stripedBgColor #{$i}; }
+@mixin bg-hover($i:"")   { background-color: $bgColorHover #{$i}; }
 
-@mixin border-base($i:"") { border-color: $baseBorderColor #{$i}; }
-@mixin border-alt($i:"")  { border-color: $altBorderColor #{$i}; }
-@mixin text-border-base($i:"")   { color: $baseBorderColor #{$i}; }
-@mixin text-border-alt($i:"")    { color: $altBorderColor #{$i}; }
+@mixin text-border-base($i:"") { color: $baseBorderColor #{$i}; }
+@mixin text-border-alt($i:"")  { color: $altBorderColor #{$i}; }
+
+@mixin text-base($i:"")       { color: $baseText #{$i}; }
+@mixin text-base-hover($i:"") { color: $baseTextHover #{$i}; }
+@mixin bg-base($i:"")         { background-color: $baseBackground #{$i}; }
+@mixin bg-base-hover($i:"")   { background-color: $baseBackgroundHover #{$i}; }
+@mixin border-base($i:"")     {     border-color: $baseBorder #{$i}; }
+
+@mixin text-alt($i:"")       { color: $altText #{$i}; }
+@mixin text-alt-hover($i:"") { color: $altTextHover #{$i}; }
+@mixin bg-alt($i:"")         { background-color: $altBackground #{$i}; }
+@mixin bg-alt-hover($i:"")   { background-color: $altBackgroundHover #{$i}; }
+@mixin border-alt($i:"")     {     border-color: $altBorder #{$i}; }
 
 @mixin text-muted($i:"")       { color: $mutedText #{$i}; }
 @mixin text-muted-hover($i:"") { color: $mutedTextHover #{$i}; }
@@ -221,7 +229,7 @@
   line-height: $lineHeight0;
 
   background-color: $inputColor;
-  color: $inputBackground;
+  color: $inputBgColor;
 }
 
 @mixin select-option {
@@ -229,7 +237,7 @@
   line-height: $baseLineHeight;
   padding: 0 $spacingSize0;
 
-  background-color: $inputBackground;
+  background-color: $inputBgColor;
   color: $inputColor;
 }
 

--- a/assets/css/romo/_vars.scss
+++ b/assets/css/romo/_vars.scss
@@ -35,13 +35,14 @@ $notAllowedCursor: not-allowed;
 
 /* colors */
 
-$baseBackground:    #fff;
-$altBackground:     #ededed;
-$stripedBackground: #fafafa;
-$backgroundHover:   #f5f5f5;
-
 $baseColor:     #444;
+$altColor:      #444;
 $disabledColor: #999;
+
+$baseBgColor:    #fff;
+$altBgColor:     #ededed;
+$stripedBgColor: #fafafa;
+$bgColorHover:   #f5f5f5;
 
 $baseBorderColor:  #ccc;
 $altBorderColor:   #fff;
@@ -49,20 +50,20 @@ $altBorderColor:   #fff;
 $linkColor:      #08c;
 $linkColorHover: darken($linkColor, 15%);
 
-$inputBackground:         #fff;
-$inputAltBackground:      #eee;
-$inputColor:              #444;
-$inputDisabledColor:      #eee;
-$inputFocusColor:         rgba(82, 168, 236, 0.8);
-$inputHighlightBackround: #3c83c7;
+$inputBgColor:          #fff;
+$inputAltBgColor:       #eee;
+$inputColor:            #444;
+$inputDisabledColor:    #eee;
+$inputFocusColor:       rgba(82, 168, 236, 0.8);
+$inputHighlightBgColor: #3c83c7;
 
 $btnBorder:                     $baseBorderColor;
-$btnBackground:                 $baseBackground;
+$btnBackground:                 $baseBgColor;
 $btnBackgroundHighlight:        darken($btnBackground, 10%);
 $btnColor:                      $baseColor;
 $btnColorHover:                 #333;
 
-$btnAltBackground:              $altBackground;
+$btnAltBackground:              $altBgColor;
 $btnAltBackgroundHighlight:     darken($btnAltBackground, 10%);
 $btnAltColor:                   $btnColor;
 
@@ -89,6 +90,18 @@ $btnSuccessColor:               #fff;
 $btnInverseBackground:          #444;
 $btnInverseBackgroundHighlight: #222;
 $btnInverseColor:               #fff;
+
+$baseText:               $baseColor;
+$baseTextHover:          $baseText;
+$baseBackground:         $baseBgColor;
+$baseBackgroundHover:    $baseBackground;
+$baseBorder:             $baseBorderColor;
+
+$altText:                $altColor;
+$altTextHover:           $altColor;
+$altBackground:          $altBgColor;
+$altBackgroundHover:     $altBackground;
+$altBorder:              $altBorderColor;
 
 $mutedText:              #999999;
 $mutedTextHover:         darken($mutedText, 10%);
@@ -126,15 +139,15 @@ $inverseBackground:      #444444;
 $inverseBackgroundHover: darken($inverseBackground, 5%);
 $inverseBorder:          darken(adjust_hue($inverseBackground, -10), 3%);
 
-$tabBackground:       $altBackground;
-$tabBackgroundHover:  darken($altBackground, 5%);
-$tabBackgroundActive: #222;
-$tabColor:            $baseColor;
-$tabColorActive:      #fff;
-$tabColorDisabled:    $disabledColor;
+$tabBgColor:       $altBgColor;
+$tabBgColorHover:  darken($altBgColor, 5%);
+$tabBgColorActive: #222;
+$tabColor:         $baseColor;
+$tabColorActive:   #fff;
+$tabColorDisabled: $disabledColor;
 
-$tooltipBackground:   #222;
-$tooltipColor:        #eee;
+$tooltipBgColor:   #222;
+$tooltipColor:     #eee;
 
 /* borders */
 

--- a/assets/css/romo/base.scss
+++ b/assets/css/romo/base.scss
@@ -97,7 +97,7 @@ a.romo-text {
 .romo-img-circle  { @include border-radius(500px); }
 .romo-img-card {
   padding: 3px;
-  background-color: $baseBackground;
+  background-color: $baseBgColor;
   border: 1px solid;
   border: 1px solid rgba(0, 0, 0, 0.2);
   @include box-shadow(0 1px 3px rgba(0, 0, 0, 0.1));
@@ -224,6 +224,8 @@ h3 { @include text1; }
 
 .romo-text-border-base { @include text-border-base(!important); }
 .romo-text-border-alt  { @include text-border-alt(!important); }
+.romo-text-base        { @include text-base(!important); }
+.romo-text-alt         { @include text-alt(!important); }
 .romo-text-muted       { @include text-muted(!important); }
 .romo-text-warning     { @include text-warning(!important); }
 .romo-text-error       { @include text-error(!important); }
@@ -231,6 +233,12 @@ h3 { @include text1; }
 .romo-text-success     { @include text-success(!important); }
 .romo-text-inverse     { @include text-inverse(!important); }
 
+.romo-text-base-hover:hover, a.romo-text-base:hover, a.romo-text-base:focus {
+  @include text-base-hover(!important);
+}
+.romo-text-alt-hover:hover, a.romo-text-alt:hover, a.romo-text-alt:focus {
+  @include text-alt-hover(!important);
+}
 .romo-text-muted-hover:hover, a.romo-text-muted:hover, a.romo-text-muted:focus {
   @include text-muted-hover(!important);
 }
@@ -250,6 +258,8 @@ h3 { @include text1; }
   @include text-inverse-hover(!important);
 }
 
+.romo-bg-base    { @include bg-base(!important); }
+.romo-bg-alt     { @include bg-alt(!important); }
 .romo-bg-muted   { @include bg-muted(!important); }
 .romo-bg-warning { @include bg-warning(!important); }
 .romo-bg-error   { @include bg-error(!important); }
@@ -257,6 +267,12 @@ h3 { @include text1; }
 .romo-bg-success { @include bg-success(!important); }
 .romo-bg-inverse { @include bg-inverse(!important); }
 
+.romo-bg-base-hover:hover, a.romo-bg-base:hover, a.romo-bg-base:focus {
+  @include bg-base-hover(!important);
+}
+.romo-bg-alt-hover:hover, a.romo-bg-alt:hover, a.romo-bg-alt:focus {
+  @include bg-alt-hover(!important);
+}
 .romo-bg-muted-hover:hover, a.romo-bg-muted:hover, a.romo-bg-muted:focus {
   @include bg-muted-hover(!important);
 }

--- a/assets/css/romo/datepicker.scss
+++ b/assets/css/romo/datepicker.scss
@@ -20,7 +20,7 @@
   padding: $spacingSize0;
   @include user-select(none);
 
-  background-color: $inputBackground;
+  background-color: $inputBgColor;
   color: $inputColor;
 }
 
@@ -44,13 +44,13 @@
 }
 
 .romo-datepicker-calendar TD.romo-datepicker-day-weekend {
-  background: $inputAltBackground;
+  background: $inputAltBgColor;
 }
 
 .romo-datepicker-calendar .romo-datepicker-prev:hover,
 .romo-datepicker-calendar .romo-datepicker-next:hover,
 .romo-datepicker-calendar TD.romo-datepicker-day.romo-datepicker-highlight:not(.disabled) {
-  background: darken($inputAltBackground, 10%);
+  background: darken($inputAltBgColor, 10%);
 }
 
 .romo-datepicker-calendar TD.romo-datepicker-day.disabled {
@@ -68,6 +68,6 @@
 
 .romo-datepicker-calendar TD.romo-datepicker-day.selected,
 .romo-datepicker-calendar TD.romo-datepicker-day.selected.romo-datepicker-highlight {
-  background-color: $inputHighlightBackround;
-  color: $inputBackground;
+  background-color: $inputHighlightBgColor;
+  color: $inputBgColor;
 }

--- a/assets/css/romo/dropdown.scss
+++ b/assets/css/romo/dropdown.scss
@@ -11,7 +11,7 @@
   float: left;
   @include border0;
 
-  background-color: $baseBackground;
+  background-color: $baseBgColor;
   border-color: $baseBorderColor;
   border-color: rgba(0, 0, 0, 0.2);
 }

--- a/assets/css/romo/forms.scss
+++ b/assets/css/romo/forms.scss
@@ -62,7 +62,7 @@ label { display: block; }
 
 .romo-form select {
   font-weight: normal;
-  background-color: $inputBackground;
+  background-color: $inputBgColor;
   @include border1;
 }
 .romo-form select optgroup { @include select-optgroup; }
@@ -84,7 +84,7 @@ label { display: block; }
 .romo-form input[type="tel"],
 .romo-form input[type="color"] {
   font-weight: normal;
-  background-color: $inputBackground;
+  background-color: $inputBgColor;
   @include border1;
   @include box-shadow(inset 0 1px 1px rgba(0, 0, 0, 0.075));
 }

--- a/assets/css/romo/grid_table.scss
+++ b/assets/css/romo/grid_table.scss
@@ -31,6 +31,8 @@ ol.romo-grid-table { @include list-unstyled(!important); }
 .romo-grid-table-striped.romo-grid-table-header.romo-grid-table-striped-alt > .romo-row:nth-child(even) { @include bg-base; }
 .romo-grid-table-striped.romo-grid-table-striped-alt { @include bg-striped; }
 
+.romo-grid-table .romo-row.romo-base    { @include bg-base; }
+.romo-grid-table .romo-row.romo-alt     { @include bg-alt; }
 .romo-grid-table .romo-row.romo-muted   { @include bg-muted; }
 .romo-grid-table .romo-row.romo-warning { @include bg-warning; }
 .romo-grid-table .romo-row.romo-error   { @include bg-error; }
@@ -43,6 +45,10 @@ ol.romo-grid-table { @include list-unstyled(!important); }
 .romo-grid-table-hover.romo-grid-table-header > .romo-row:not(:first-child):hover,
 .romo-grid-table-hover.romo-grid-table-header.romo-grid-table-alt > .romo-row:not(:first-child):hover { @include bg-hover; }
 
+.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-base:hover,
+.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-base:not(:first-child):hover { @include bg-base-hover; }
+.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-alt:hover,
+.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-alt:not(:first-child):hover { @include bg-alt-hover; }
 .romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-muted:hover,
 .romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-muted:not(:first-child):hover { @include bg-muted-hover; }
 .romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-warning:hover,

--- a/assets/css/romo/modal.scss
+++ b/assets/css/romo/modal.scss
@@ -22,7 +22,7 @@
   @include border0;
   @include box-shadow(0 5px 10px rgba(0, 0, 0, 0.2));
 
-  background-color: $baseBackground;
+  background-color: $baseBgColor;
   border-color: $baseBorderColor;
   border-color: rgba(0, 0, 0, 0.2);
 }

--- a/assets/css/romo/select.scss
+++ b/assets/css/romo/select.scss
@@ -49,7 +49,7 @@
   padding: 4px 0;
   @include user-select(none);
 
-  background-color: $inputBackground;
+  background-color: $inputBgColor;
   color: $inputColor;
 }
 
@@ -74,8 +74,8 @@
 }
 
 .romo-select-option-list LI.romo-select-highlight {
-  background-color: $inputHighlightBackround;
-  color: $inputBackground;
+  background-color: $inputHighlightBgColor;
+  color: $inputBgColor;
 }
 
 .romo-select-option-list LI.disabled {
@@ -84,6 +84,6 @@
 
 .romo-select-option-list LI.disabled,
 .romo-select-option-list LI.disabled.romo-select-highlight {
-  background-color: $inputBackground;
+  background-color: $inputBgColor;
   color: $disabledColor;
 }

--- a/assets/css/romo/table.scss
+++ b/assets/css/romo/table.scss
@@ -21,6 +21,8 @@
 .romo-table-striped.romo-table-striped-alt tbody > tr:nth-child(odd) { @include bg-base; }
 .romo-table-striped.romo-table-striped-alt { @include bg-striped; }
 
+.romo-table tr.romo-base    { @include bg-base; }
+.romo-table tr.romo-alt     { @include bg-alt; }
 .romo-table tr.romo-muted   { @include bg-muted; }
 .romo-table tr.romo-warning { @include bg-warning; }
 .romo-table tr.romo-error   { @include bg-error; }
@@ -31,6 +33,8 @@
 .romo-table-hover tbody tr:hover,
 .romo-table-hover.romo-table-alt tbody tr:hover { @include bg-hover; }
 
+.romo-table-hover tbody tr.romo-base:hover    { @include bg-base-hover; }
+.romo-table-hover tbody tr.romo-alt:hover     { @include bg-alt-hover; }
 .romo-table-hover tbody tr.romo-muted:hover   { @include bg-muted-hover; }
 .romo-table-hover tbody tr.romo-warning:hover { @include bg-warning-hover; }
 .romo-table-hover tbody tr.romo-error:hover   { @include bg-error-hover; }
@@ -56,21 +60,23 @@
 .romo-table-border2     th, .romo-table-border2     td { @include border2-bottom; @include border2-right; }
 .romo-table-border-none th, .romo-table-border-none td { @include border-style(none); }
 
+.romo-table-border-base    { @include border-base; }
+.romo-table-border-alt     { @include border-alt; }
 .romo-table-border-muted   { @include border-muted; }
 .romo-table-border-warning { @include border-warning; }
 .romo-table-border-error   { @include border-error; }
 .romo-table-border-info    { @include border-info; }
 .romo-table-border-success { @include border-success; }
 .romo-table-border-inverse { @include border-inverse; }
-.romo-table-border-alt     { @include border-alt; }
 
+.romo-table-border-base    th, .romo-table-border-base    td { @include border-base; }
+.romo-table-border-alt     th, .romo-table-border-alt     td { @include border-alt; }
 .romo-table-border-muted   th, .romo-table-border-muted   td { @include border-muted; }
 .romo-table-border-warning th, .romo-table-border-warning td { @include border-warning; }
 .romo-table-border-error   th, .romo-table-border-error   td { @include border-error; }
 .romo-table-border-info    th, .romo-table-border-info    td { @include border-info; }
 .romo-table-border-success th, .romo-table-border-success td { @include border-success; }
 .romo-table-border-inverse th, .romo-table-border-inverse td { @include border-inverse; }
-.romo-table-border-alt     th, .romo-table-border-alt     td { @include border-alt; }
 
 .romo-table-pad    th, .romo-table-pad    td,
 .romo-table-pad1   th, .romo-table-pad1   td { @include pad1; }

--- a/assets/css/romo/tabs.scss
+++ b/assets/css/romo/tabs.scss
@@ -8,7 +8,7 @@
   @include list-unstyled;
   @include clearfix;
 
-  border-bottom: $tabDividerSize solid $tabBackgroundActive;
+  border-bottom: $tabDividerSize solid $tabBgColorActive;
 }
 
 .romo-tabs > li {
@@ -25,22 +25,22 @@
   cursor: pointer;
 
   @include border1;
-  background-color: $tabBackground;
-  border-color: $tabBackground;
+  background-color: $tabBgColor;
+  border-color: $tabBgColor;
   color: $tabColor;
 
   &:hover,
   &:focus {
     outline: 0;
     text-decoration: none;
-    background-color: $tabBackgroundHover;
-    border-color: $tabBackgroundHover;
+    background-color: $tabBgColorHover;
+    border-color: $tabBgColorHover;
   }
 }
 
 .romo-tabs > li.active > a {
-  background-color: $tabBackgroundActive;
-  border-color: $tabBackgroundActive;
+  background-color: $tabBgColorActive;
+  border-color: $tabBgColorActive;
   color: $tabColorActive;
 }
 
@@ -51,8 +51,8 @@
 
   &:hover,
   &:focus {
-    background-color: $tabBackground;
-    border-color: $tabBackgroundHover;
+    background-color: $tabBgColor;
+    border-color: $tabBgColorHover;
   }
 }
 
@@ -67,5 +67,5 @@
 .romo-tabs.romo-tabs-stacked { @include rm-border; }
 .romo-tabs.romo-tabs-stacked > li { float: none; }
 .romo-tabs.romo-tabs-stacked > li > a { @include border1; border-color: $baseBorderColor; }
-.romo-tabs.romo-tabs-stacked > li.active > a { border-color: $tabBackgroundActive; }
+.romo-tabs.romo-tabs-stacked > li.active > a { border-color: $tabBgColorActive; }
 .romo-tabs.romo-tabs-stacked > li:not(:last-child) > a { @include rm-border-bottom; }

--- a/assets/css/romo/tooltip.scss
+++ b/assets/css/romo/tooltip.scss
@@ -71,19 +71,19 @@
 /* theme */
 
 .romo-tooltip-popup {
-  background-color: $tooltipBackground;
+  background-color: $tooltipBgColor;
   color: $tooltipColor;
 }
 
 .romo-tooltip-popup[data-romo-tooltip-position="top"] .romo-tooltip-arrow {
-  border-top-color: $tooltipBackground;
+  border-top-color: $tooltipBgColor;
 }
 .romo-tooltip-popup[data-romo-tooltip-position="right"] .romo-tooltip-arrow {
-  border-right-color: $tooltipBackground;
+  border-right-color: $tooltipBgColor;
 }
 .romo-tooltip-popup[data-romo-tooltip-position="bottom"] .romo-tooltip-arrow {
-  border-bottom-color: $tooltipBackground;
+  border-bottom-color: $tooltipBgColor;
 }
 .romo-tooltip-popup[data-romo-tooltip-position="left"] .romo-tooltip-arrow {
-  border-left-color: $tooltipBackground;
+  border-left-color: $tooltipBgColor;
 }

--- a/gh-pages/assets/css/gh-pages.scss
+++ b/gh-pages/assets/css/gh-pages.scss
@@ -8,7 +8,7 @@ $contentWidth: 1170px;
 $navBarHeight: 45px;
 $navBarZIndex: 1300; /* reserved for app use by Romo, (below modals, above everything else) */
 
-$navBackground: #222;
+$navBgColor:    #222;
 $navColor:      #ccc;
 $navColorHover: #fff;
 
@@ -31,7 +31,7 @@ body { padding-top: $navBarHeight + $spacingSize1 + 2px; }
   display: block;
   width: 100%;
   @include clearfix;
-  background-color: $navBackground;
+  background-color: $navBgColor;
   font-weight: 300;
 
   a {

--- a/gh-pages/view_handlers/css/grid_tables.md
+++ b/gh-pages/view_handlers/css/grid_tables.md
@@ -244,6 +244,18 @@ Add color emphasis to grid table rows.
       <span class="romo-span romo-5-12">Slug</span>
       <span class="romo-span romo-1-12">Count</span>
     </li>
+    <li class="romo-row romo-base">
+      <span class="romo-span romo-1-12">1</span>
+      <span class="romo-span romo-5-12">Joe Test</span>
+      <span class="romo-span romo-5-12">joe-test</span>
+      <span class="romo-span romo-1-12">10</span>
+    </li>
+    <li class="romo-row romo-alt">
+      <span class="romo-span romo-1-12">1</span>
+      <span class="romo-span romo-5-12">Joe Test</span>
+      <span class="romo-span romo-5-12">joe-test</span>
+      <span class="romo-span romo-1-12">10</span>
+    </li>
     <li class="romo-row romo-muted">
       <span class="romo-span romo-1-12">1</span>
       <span class="romo-span romo-5-12">Joe Test</span>
@@ -286,6 +298,8 @@ Add color emphasis to grid table rows.
 ```html
 <ul class="romo-grid-table romo-grid-table-header">
   <li class="romo-row">...</li>
+  <li class="romo-row romo-base">...</li>
+  <li class="romo-row romo-alt">...</li>
   <li class="romo-row romo-muted">...</li>
   <li class="romo-row romo-warning">...</li>
   <li class="romo-row romo-error">...</li>
@@ -510,6 +524,18 @@ Add hover state to rows
 
 <div class="romo-pad2-bottom">
   <ul class="romo-grid-table romo-grid-table-hover">
+    <li class="romo-row romo-base">
+      <span class="romo-span romo-1-12">1</span>
+      <span class="romo-span romo-5-12">Joe Test</span>
+      <span class="romo-span romo-5-12">joe-test</span>
+      <span class="romo-span romo-1-12">10</span>
+    </li>
+    <li class="romo-row romo-alt">
+      <span class="romo-span romo-1-12">1</span>
+      <span class="romo-span romo-5-12">Joe Test</span>
+      <span class="romo-span romo-5-12">joe-test</span>
+      <span class="romo-span romo-1-12">10</span>
+    </li>
     <li class="romo-row romo-muted">
       <span class="romo-span romo-1-12">1</span>
       <span class="romo-span romo-5-12">Joe Test</span>
@@ -549,6 +575,19 @@ Add hover state to rows
   </ul>
 </div>
 
+```html
+<ul class="romo-grid-table romo-grid-table-hover">
+  <li class="romo-row romo-base">...</li>
+  <li class="romo-row romo-alt">...</li>
+  <li class="romo-row romo-muted">...</li>
+  <li class="romo-row romo-warning">...</li>
+  <li class="romo-row romo-error">...</li>
+  <li class="romo-row romo-info">...</li>
+  <li class="romo-row romo-success">...</li>
+  <li class="romo-row romo-inverse romo-text-inverse">...</li>
+</ul>
+```
+
 <div>
   <ul class="romo-grid-table romo-grid-table-header romo-grid-table-hover">
     <li class="romo-row">
@@ -556,6 +595,18 @@ Add hover state to rows
       <span class="romo-span romo-5-12">Name</span>
       <span class="romo-span romo-5-12">Slug</span>
       <span class="romo-span romo-1-12">Count</span>
+    </li>
+    <li class="romo-row romo-base">
+      <span class="romo-span romo-1-12">1</span>
+      <span class="romo-span romo-5-12">Joe Test</span>
+      <span class="romo-span romo-5-12">joe-test</span>
+      <span class="romo-span romo-1-12">10</span>
+    </li>
+    <li class="romo-row romo-alt">
+      <span class="romo-span romo-1-12">1</span>
+      <span class="romo-span romo-5-12">Joe Test</span>
+      <span class="romo-span romo-5-12">joe-test</span>
+      <span class="romo-span romo-1-12">10</span>
     </li>
     <li class="romo-row romo-muted">
       <span class="romo-span romo-1-12">1</span>
@@ -599,6 +650,8 @@ Add hover state to rows
 ```html
 <ul class="romo-grid-table romo-grid-table-header romo-grid-table-hover">
   <li class="romo-row">...</li>
+  <li class="romo-row romo-base">...</li>
+  <li class="romo-row romo-alt">...</li>
   <li class="romo-row romo-muted">...</li>
   <li class="romo-row romo-warning">...</li>
   <li class="romo-row romo-error">...</li>
@@ -782,6 +835,64 @@ Remove all borders from the grid table.
 Adds border color emphasis to the entire grid table.
 
 <div class="romo-pad2-bottom">
+  <ul class="romo-grid-table romo-grid-table-header romo-grid-table-border2 romo-grid-table-border-base">
+    <li class="romo-row">
+      <span class="romo-span romo-1-12">#</span>
+      <span class="romo-span romo-5-12">Name</span>
+      <span class="romo-span romo-5-12">Slug</span>
+      <span class="romo-span romo-1-12">Count</span>
+    </li>
+    <li class="romo-row">
+      <span class="romo-span romo-1-12">1</span>
+      <span class="romo-span romo-5-12">Joe Test</span>
+      <span class="romo-span romo-5-12">joe-test</span>
+      <span class="romo-span romo-1-12">10</span>
+    </li>
+    <li class="romo-row">
+      <span class="romo-span romo-1-12">2</span>
+      <span class="romo-span romo-5-12">Jane Doe</span>
+      <span class="romo-span romo-5-12">jane-doe</span>
+      <span class="romo-span romo-1-12">18</span>
+    </li>
+    <li class="romo-row">
+      <span class="romo-span romo-1-12">3</span>
+      <span class="romo-span romo-5-12">Good Corp.</span>
+      <span class="romo-span romo-5-12">good-corp</span>
+      <span class="romo-span romo-1-12">5</span>
+    </li>
+  </ul>
+</div>
+
+<div class="romo-pad2-bottom">
+  <ul class="romo-grid-table romo-grid-table-header romo-grid-table-border2 romo-grid-table-border-alt">
+    <li class="romo-row">
+      <span class="romo-span romo-1-12">#</span>
+      <span class="romo-span romo-5-12">Name</span>
+      <span class="romo-span romo-5-12">Slug</span>
+      <span class="romo-span romo-1-12">Count</span>
+    </li>
+    <li class="romo-row">
+      <span class="romo-span romo-1-12">1</span>
+      <span class="romo-span romo-5-12">Joe Test</span>
+      <span class="romo-span romo-5-12">joe-test</span>
+      <span class="romo-span romo-1-12">10</span>
+    </li>
+    <li class="romo-row">
+      <span class="romo-span romo-1-12">2</span>
+      <span class="romo-span romo-5-12">Jane Doe</span>
+      <span class="romo-span romo-5-12">jane-doe</span>
+      <span class="romo-span romo-1-12">18</span>
+    </li>
+    <li class="romo-row">
+      <span class="romo-span romo-1-12">3</span>
+      <span class="romo-span romo-5-12">Good Corp.</span>
+      <span class="romo-span romo-5-12">good-corp</span>
+      <span class="romo-span romo-1-12">5</span>
+    </li>
+  </ul>
+</div>
+
+<div class="romo-pad2-bottom">
   <ul class="romo-grid-table romo-grid-table-header romo-grid-table-border2 romo-grid-table-border-muted">
     <li class="romo-row">
       <span class="romo-span romo-1-12">#</span>
@@ -956,7 +1067,7 @@ Adds border color emphasis to the entire grid table.
 </div>
 
 ```html
-<ul class="romo-grid-table romo-grid-table-border-{muted|warning|error|info|success|inverse}">
+<ul class="romo-grid-table romo-grid-table-border-{base|alt|muted|warning|error|info|success|inverse}">
   ...
 </ul>
 ```

--- a/gh-pages/view_handlers/css/tables.md
+++ b/gh-pages/view_handlers/css/tables.md
@@ -298,6 +298,18 @@ Add color emphasis to rows.
       </tr>
     </thead>
     <tbody>
+      <tr class="romo-base">
+        <td>2</td>
+        <td>Jane Doe</td>
+        <td>jane-doe</td>
+        <td>18</td>
+      </tr>
+      <tr class="romo-alt">
+        <td>2</td>
+        <td>Jane Doe</td>
+        <td>jane-doe</td>
+        <td>18</td>
+      </tr>
       <tr class="romo-muted romo-text-muted">
         <td>1</td>
         <td>Joe Test</td>
@@ -341,6 +353,8 @@ Add color emphasis to rows.
 ```html
 <table class="romo-table romo-table-hover">
   ...
+  <tr class="romo-base">...</tr>
+  <tr class="romo-alt">...</tr>
   <tr class="romo-muted romo-text-muted">...</tr>
   <tr class="romo-warning">...</tr>
   <tr class="romo-error">...</tr>
@@ -515,6 +529,18 @@ Add hover state to rows within a `<tbody>`.
       </tr>
     </thead>
     <tbody>
+      <tr class="romo-base">
+        <td>2</td>
+        <td>Jane Doe</td>
+        <td>jane-doe</td>
+        <td>18</td>
+      </tr>
+      <tr class="romo-alt">
+        <td>2</td>
+        <td>Jane Doe</td>
+        <td>jane-doe</td>
+        <td>18</td>
+      </tr>
       <tr class="romo-muted romo-text-muted">
         <td>1</td>
         <td>Joe Test</td>
@@ -558,6 +584,8 @@ Add hover state to rows within a `<tbody>`.
 ```html
 <table class="romo-table romo-table-hover">
   ...
+  <tr class="romo-base">...</tr>
+  <tr class="romo-alt">...</tr>
   <tr class="romo-muted romo-text-muted">...</tr>
   <tr class="romo-warning">...</tr>
   <tr class="romo-error">...</tr>
@@ -772,6 +800,72 @@ Remove all borders from the table.
 Adds border color empasis to the entire table.
 
 <div class="romo-push2-bottom">
+  <table class="romo-table romo-table-border2 romo-table-border-base">
+    <thead>
+      <tr>
+        <th>#</th>
+        <th>Name</th>
+        <th>Slug</th>
+        <th>Count</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>1</td>
+        <td>Joe Test</td>
+        <td>joe-test</td>
+        <td>10</td>
+      </tr>
+      <tr>
+        <td>2</td>
+        <td>Jane Doe</td>
+        <td>jane-doe</td>
+        <td>18</td>
+      </tr>
+      <tr>
+        <td>3</td>
+        <td>Good Corp.</td>
+        <td>good-corp</td>
+        <td>5</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+<div class="romo-push2-bottom">
+  <table class="romo-table romo-table-border2 romo-table-border-alt">
+    <thead>
+      <tr>
+        <th>#</th>
+        <th>Name</th>
+        <th>Slug</th>
+        <th>Count</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>1</td>
+        <td>Joe Test</td>
+        <td>joe-test</td>
+        <td>10</td>
+      </tr>
+      <tr>
+        <td>2</td>
+        <td>Jane Doe</td>
+        <td>jane-doe</td>
+        <td>18</td>
+      </tr>
+      <tr>
+        <td>3</td>
+        <td>Good Corp.</td>
+        <td>good-corp</td>
+        <td>5</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+<div class="romo-push2-bottom">
   <table class="romo-table romo-table-border2 romo-table-border-muted">
     <thead>
       <tr>
@@ -970,50 +1064,7 @@ Adds border color empasis to the entire table.
 </div>
 
 ```html
-<table class="romo-table romo-table-border2 romo-table-border-{muted|warning|error|info|success|inverse}">
-  ...
-</table>
-```
-
-### `.romo-table-border-alt`
-
-Uses the alternate border color for the table borders.
-
-<div>
-  <table class="romo-table romo-table-border2 romo-table-alt romo-table-border-alt">
-    <thead>
-      <tr>
-        <th>#</th>
-        <th>Name</th>
-        <th>Slug</th>
-        <th>Count</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>1</td>
-        <td>Joe Test</td>
-        <td>joe-test</td>
-        <td>10</td>
-      </tr>
-      <tr>
-        <td>2</td>
-        <td>Jane Doe</td>
-        <td>jane-doe</td>
-        <td>18</td>
-      </tr>
-      <tr>
-        <td>3</td>
-        <td>Good Corp.</td>
-        <td>good-corp</td>
-        <td>5</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-
-```html
-<table class="romo-table romo-table-border2 romo-table-alt romo-table-border-alt">
+<table class="romo-table romo-table-border2 romo-table-border-{base|alt|muted|warning|error|info|success|inverse}">
   ...
 </table>
 ```

--- a/gh-pages/view_handlers/css/typography.md
+++ b/gh-pages/view_handlers/css/typography.md
@@ -245,6 +245,8 @@ Or only set a font weight on hover.
 Use style classes to add color to text.
 
 <div>
+  <span class="romo-text-base">Fusce dapibus, tellus ac cursus commodo, tortor mauris nibh.</span><br />
+  <span class="romo-text-alt">Fusce dapibus, tellus ac cursus commodo, tortor mauris nibh.</span><br />
   <span class="romo-text-muted">Fusce dapibus, tellus ac cursus commodo, tortor mauris nibh.</span><br />
   <span class="romo-text-warning">Etiam porta sem malesuada magna mollis euismod.</span><br />
   <span class="romo-text-error">Donec ullamcorper nulla non metus auctor fringilla.</span><br />
@@ -254,6 +256,8 @@ Use style classes to add color to text.
 </div>
 
 ```html
+<span class="romo-text-base">...</span><br />
+<span class="romo-text-alt">...</span><br />
 <span class="romo-text-muted">...</span><br />
 <span class="romo-text-warning">...</span><br />
 <span class="romo-text-error">...</span><br />
@@ -265,6 +269,8 @@ Use style classes to add color to text.
 Or, to links.
 
 <div>
+  <a href="#" class="romo-text-base">Fusce dapibus, tellus ac cursus commodo, tortor mauris nibh.</a><br />
+  <a href="#" class="romo-text-alt">Fusce dapibus, tellus ac cursus commodo, tortor mauris nibh.</a><br />
   <a href="#" class="romo-text-muted">Fusce dapibus, tellus ac cursus commodo, tortor mauris nibh.</a><br />
   <a href="#" class="romo-text-warning">Etiam porta sem malesuada magna mollis euismod.</a><br />
   <a href="#" class="romo-text-error">Donec ullamcorper nulla non metus auctor fringilla.</a><br />
@@ -274,6 +280,8 @@ Or, to links.
 </div>
 
 ```html
+<a href="#" class="romo-text-base">...</a><br />
+<a href="#" class="romo-text-alt">...</a><br />
 <a href="#" class="romo-text-muted">...</a><br />
 <a href="#" class="romo-text-warning">...</a><br />
 <a href="#" class="romo-text-error">...</a><br />
@@ -285,6 +293,8 @@ Or, to links.
 Or, on hover only (non-links).
 
 <div>
+  <span class="romo-text-base-hover">Fusce dapibus, tellus ac cursus commodo, tortor mauris nibh.</span><br />
+  <span class="romo-text-alt-hover">Fusce dapibus, tellus ac cursus commodo, tortor mauris nibh.</span><br />
   <span class="romo-text-muted-hover">Fusce dapibus, tellus ac cursus commodo, tortor mauris nibh.</span><br />
   <span class="romo-text-warning-hover">Etiam porta sem malesuada magna mollis euismod.</span><br />
   <span class="romo-text-error-hover">Donec ullamcorper nulla non metus auctor fringilla.</span><br />
@@ -294,6 +304,8 @@ Or, on hover only (non-links).
 </div>
 
 ```html
+<span class="romo-text-base-hover">...</span><br />
+<span class="romo-text-alt-hover">...</span><br />
 <span class="romo-text-muted-hover">...</span><br />
 <span class="romo-text-warning-hover">...</span><br />
 <span class="romo-text-error-hover">...</span><br />
@@ -305,6 +317,8 @@ Or, on hover only (non-links).
 Or, to the background instead of the text.
 
 <div>
+  <span class="romo-bg-base">Fusce dapibus, tellus ac cursus commodo, tortor mauris nibh.</span><br />
+  <span class="romo-bg-alt">Fusce dapibus, tellus ac cursus commodo, tortor mauris nibh.</span><br />
   <span class="romo-bg-muted">Fusce dapibus, tellus ac cursus commodo, tortor mauris nibh.</span><br />
   <span class="romo-bg-warning">Etiam porta sem malesuada magna mollis euismod.</span><br />
   <span class="romo-bg-error">Donec ullamcorper nulla non metus auctor fringilla.</span><br />
@@ -314,6 +328,8 @@ Or, to the background instead of the text.
 </div>
 
 ```html
+<span class="romo-bg-base">...</span><br />
+<span class="romo-bg-alt">...</span><br />
 <span class="romo-bg-muted">...</span><br />
 <span class="romo-bg-warning">...</span><br />
 <span class="romo-bg-error">...</span><br />
@@ -325,6 +341,8 @@ Or, to the background instead of the text.
 Or, to the background instead of the text on hover only.
 
 <div>
+  <span class="romo-bg-base-hover">Fusce dapibus, tellus ac cursus commodo, tortor mauris nibh.</span><br />
+  <span class="romo-bg-alt-hover">Fusce dapibus, tellus ac cursus commodo, tortor mauris nibh.</span><br />
   <span class="romo-bg-muted-hover">Fusce dapibus, tellus ac cursus commodo, tortor mauris nibh.</span><br />
   <span class="romo-bg-warning-hover">Etiam porta sem malesuada magna mollis euismod.</span><br />
   <span class="romo-bg-error-hover">Donec ullamcorper nulla non metus auctor fringilla.</span><br />
@@ -334,6 +352,8 @@ Or, to the background instead of the text on hover only.
 </div>
 
 ```html
+<span class="romo-bg-base-hover">...</span><br />
+<span class="romo-bg-alt-hover">...</span><br />
 <span class="romo-bg-muted-hover">...</span><br />
 <span class="romo-bg-warning-hover">...</span><br />
 <span class="romo-bg-error-hover">...</span><br />
@@ -350,6 +370,7 @@ Or, combine in any number of ways.
   <span class="romo-text-error romo-bg-warning">Donec ullamcorper nulla non metus auctor fringilla.</span><br />
   <span class="romo-text-info romo-bg-inverse-hover">Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis.</span><br />
   <span class="romo-text-error-hover romo-bg-success-hover">Duis mollis, est non commodo luctus, nisi erat porttitor ligula.</span><br />
+  <span class="romo-text-warning-hover romo-bg-base-hover">Duis mollis, est non commodo luctus, nisi erat porttitor ligula.</span><br />
   <a href="#" class="romo-text-inverse romo-bg-inverse">Duis mollis, est non commodo luctus, nisi erat porttitor ligula.</a><br />
 </div>
 
@@ -359,5 +380,6 @@ Or, combine in any number of ways.
 <span class="romo-text-error romo-bg-warning">...</span><br />
 <span class="romo-text-info romo-bg-inverse-hover">...</span><br />
 <span class="romo-text-error-hover romo-bg-success-hover">...</span><br />
+<span class="romo-text-warning-hover romo-bg-base-hover">...</span><br />
 <a href="#" class="romo-text-inverse romo-bg-inverse">...</a><br />
 ```


### PR DESCRIPTION
This is in addition to the 'muted', 'warning', etc colors.  This
allows you to get to back to the base/alt colors when some parent
elem has some custom color set.  This is also useful to get back
to the base/alt on hover when non-hover has a custom color.

Check this for an example on tables:
![image-hae0l](https://cloud.githubusercontent.com/assets/82110/9972229/14efd662-5e28-11e5-8cfa-7b16c4bf6b49.jpg)

@jcredding ready for review.
