### PR TITLE
inline js: cleanup invoke handling; always show before init html

### DIFF
--- a/assets/js/romo/inline.js
+++ b/assets/js/romo/inline.js
@@ -10,14 +10,10 @@ var RomoInline = function(element) {
   this.dismissElem = undefined;
 
   this.elem.on('inline:triggerDismiss', $.proxy(this.onDismissClick, this));
-  this.elem.on('inline:triggerInvoke',  $.proxy(function(e) {
-    this.doInvoke();
+  this.elem.on('inline:triggerShow',  $.proxy(function(e) {
+    this.doShow();
   }, this));
 
-  this.elem.on('invoke:invoke', $.proxy(function(e, invoke) {
-    this.doInvoke();
-    return false;
-  }, this));
   this.elem.on('invoke:loadStart', $.proxy(function(e, invoke) {
     this.doLoadStart();
     return false;
@@ -40,24 +36,20 @@ RomoInline.prototype.doInit = function() {
   // override as needed
 }
 
-RomoInline.prototype.doInvoke = function() {
-  this.elem.show();
-  this.toggleElem.hide();
-  this.elem.trigger('inline:invoke', [this]);
-}
-
 RomoInline.prototype.doLoadStart = function() {
   this.elem.html('');
   this.elem.trigger('inline:loadStart', [this]);
 }
 
 RomoInline.prototype.doLoadSuccess = function(data) {
+  this.doShow();
   Romo.initHtml(this.elem, data);
   this.doBindDismiss();
   this.elem.trigger('inline:loadSuccess', [data, this]);
 }
 
 RomoInline.prototype.doLoadError = function(xhr) {
+  this.doShow();
   this.elem.trigger('inline:loadError', [xhr, this]);
 }
 
@@ -83,6 +75,12 @@ RomoInline.prototype.doDismiss = function() {
   this.toggleElem.show();
   this.elem.hide();
   this.elem.trigger('inline:dismiss', [this]);
+}
+
+RomoInline.prototype.doShow = function() {
+  this.elem.show();
+  this.toggleElem.hide();
+  this.elem.trigger('inline:show', [this]);
 }
 
 Romo.onInitUI(function(e) {


### PR DESCRIPTION
This does a couple of cleanups to how inlines handle interacting
with invoke components.  This all surfaced in light of changes made
in #54.  That PR inadvertently switched invokes to trigger the load
success event before triggering the general invoke event.  This
shouldn't have broken anything, but it had side-effects on inline
components.  Inlines used the general invoke event to trigger showing
the inline elem and used the load success event to trigger init'ing
the loaded html.  Inlines were assuming the general invoke would
always come in before the load success event (as you don't want to
init html that is hidden).  So when I changed the event order in
#54 it caused inlines to init their loaded html before displaying

it (which isn't intended as components may use whether they are
shown or not to influence behavior based on init).

This really exposed some unintended coupling between inlines and
invokes.  If the inlines are picky about the state of the inline
when load success comes it, they should really handle it themselves.

This does a couple of changes to fix things:
- remove the `doInvoke` method on the inline.  A better name for this
  method is "show".  This updates the method to be called `doShow`
  and switches to triggering `inline:show` events.  This also helps
  with name confusing with the invoke events.  Also this more accurately
  describes what the method does (what does "invoking" an inline do?).
- update the load success/error logic to always show the inline before
  initializing the newly loaded html content.  The inline expects the
  inline contents to always be shown when initializing them.

@jcredding ready for review.
