### PR TITLE
css: add style class for color text the disabled color

### DIFF
--- a/assets/css/romo/_mixins.scss
+++ b/assets/css/romo/_mixins.scss
@@ -145,6 +145,8 @@
 @mixin text-border-base($i:"") { color: $baseBorderColor #{$i}; }
 @mixin text-border-alt($i:"")  { color: $altBorderColor #{$i}; }
 
+@mixin text-disabled($i:"") { color: $disabledColor #{$i}; }
+
 @mixin text-base($i:"")       { color: $baseText #{$i}; }
 @mixin text-base-hover($i:"") { color: $baseTextHover #{$i}; }
 @mixin bg-base($i:"")         { background-color: $baseBackground #{$i}; }

--- a/assets/css/romo/base.scss
+++ b/assets/css/romo/base.scss
@@ -224,6 +224,7 @@ h3 { @include text1; }
 
 .romo-text-border-base { @include text-border-base(!important); }
 .romo-text-border-alt  { @include text-border-alt(!important); }
+.romo-text-disabled    { @include text-disabled(!important); }
 .romo-text-base        { @include text-base(!important); }
 .romo-text-alt         { @include text-alt(!important); }
 .romo-text-muted       { @include text-muted(!important); }


### PR DESCRIPTION
This disabled color styling is already used in the disabled buttons,
disabled dates in the datepicker and disabled options in the selects.
This adds a style class so users can manually change to this color
in ad-hoc markup.

@jcredding ready for review.
