### PR TITLE
form js: add ability to confirm form submissions

### DIFF
--- a/assets/js/romo/dropdown_form.js
+++ b/assets/js/romo/dropdown_form.js
@@ -69,6 +69,9 @@ RomoDropdownForm.prototype.doBindForm = function() {
   formElem.on('form:ready', $.proxy(function(e, form) {
     this.elem.trigger('dropdownForm:form:ready', [form, this]);
   }, this));
+  formElem.on('form:confirmSubmit', $.proxy(function(e, form) {
+    this.elem.trigger('dropdownForm:form:confirmSubmit', [form, this]);
+  }, this));
   formElem.on('form:beforeSubmit', $.proxy(function(e, form) {
     this.elem.trigger('dropdownForm:form:beforeSubmit', [form, this]);
   }, this));
@@ -88,7 +91,7 @@ RomoDropdownForm.prototype.doBindForm = function() {
     this.elem.trigger('dropdownForm:form:browserSubmit', [form, this]);
   }, this));
 
-  var submitElement = this.dropdown.popupElem.find('[data-romo-form-submit="true"]')[0];
+  var submitElement = this.dropdown.popupElem.find('[data-romo-form-submit]')[0];
   var indicatorElements = this.dropdown.popupElem.find('[data-romo-indicator-auto="true"]');
   this.form = formElem.romoForm(submitElement, indicatorElements)[0];
 }

--- a/assets/js/romo/form.js
+++ b/assets/js/romo/form.js
@@ -6,7 +6,7 @@ $.fn.romoForm = function(givenSubmitElement, givenIndicatorElements) {
 
 var RomoForm = function(element, givenSubmitElement, givenIndicatorElements) {
   this.elem = $(element);
-  this.defaultSubmitElem = this.elem.find('button[type="submit"], input[type="submit"], [data-romo-form-submit="true"]');
+  this.defaultSubmitElem = this.elem.find('button[type="submit"], input[type="submit"], [data-romo-form-submit]');
   this.submitElem = $(givenSubmitElement || this.defaultSubmitElem);
   this.defaultIndicatorElems = this.elem.find('[data-romo-indicator-auto="true"]');
   this.indicatorElems = $(givenIndicatorElements || this.defaultIndicatorElems);
@@ -80,7 +80,9 @@ RomoForm.prototype.onSubmitClick = function(e) {
     e.preventDefault();
   }
 
-  if (this.submitElem.hasClass('disabled') === false) {
+  if (this.submitElem.data('romo-form-submit') === 'confirm') {
+    this.elem.trigger('form:confirmSubmit', [this]);
+  } else if (this.submitElem.hasClass('disabled') === false) {
     this.doSubmit();
   }
 }

--- a/assets/js/romo/inline_form.js
+++ b/assets/js/romo/inline_form.js
@@ -59,6 +59,9 @@ RomoInlineForm.prototype.doBindForm = function() {
   formElem.on('form:ready', $.proxy(function(e, form) {
     this.elem.trigger('inlineForm:form:ready', [form, this]);
   }, this));
+  formElem.on('form:confirmSubmit', $.proxy(function(e, form) {
+    this.elem.trigger('inlineForm:form:confirmSubmit', [form, this]);
+  }, this));
   formElem.on('form:beforeSubmit', $.proxy(function(e, form) {
     this.elem.trigger('inlineForm:form:beforeSubmit', [form, this]);
   }, this));
@@ -75,7 +78,7 @@ RomoInlineForm.prototype.doBindForm = function() {
     this.elem.trigger('inlineForm:form:submitError', [xhr, form, this]);
   }, this));
 
-  var submitElement = this.elem.find('[data-romo-form-submit="true"]')[0];
+  var submitElement = this.elem.find('[data-romo-form-submit]')[0];
   var indicatorElements = this.elem.find('[data-romo-indicator-auto="true"]');
   this.form = formElem.romoForm(submitElement, indicatorElements)[0];
 }

--- a/assets/js/romo/modal_form.js
+++ b/assets/js/romo/modal_form.js
@@ -78,6 +78,9 @@ RomoModalForm.prototype.doBindForm = function() {
   formElem.on('form:ready', $.proxy(function(e, form) {
     this.elem.trigger('modalForm:form:ready', [form, this]);
   }, this));
+  formElem.on('form:confirmSubmit', $.proxy(function(e, form) {
+    this.elem.trigger('modalForm:form:confirmSubmit', [form, this]);
+  }, this));
   formElem.on('form:beforeSubmit', $.proxy(function(e, form) {
     this.elem.trigger('modalForm:form:beforeSubmit', [form, this]);
   }, this));
@@ -97,7 +100,7 @@ RomoModalForm.prototype.doBindForm = function() {
     this.elem.trigger('modalForm:form:browserSubmit', [form, this]);
   }, this));
 
-  var submitElement = this.modal.popupElem.find('[data-romo-form-submit="true"]')[0];
+  var submitElement = this.modal.popupElem.find('[data-romo-form-submit]')[0];
   var indicatorElements = this.modal.popupElem.find('[data-romo-indicator-auto="true"]');
   this.form = formElem.romoForm(submitElement, indicatorElements)[0];
 }


### PR DESCRIPTION
To enable this, configure your submit elem `data-romo-form-submit`
attr with "confirm" instead of the standard "true" value.  This
will trigger the `form:confirmSubmit` event instead of submitting
the form.  Use this event to do whatever you need to confirm the
form submission.  Once, confirmed, manually call `doSubmit` on the
form object or alternatively trigger the `form:triggerSubmit` event
on the form elem and the form will submit as usual.

This event has also been setup to proxy from dropdown, modal and
inline form components.

@jcredding ready for review.
