### PR TITLE
Invoke: Stop triggering on both elem and target elem

### DIFF
--- a/assets/js/romo/invoke.js
+++ b/assets/js/romo/invoke.js
@@ -100,9 +100,10 @@ RomoInvoke.prototype._doInvoke = function() {
 }
 
 RomoInvoke.prototype._trigger = function(event_name, event_data) {
-  this.elem.trigger(event_name, event_data);
-  if (this.targetElem !== undefined) {
+  if (this.targetElem[0] !== undefined) {
     this.targetElem.trigger(event_name, event_data);
+  } else {
+    this.elem.trigger(event_name, event_data);
   }
 }
 


### PR DESCRIPTION
This changes the invoke to stop trigger on its elem and its target
elem. This fixes an issue with invokes that are nested in other
components that listen for invoke events. The outer components
would respond to nested invoke elems because they weren't caught
and would bubble up. This typically happened because only one of
the nested invokes events were being listened to, either only the
main elem or only the target elem.

To fix this, the invoke will now only publish to its main elem or
only publish to its target elem. So if a target elem is specified
all of the invoke events will go to the target elem and not to
the main elem. This also fixes a bug that was causing the invoke
to always think there was a target elem. It was comparing if a
jquery/zepto object was not `undefined` which always returned
true. This updates it to pull out the first element in the
jquery/zepto object and use it for comparing which works as
expected.

@kellyredding - Ready for review.
