### PR TITLE
invoke js: add options method data option

### DIFF
--- a/assets/js/romo/invoke.js
+++ b/assets/js/romo/invoke.js
@@ -9,6 +9,7 @@ var RomoInvoke = function(element) {
   this.targetElem = $(this.elem.data('romo-invoke-target'));
   this.invokeOn = this.elem.data('romo-invoke-on') || 'click';
   this.invokeAttr = this.elem.data('romo-invoke-attr') || 'href';
+  this.invokeMethod = this.elem.data('romo-invoke-method') || 'GET';
   this.loadOnlyOnce = this.elem.data('romo-invoke-load-once') === true;
 
   this.elem.unbind(this.invokeOn);
@@ -59,6 +60,7 @@ RomoInvoke.prototype.doLoad = function(href) {
   this._trigger('invoke:loadStart', [this]);
 
   $.ajax({
+    type:    this.invokeMethod,
     url:     href,
     success: $.proxy(this.onLoadAjaxSuccess, this),
     error:   $.proxy(this.onLoadAjaxError,   this)


### PR DESCRIPTION
This allows you to use a different ajax method for loading data
but still default to 'GET' if no custom method is supplied.  This
allows you to use invokes in more applications than just simply
fetching data with a 'GET'.

@jcredding ready for review.
