### PR TITLE
datepicker: add trigger events to set format/date

### DIFF
--- a/assets/js/romo/datepicker.js
+++ b/assets/js/romo/datepicker.js
@@ -73,6 +73,12 @@ RomoDatepicker.prototype.doBindElem = function() {
   this.elem.on('datepicker:triggerDisable', $.proxy(function(e) {
     this.doDisable();
   }, this));
+  this.elem.on('datepicker:triggerSetFormat', $.proxy(function(e) {
+    this.doSetFormat();
+  }, this));
+  this.elem.on('datepicker:triggerSetDate', $.proxy(function(e, value) {
+    this.doSetDate(value);
+  }, this));
 }
 
 RomoDatepicker.prototype.doSetFormat = function() {


### PR DESCRIPTION
This allows you to access these functions via events (for cases where
you don't have access to the auto-initialized component instance).
This follows the patter of trigger events on this and other components.

@jcredding ready for review.
