### PR TITLE
js: track parent-child elem relationships; use to remove appropriately

### DIFF
--- a/assets/js/romo/datepicker.js
+++ b/assets/js/romo/datepicker.js
@@ -43,6 +43,15 @@ RomoDatepicker.prototype.doBindElem = function() {
   this.elem.before(elemWrapper);
   elemWrapper.append(this.elem);
 
+  // the elem wrapper should be treated like a child elem.  add it to Romo's
+  // parent-child elems so it will be removed when the elem (input) is removed.
+  // delay adding it b/c the `append` statement above is not a "move", it is
+  // a "remove" and "add" so if added immediately the "remove" part will
+  // incorrectly remove the wrapper.  Any value will do - I chose 100 arbitrarily.
+  setTimeout($.proxy(function() {
+    Romo.parentChildElems.add(this.elem, [elemWrapper]);
+  }, this), 100);
+
   this.elem.attr('autocomplete', 'off');
 
   this.indicatorElem = $();

--- a/assets/js/romo/modal.js
+++ b/assets/js/romo/modal.js
@@ -6,17 +6,8 @@ $.fn.romoModal = function() {
 
 var RomoModal = function(element) {
   this.elem = $(element);
-  this.popupElem = $('<div class="romo-modal-popup"><div class="romo-modal-body"></div></div>');
-  this.popupElem.appendTo(this.elem.closest(this.elem.data('romo-modal-append-to-closest') || 'body'));
-  this.bodyElem = this.popupElem.find('> .romo-modal-body');
-  this.contentElem = $();
-  this.closeElem = $();
-  this.dragElem = $();
+  this.doInitPopup();
   this.romoInvoke = this.elem.romoInvoke()[0];
-
-  if (this.elem.data('romo-modal-style-class') !== undefined) {
-    this.bodyElem.addClass(this.elem.data('romo-modal-style-class'));
-  }
 
   this.elem.unbind('click');
   this.elem.on('click', $.proxy(this.onToggleClick, this));
@@ -45,6 +36,24 @@ RomoModal.prototype.doInit = function() {
   // override as needed
 }
 
+RomoModal.prototype.doInitPopup = function() {
+  this.popupElem = $('<div class="romo-modal-popup"><div class="romo-modal-body"></div></div>');
+  this.popupElem.appendTo(this.elem.closest(this.elem.data('romo-modal-append-to-closest') || 'body'));
+
+  this.bodyElem = this.popupElem.find('> .romo-modal-body');
+  if (this.elem.data('romo-modal-style-class') !== undefined) {
+    this.bodyElem.addClass(this.elem.data('romo-modal-style-class'));
+  }
+
+  this.contentElem = $();
+  this.closeElem   = $();
+  this.dragElem    = $();
+
+  // the popup should be treated like a child elem.  add it to Romo's
+  // parent-child elems so it will be removed when the elem is removed.
+  Romo.parentChildElems.add(this.elem, [this.popupElem]);
+}
+
 RomoModal.prototype.doInitBody = function() {
   this.doResetBody();
 
@@ -52,8 +61,14 @@ RomoModal.prototype.doInitBody = function() {
   if (this.contentElem.size() === 0) {
     this.contentElem = this.bodyElem;
   }
+
   this.closeElem = this.popupElem.find('[data-romo-modal-close="true"]');
+  this.closeElem.unbind('click');
+  this.closeElem.on('click', $.proxy(this.onPopupClose, this));
+
   this.dragElem = this.popupElem.find('[data-romo-modal-drag="true"]');
+  this.dragElem.addClass('romo-modal-grab');
+  this.dragElem.on('mousedown', $.proxy(this.onMouseDown, this));
 
   var css = {
     'min-width':  this.elem.data('romo-modal-min-width'),
@@ -73,12 +88,6 @@ RomoModal.prototype.doInitBody = function() {
   }
 
   this.contentElem.css(css);
-
-  this.closeElem.unbind('click');
-  this.closeElem.on('click', $.proxy(this.onPopupClose, this));
-
-  this.dragElem.addClass('romo-modal-grab');
-  this.dragElem.on('mousedown', $.proxy(this.onMouseDown, this));
 }
 
 RomoModal.prototype.doResetBody = function() {

--- a/assets/js/romo/select.js
+++ b/assets/js/romo/select.js
@@ -130,6 +130,10 @@ RomoSelect.prototype._buildSelectDropdownElem = function() {
   romoSelectDropdownElem.before(this.elemWrapper);
   this.elemWrapper.append(romoSelectDropdownElem);
 
+  // the elem wrapper should be treated like a child elem.  add it to Romo's
+  // parent-child elems so it will be removed when the elem (select) is removed.
+  Romo.parentChildElems.add(this.elem, [this.elemWrapper]);
+
   var caretClass = this.elem.data('romo-select-caret') || this.defaultCaretClass;
   if (caretClass !== undefined && caretClass !== 'none') {
     var caret = $('<i class="romo-select-caret '+caretClass+'"></i>');

--- a/assets/js/romo/tooltip.js
+++ b/assets/js/romo/tooltip.js
@@ -6,11 +6,7 @@ $.fn.romoTooltip = function() {
 
 var RomoTooltip = function(element) {
   this.elem = $(element);
-  this.popupElem = $('<div class="romo-tooltip-popup"><div class="romo-tooltip-arrow"></div><div class="romo-tooltip-body"></div></div>');
-  this.popupElem.appendTo(this.elem.closest(this.elem.data('romo-tooltip-append-to-closest') || 'body'));
-  this.doSetPopupZIndex(this.elem);
-  this.arrowElem = this.popupElem.find('> .romo-tooltip-arrow');
-  this.bodyElem = this.popupElem.find('> .romo-tooltip-body');
+  this.doInitPopup();
 
   this.hoverState = 'out';
   this.delayEnter = 0;
@@ -25,19 +21,6 @@ var RomoTooltip = function(element) {
   if (this.elem.data('romo-tooltip-delay-leave') !== undefined && this.elem.data('romo-tooltip-delay-leave') !== '') {
     this.delayLeave = this.elem.data('romo-tooltip-delay-leave');
   }
-
-  this.popupPosition = this.elem.data('romo-tooltip-position') || 'top';
-  this.popupElem.attr('data-romo-tooltip-position', this.popupPosition);
-  this.popupAlignment = this.elem.data('romo-tooltip-alignment') || 'center';
-  this.popupElem.attr('data-romo-tooltip-alignment', this.popupAlignment);
-
-  // don't propagate click events on the popup elem.  this prevents the popup
-  // from closing when clicked (see body click event bind on popup open)
-  this.popupElem.on('click', function(e) {
-    if (e !== undefined) {
-      e.stopPropagation();
-    }
-  })
 
   if (this.elem.data('romo-tooltip-style-class') !== undefined) {
     this.bodyElem.addClass(this.elem.data('romo-tooltip-style-class'));
@@ -61,6 +44,33 @@ var RomoTooltip = function(element) {
 
 RomoTooltip.prototype.doInit = function() {
   // override as needed
+}
+
+RomoTooltip.prototype.doInitPopup = function() {
+  this.popupElem = $('<div class="romo-tooltip-popup"><div class="romo-tooltip-arrow"></div><div class="romo-tooltip-body"></div></div>');
+  this.popupElem.appendTo(this.elem.closest(this.elem.data('romo-tooltip-append-to-closest') || 'body'));
+
+  this.bodyElem = this.popupElem.find('> .romo-tooltip-body');
+
+  this.popupPosition = this.elem.data('romo-tooltip-position') || 'top';
+  this.popupElem.attr('data-romo-tooltip-position', this.popupPosition);
+
+  this.popupAlignment = this.elem.data('romo-tooltip-alignment') || 'center';
+  this.popupElem.attr('data-romo-tooltip-alignment', this.popupAlignment);
+
+  this.doSetPopupZIndex(this.elem);
+
+  // don't propagate click events on the popup elem.  this prevents the popup
+  // from closing when clicked (see body click event bind on popup open)
+  this.popupElem.on('click', function(e) {
+    if (e !== undefined) {
+      e.stopPropagation();
+    }
+  })
+
+  // the popup should be treated like a child elem.  add it to Romo's
+  // parent-child elems so it will be removed when the elem is removed.
+  Romo.parentChildElems.add(this.elem, [this.popupElem]);
 }
 
 RomoTooltip.prototype.doInitBody = function() {


### PR DESCRIPTION
The problem we are tying to solve here is that some js components
that bind to DOM elems need to create additional DOM elems that
are not hierarchial children but are in their nature/design.  These
generated DOM elems are useless without the source elem.  However,
if the source elem was removed, these DOM elems would linger b/c
they existed in a separate elem tree.

This adds a parent/child elem tracking class that monitors DOM
removals at the body level.  If it detects a node removal that
contains parent elems, it goes and looks up the child elems for
each parent and removes them.  This keeps the DOM clean and avoids
weird edge-case behavior of orphaned DOM elements lingering when
they shouldn't.

This has been added to the tooltip, modal, dropdown, select and
datepicker components.  The tooltips, modals and dropdowns all
build popup elems that are appended to the body.  The selects appends
a wrapper after itself while the datepicker appends a wrapper and
then nests itself in said wrapper.  These wrappers/popups should
be removed if/when their component elems are removed.

The tracking class is a collection with `add` and `remove` methods.
Components use the `add` method to associate child elems with parent
elems.  The `remove` method is used by the DOM observer to remove
all child elems for parent elems in a node's tree.  Internally, the
tracking class generates elem ids and sets them for usage as a data
attr on the parent elems.

This gif shows two scenarios: 1) me replacing a set of markup that has tooltips and a dropdown to show that elems are no longer just accumulating and 2) a case where I use javascript to remove all parent elems and you see that the generated markup is also removed (ie all the popups).

![gif](https://cloud.githubusercontent.com/assets/82110/10921243/0c24cbec-823a-11e5-8596-8f32a45a0674.gif)

@jcredding ready for review.
