### PR TITLE
dropdown: turn off body event handling if modal is opened

### DIFF
--- a/assets/js/romo/dropdown.js
+++ b/assets/js/romo/dropdown.js
@@ -61,6 +61,16 @@ RomoDropdown.prototype.doInit = function() {
 RomoDropdown.prototype.doInitBody = function() {
   this.doResetBody();
 
+  this.popupElem.on('modal:popupOpen', $.proxy(function(e) {
+    this.doUnBindWindowBodyClick();
+    this.doUnBindWindowBodyKeyUp();
+    this.doUnBindElemKeyUp();
+  }, this));
+  this.popupElem.on('modal:popupClose', $.proxy(function(e) {
+    this.doBindWindowBodyClick();
+    this.doBindWindowBodyKeyUp();
+    this.doBindElemKeyUp();
+  }, this));
   this.contentElem = this.bodyElem.find('.romo-dropdown-content').last();
   if (this.contentElem.size() === 0) {
     this.contentElem = this.bodyElem;
@@ -253,12 +263,12 @@ RomoDropdown.prototype.onElemKeyUp = function(e) {
 
 RomoDropdown.prototype.doBindWindowBodyClick = function() {
   $('body').on('click', $.proxy(this.onWindowBodyClick, this));
-  $('body').on('modal:mousedown', $.proxy(this.onWindowBodyClick, this));
+  $('body').on('modal:mousemove', $.proxy(this.onWindowBodyClick, this));
 }
 
 RomoDropdown.prototype.doUnBindWindowBodyClick = function() {
   $('body').off('click', $.proxy(this.onWindowBodyClick, this));
-  $('body').off('modal:mousedown', $.proxy(this.onWindowBodyClick, this));
+  $('body').off('modal:mousemove', $.proxy(this.onWindowBodyClick, this));
 }
 
 RomoDropdown.prototype.onWindowBodyClick = function(e) {

--- a/assets/js/romo/modal.js
+++ b/assets/js/romo/modal.js
@@ -206,7 +206,6 @@ RomoModal.prototype.doPopupClose = function() {
 }
 
 RomoModal.prototype.onMouseDown = function(e) {
-  $('body').trigger('modal:mousedown');
   e.preventDefault();
   e.stopPropagation();
   this.doDragStart(e);
@@ -229,6 +228,7 @@ RomoModal.prototype.doDragStart = function(e) {
 }
 
 RomoModal.prototype.onMouseMove = function(e) {
+  $('body').trigger('modal:mousemove');
   e.preventDefault();
   e.stopPropagation();
   this.doDragMove(e.clientX, e.clientY);

--- a/assets/js/romo/tooltip.js
+++ b/assets/js/romo/tooltip.js
@@ -178,7 +178,7 @@ RomoTooltip.prototype.doPopupOpen = function() {
   this.doPlacePopupElem();
 
   if (this.elem.parents('.romo-modal-popup').size() !== 0) {
-    $('body').on('modal:mousedown',  $.proxy(this.onModalPopupChange, this));
+    $('body').on('modal:mousemove',  $.proxy(this.onModalPopupChange, this));
     $('body').on('modal:popupclose', $.proxy(this.onModalPopupChange, this));
   }
   $(window).on('resize', $.proxy(this.onResizeWindow, this));
@@ -200,7 +200,7 @@ RomoTooltip.prototype.doPopupClose = function() {
   this.popupElem.removeClass('romo-tooltip-open');
 
   if (this.elem.parents('.romo-modal-popup').size() !== 0) {
-    $('body').off('modal:mousedown',  $.proxy(this.onModalPopupChange, this));
+    $('body').off('modal:mousemove',  $.proxy(this.onModalPopupChange, this));
     $('body').off('modal:popupclose', $.proxy(this.onModalPopupChange, this));
   }
   $(window).off('resize', $.proxy(this.onResizeWindow, this));


### PR DESCRIPTION
This updates the dropdown component to turn off its body event
handling while a modal (that was opened from the dropdown) is open.
The effect here is that any body event handling will be limited to
the modal while it is open and the dropdown will ignore body event
handling until the modal is closed.

This only applies to modals opened from dropdowns.  Modals opened
outside of the dropdown behave as before.

Note: this also switches dropdowns/tooltips to close on modal _moves_.
The old logic closed all popups as soon as you mouse down.  This is 
technically not necessary as problems don't come up until you
start moving the modal (dragging it).  The changes to wait as long
as possible before closing.  This was noticed while messing around
with the above changes.

@jcredding ready for review.
