### PR TITLE
indicator js: capture css/html contents on start

### DIFF
--- a/assets/js/romo/indicator.js
+++ b/assets/js/romo/indicator.js
@@ -31,12 +31,6 @@ var RomoIndicator = function(element) {
   this.doInit();
   this.spinner = new Spinner(this.spinnerOpts);
 
-  this.elemHtml = this.elem.html();
-  this.elem.css({
-    'position': 'relative',
-    'width':    this.elem.css('width'),
-    'height':   this.elem.css('height'),
-  });
   this.elem.on('indicator:triggerStart', $.proxy(this.onStart, this));
   this.elem.on('indicator:triggerStop', $.proxy(this.onStop, this));
 
@@ -70,6 +64,13 @@ RomoIndicator.prototype.onStop = function(e) {
 }
 
 RomoIndicator.prototype.doStart = function() {
+  this.elemHtml  = this.elem.html();
+  this.elemStyle = this.elem.attr('style');
+  this.elem.css({
+    'position': 'relative',
+    'width':    this.elem.css('width'),
+    'height':   this.elem.css('height'),
+  });
   this.elem.html('');
   this.spinner.spin(this.elem[0]);
   this.elem.trigger('indicator:start', [this]);
@@ -77,7 +78,17 @@ RomoIndicator.prototype.doStart = function() {
 
 RomoIndicator.prototype.doStop = function() {
   this.spinner.stop();
-  this.elem.html(this.elemHtml);
+  if (this.elemHtml !== undefined) {
+    this.elem.html(this.elemHtml);
+  }
+  this.elem.css({
+    'position': '',
+    'width':    '',
+    'height':   '',
+  });
+  if (this.elemStyle !== undefined) {
+    this.elem.attr('style', this.elemStyle);
+  }
   this.elem.trigger('indicator:stop', [this]);
 }
 


### PR DESCRIPTION
This as opposed to on init.  Sometimes the full css width/height
etc aren't set at init-time (due to markup being lazy loaded, etc).
This allows the dimensions and markup to change and the captured
css/html to handle this appropriately.

This switches to conditionally setting the html on stop.  This case
has to be handled now that the html isn't being captured on init.

Finally, this switches to capturing the style attr it overrides
and setting it on stop.  This ensures it safely applies the css
necessary while the indicator is running but resets the state and
cleans things up appropriately.

@jcredding ready for review.  I think you and I have both seen issues with this when using font awesome icons in buttons that are indicators, for example.
