### PR TITLE
modal/dropdown/tooltip js: api to specify custom append to elems

### DIFF
--- a/assets/js/romo/dropdown.js
+++ b/assets/js/romo/dropdown.js
@@ -7,7 +7,7 @@ $.fn.romoDropdown = function() {
 var RomoDropdown = function(element) {
   this.elem = $(element);
   this.popupElem = $('<div class="romo-dropdown-popup"><div class="romo-dropdown-body"></div></div>');
-  this.popupElem.appendTo('body');
+  this.popupElem.appendTo(this.elem.closest(this.elem.data('romo-dropdown-append-to-closest') || 'body'));
   this.doSetPopupZIndex(this.elem);
   this.bodyElem = this.popupElem.find('> .romo-dropdown-body');
   this.contentElem = $();

--- a/assets/js/romo/modal.js
+++ b/assets/js/romo/modal.js
@@ -7,7 +7,7 @@ $.fn.romoModal = function() {
 var RomoModal = function(element) {
   this.elem = $(element);
   this.popupElem = $('<div class="romo-modal-popup"><div class="romo-modal-body"></div></div>');
-  this.popupElem.appendTo('body');
+  this.popupElem.appendTo(this.elem.closest(this.elem.data('romo-modal-append-to-closest') || 'body'));
   this.bodyElem = this.popupElem.find('> .romo-modal-body');
   this.contentElem = $();
   this.closeElem = $();

--- a/assets/js/romo/tooltip.js
+++ b/assets/js/romo/tooltip.js
@@ -7,7 +7,7 @@ $.fn.romoTooltip = function() {
 var RomoTooltip = function(element) {
   this.elem = $(element);
   this.popupElem = $('<div class="romo-tooltip-popup"><div class="romo-tooltip-arrow"></div><div class="romo-tooltip-body"></div></div>');
-  this.popupElem.appendTo('body');
+  this.popupElem.appendTo(this.elem.closest(this.elem.data('romo-tooltip-append-to-closest') || 'body'));
   this.doSetPopupZIndex(this.elem);
   this.arrowElem = this.popupElem.find('> .romo-tooltip-arrow');
   this.bodyElem = this.popupElem.find('> .romo-tooltip-body');


### PR DESCRIPTION
By default, the popups for these components are appended to the
body.  This is a safe default as it will minimize the number of
parent styles that get trickled down to your popups.  However if,
for example, you want to full screen some markup that uses these
components you won't be able to see their popups by default (b/c
the body isn't being full screened).

This adds a data attribute for specifying which elem to append the
popup to.  It will still default to the body, but can be passes a
selector.  The selector will be used to find the closest matching
elem and append the popup to that elem.

@jcredding ready for review.
