### PR TITLE
Update inline form to propagate the inline show event

### DIFF
--- a/assets/js/romo/inline_form.js
+++ b/assets/js/romo/inline_form.js
@@ -40,9 +40,6 @@ RomoInlineForm.prototype.doBindInline = function() {
   this.elem.on('inline:ready', $.proxy(function(e, inline) {
     this.elem.trigger('inlineForm:inline:ready', [inline, this]);
   }, this));
-  this.elem.on('inline:invoke', $.proxy(function(e, inline) {
-    this.elem.trigger('inlineForm:inline:invoke', [inline, this]);
-  }, this));
   this.elem.on('inline:loadStart', $.proxy(function(e, inline) {
     this.elem.trigger('inlineForm:inline:loadStart', [inline, this]);
   }, this));
@@ -51,6 +48,9 @@ RomoInlineForm.prototype.doBindInline = function() {
   }, this));
   this.elem.on('inline:loadError', $.proxy(function(e, xhr, inline) {
     this.elem.trigger('inlineForm:inline:loadError', [xhr, inline, this]);
+  }, this));
+  this.elem.on('inline:show', $.proxy(function(e, inline) {
+    this.elem.trigger('inlineForm:inline:show', [inline, this]);
   }, this));
   this.elem.on('inline:dismiss', $.proxy(function(e, inline) {
     this.elem.trigger('inlineForm:inline:dismiss', [inline, this]);


### PR DESCRIPTION
This updates the inline form to propagate the inline show event.
This is the pattern we use for all the other inline events. When
the event was added we forgot to update the inline form. This
allows javascript logic to only bind to inline form events and
not have to know anything about the inline it composes.

This also removes propagating the inline invoke event. The event
was removed and is no longer published by inline components.

Related to #55 (662d7b1)

@kellyredding - Ready for review.
