### PR TITLE
modal/dropdown: add API to bind/unbind body event handling

### DIFF
--- a/assets/js/romo/dropdown.js
+++ b/assets/js/romo/dropdown.js
@@ -45,8 +45,8 @@ var RomoDropdown = function(element) {
   this.elem.on('invoke:loadError', $.proxy(function(e, xhr, invoke) {
     this.doLoadBodyError(xhr);
   }, this));
-  this.elem.on('keyup', $.proxy(this.onElemKeyUp, this));
-  this.popupElem.on('keyup', $.proxy(this.onElemKeyUp, this));
+
+  this.doBindElemKeyUp();
 
   this.doInit();
   this.doInitBody();
@@ -180,10 +180,13 @@ RomoDropdown.prototype.doPopupOpen = function() {
   // event, then the toggle click will propagate which will call
   // this event and immediately close the popup.
   setTimeout($.proxy(function() {
-    $('body').on('click', $.proxy(this.onWindowBodyClick, this));
-    $('body').on('modal:mousedown', $.proxy(this.onWindowBodyClick, this));
+    this.doBindWindowBodyClick();
   }, this), 100);
-  $('body').on('keyup', $.proxy(this.onWindowBodyKeyUp, this));
+
+  // bind "esc" keystroke to toggle close
+  this.doBindWindowBodyKeyUp();
+
+  // bind window resizes reposition dropdown
   $(window).on('resize', $.proxy(this.onResizeWindow, this));
 
   this.elem.trigger('dropdown:popupOpen', [this]);
@@ -205,9 +208,13 @@ RomoDropdown.prototype.onPopupClose = function(e) {
 RomoDropdown.prototype.doPopupClose = function() {
   this.popupElem.removeClass('romo-dropdown-open');
 
-  $('body').off('click', $.proxy(this.onWindowBodyClick, this));
-  $('body').off('modal:mousedown', $.proxy(this.onWindowBodyClick, this));
-  $('body').off('keyup', $.proxy(this.onWindowBodyKeyUp, this));
+  // unbind any event to close the popup when clicking away from it
+  this.doUnBindWindowBodyClick();
+
+  // unbind "esc" keystroke to toggle close
+  this.doUnBindWindowBodyKeyUp();
+
+  // unbind window resizes reposition dropdown
   $(window).off('resize', $.proxy(this.onResizeWindow, this));
 
   // clear the content elem markup if configured to
@@ -216,6 +223,16 @@ RomoDropdown.prototype.doPopupClose = function() {
   }
 
   this.elem.trigger('dropdown:popupClose', [this]);
+}
+
+RomoDropdown.prototype.doBindElemKeyUp = function() {
+  this.elem.on('keyup', $.proxy(this.onElemKeyUp, this));
+  this.popupElem.on('keyup', $.proxy(this.onElemKeyUp, this));
+}
+
+RomoDropdown.prototype.doUnBindElemKeyUp = function() {
+  this.elem.off('keyup', $.proxy(this.onElemKeyUp, this));
+  this.popupElem.off('keyup', $.proxy(this.onElemKeyUp, this));
 }
 
 RomoDropdown.prototype.onElemKeyUp = function(e) {
@@ -234,6 +251,16 @@ RomoDropdown.prototype.onElemKeyUp = function(e) {
   return true;
 }
 
+RomoDropdown.prototype.doBindWindowBodyClick = function() {
+  $('body').on('click', $.proxy(this.onWindowBodyClick, this));
+  $('body').on('modal:mousedown', $.proxy(this.onWindowBodyClick, this));
+}
+
+RomoDropdown.prototype.doUnBindWindowBodyClick = function() {
+  $('body').off('click', $.proxy(this.onWindowBodyClick, this));
+  $('body').off('modal:mousedown', $.proxy(this.onWindowBodyClick, this));
+}
+
 RomoDropdown.prototype.onWindowBodyClick = function(e) {
   // if not clicked on the popup elem or the elem
   var target = $(e.target);
@@ -243,6 +270,14 @@ RomoDropdown.prototype.onWindowBodyClick = function(e) {
     this.doPopupClose();
   }
   return true;
+}
+
+RomoDropdown.prototype.doBindWindowBodyKeyUp = function() {
+  $('body').on('keyup', $.proxy(this.onWindowBodyKeyUp, this));
+}
+
+RomoDropdown.prototype.doUnBindWindowBodyKeyUp = function() {
+  $('body').off('keyup', $.proxy(this.onWindowBodyKeyUp, this));
 }
 
 RomoDropdown.prototype.onWindowBodyKeyUp = function(e) {

--- a/assets/js/romo/modal.js
+++ b/assets/js/romo/modal.js
@@ -33,6 +33,8 @@ var RomoModal = function(element) {
     this.doLoadBodyError(xhr);
   }, this));
 
+  this.doBindElemKeyUp();
+
   this.doInit();
   this.doInitBody();
 
@@ -158,11 +160,11 @@ RomoModal.prototype.doPopupOpen = function() {
   // event, then the toggle click will propagate which will call
   // this event and immediately close the popup.
   setTimeout($.proxy(function() {
-    $('body').on('click', $.proxy(this.onWindowBodyClick, this));
+    this.doBindWindowBodyClick();
   }, this), 100);
 
   // bind "esc" keystroke to toggle close
-  $('body').on('keyup', $.proxy(this.onWindowBodyKeyUp, this));
+  this.doBindWindowBodyKeyUp();
 
   // bind window resizes reposition modal
   $(window).on('resize', $.proxy(this.onResizeWindow, this));
@@ -187,10 +189,10 @@ RomoModal.prototype.doPopupClose = function() {
   this.popupElem.removeClass('romo-modal-open');
 
   // unbind any event to close the popup when clicking away from it
-  $('body').off('click', $.proxy(this.onWindowBodyClick, this));
+  this.doUnBindWindowBodyClick();
 
   // unbind "esc" keystroke to toggle close
-  $('body').off('keyup', $.proxy(this.onWindowBodyKeyUp, this));
+  this.doUnBindWindowBodyKeyUp();
 
   // unbind window resizes reposition modal
   $(window).off('resize', $.proxy(this.onResizeWindow, this));
@@ -262,12 +264,54 @@ RomoModal.prototype.doDragStop = function(e) {
   this.elem.trigger("modal:dragStop", [this]);
 }
 
+RomoModal.prototype.doBindElemKeyUp = function() {
+  this.elem.on('keyup', $.proxy(this.onElemKeyUp, this));
+  this.popupElem.on('keyup', $.proxy(this.onElemKeyUp, this));
+}
+
+RomoModal.prototype.doUnBindElemKeyUp = function() {
+  this.elem.off('keyup', $.proxy(this.onElemKeyUp, this));
+  this.popupElem.off('keyup', $.proxy(this.onElemKeyUp, this));
+}
+
+RomoModal.prototype.onElemKeyUp = function(e) {
+  if (this.elem.hasClass('disabled') === false) {
+    if (this.popupElem.hasClass('romo-modal-open')) {
+      if(e.keyCode === 27 /* Esc */ ) {
+        this.doPopupClose();
+        return false;
+      } else {
+        return true;
+      }
+    } else {
+      return true;
+    }
+  }
+  return true;
+}
+
+RomoModal.prototype.doBindWindowBodyClick = function() {
+  $('body').on('click', $.proxy(this.onWindowBodyClick, this));
+}
+
+RomoModal.prototype.doUnBindWindowBodyClick = function() {
+  $('body').off('click', $.proxy(this.onWindowBodyClick, this));
+}
+
 RomoModal.prototype.onWindowBodyClick = function(e) {
   // if not clicked on the popup elem
   if (e !== undefined && $(e.target).parents('.romo-modal-popup').size() === 0) {
     this.doPopupClose();
   }
   return true;
+}
+
+RomoModal.prototype.doBindWindowBodyKeyUp = function() {
+  $('body').on('keyup', $.proxy(this.onWindowBodyKeyUp, this));
+}
+
+RomoModal.prototype.doUnBindWindowBodyKeyUp = function() {
+  $('body').off('keyup', $.proxy(this.onWindowBodyKeyUp, this));
 }
 
 RomoModal.prototype.onWindowBodyKeyUp = function(e) {

--- a/lib/romo/dassets.rb
+++ b/lib/romo/dassets.rb
@@ -56,7 +56,7 @@ module Romo::Dassets
         'js/romo/modal_form.js',
         'js/romo/tooltip.js',
         'js/romo/indicator.js',
-        'js/romo/sortable.js',
+        'js/romo/sortable.js'
       ]
 
     end

--- a/test/unit/dassets_tests.rb
+++ b/test/unit/dassets_tests.rb
@@ -58,7 +58,7 @@ module Romo::Dassets
         'js/romo/modal_form.js',
         'js/romo/tooltip.js',
         'js/romo/indicator.js',
-        'js/romo/sortable.js',
+        'js/romo/sortable.js'
       ]
       assert_equal exp_js_sources, Dassets.config.combinations['js/romo.js']
     end


### PR DESCRIPTION
Both modals and dropdowns add event binding on the window body
to close their popups when the body is clicked or the esc key
is hit.

This reworks the binding/unbinding into a formal API so that it
can be turned on/off.  This is specifically needed for the new
romo-av modal/dropdown video components.  Because of browser quirks
when videos are in fullscreen, modal/dropdown videos need to disable
the body events while in fullscreen.  The net effect is you can
hit esc to exit fullscreen and not dismiss the video modal popup.

In addition, this bind element key up handling on the modal.  This
was added out of necessity for the dropdown component which was
implemented after the modal was.  The modals body key up handling
covered the modal but I chose to add the elem key up handling to
keep it consistent with the dropdown component.

@jcredding ready for review.
