### PR TITLE
Make `Dassets.configure!` safe to call multiple times

### DIFF
--- a/lib/romo/dassets.rb
+++ b/lib/romo/dassets.rb
@@ -10,6 +10,8 @@ module Romo::Dassets
   # eventually would have a gem, "romo-dassets", do this or something
 
   def self.configure!
+    return if @configured
+
     Dassets.configure do |c|
       c.source Romo.gem_assets_path do |s|
         s.filter{ |paths| paths.reject{ |p| File.basename(p) =~ /^_/ } }
@@ -58,8 +60,11 @@ module Romo::Dassets
         'js/romo/indicator.js',
         'js/romo/sortable.js'
       ]
-
     end
+
+    @configured = true
   end
+
+  def self.reset!; @configured = false; end
 
 end

--- a/test/unit/dassets_tests.rb
+++ b/test/unit/dassets_tests.rb
@@ -11,6 +11,8 @@ module Romo::Dassets
     desc "Romo::Dassets"
     subject{ Romo::Dassets }
 
+    should have_imeths :configure!, :reset!
+
     should "configure Romo with Dassets" do
       subject.configure!
 
@@ -61,6 +63,24 @@ module Romo::Dassets
         'js/romo/sortable.js'
       ]
       assert_equal exp_js_sources, Dassets.config.combinations['js/romo.js']
+    end
+
+    should "only configure itself once unless reset" do
+      subject.configure!
+      # modify the romo css so we can see that it isn't altered by calling
+      # configure again unless we call reset
+      Dassets.configure do |c|
+        c.combination "css/romo.css", []
+      end
+      assert_equal [], Dassets.config.combinations['css/romo.css']
+      subject.configure!
+      assert_equal [], Dassets.config.combinations['css/romo.css']
+
+      subject.reset!
+
+      assert_equal [], Dassets.config.combinations['css/romo.css']
+      subject.configure!
+      assert_not_equal [], Dassets.config.combinations['css/romo.css']
     end
 
   end


### PR DESCRIPTION
This makes the `Dassets.configure!` method safe to call multiple
times by setting a flag to true when its called. It checks the flag
when its called and if its true it returns doing nothing. This is
so multiple gems can use romo and configure it with dassets without
being aware of one another or worrying about call order.

@kellyredding - Ready for review.
