### PR TITLE
css: border-radius-circle

### DIFF
--- a/assets/css/romo/base.scss
+++ b/assets/css/romo/base.scss
@@ -533,6 +533,9 @@ h3 { @include text1; }
 .romo-border2-bottom-left-radius-hover:hover   { @include border2-bottom-left-radius(!important); }
 .romo-rm-border-bottom-left-radius-hover:hover { @include rm-border-bottom-left-radius(!important); }
 
+.romo-border-radius-circle { @include border-radius(500px); }
+.romo-border-radius-circle-hover:hover { @include border-radius(500px); }
+
 /* spacing */
 
 .romo-pad,

--- a/gh-pages/view_handlers/css/helpers.md
+++ b/gh-pages/view_handlers/css/helpers.md
@@ -167,6 +167,9 @@ Add border radius.
   <div class="romo-border2 romo-border2-top-right-radius-hover romo-push0-bottom">.romo-border2-top-right-radius-hover</div>
   <div class="romo-border2 romo-border2-bottom-left-radius-hover romo-push0-bottom">.romo-border2-bottom-left-radius-hover</div>
   <div class="romo-border2 romo-border2-bottom-right-radius-hover">.romo-border2-bottom-right-radius-hover</div>
+  <div class="romo-border2 romo-border-radius-circle romo-push0-bottom">.romo-border-radius-circle</div>
+  <div class="romo-border2 romo-border-radius-circle-hover romo-push0-bottom">.romo-border-radius-circle-hover</div>
+
 </div>
 
 ```html


### PR DESCRIPTION
This takes the border radius logic and provides it as a general
border radius class.  Use this when you want to make any elem
look like a circle.

@jcredding ready for review.
