### PR TITLE
romo-hover style class concept; applied to display style classes

### DIFF
--- a/assets/css/romo/base.scss
+++ b/assets/css/romo/base.scss
@@ -628,6 +628,15 @@ h3 { @include text1; }
 .romo-block        { display: block !important; }
 .romo-display-none { display: none !important;}
 
+.romo-hover:hover {
+  .romo-inline-hover       { display: inline !important; }
+  .romo-inline-block-hover { display: inline-block !important; }
+  .romo-inline-flex-hover  { @include display-inline-flex(!important); }
+  .romo-flex-hover         { @include display-flex(!important); }
+  .romo-block-hover        { display: block !important; }
+  .romo-display-none-hover { display: none !important;}
+}
+
 .romo-relative { position: relative !important; }
 .romo-absolute { position: absolute !important; }
 .romo-absolute-fill {


### PR DESCRIPTION
This introduces a new style class, `romo-hover` which is designed
to enable child hover style classes when the parent elem is hovered.
This also applies this concept to the display helper style classes.

The practical application here is to conditionally show child elems
when a parent is hovered - all using style classes instead of relying
on custom CSS.  To accomplish this example, you would add `romo-hover`
to the parent elem and then add `romo-display-none` and
`romo-display-{block|whatever}-hover` to the child elems that you
only want displayed on hover.  This would make the element hidden
by default but display {whatever} when the parent is hovered.

@jcredding ready for review.
