### PR TITLE
always trigger datepicker change events on elem change

### DIFF
--- a/assets/js/romo/datepicker.js
+++ b/assets/js/romo/datepicker.js
@@ -11,13 +11,14 @@ var RomoDatepicker = function(element) {
     "January", "February", "March", "April", "May", "June",
     "July", "August", "September", "October", "November", "December"
   ]
-  this.defaultPrevClass = undefined;
-  this.defaultNextClass = undefined;
-  this.defaultIndicatorClass  = undefined;
-  this.itemSelector = 'TD.romo-datepicker-day:not(.disabled)';
-  this.calTable = $();
-  this.date = undefined;
-  this.today = new Date;
+  this.defaultPrevClass      = undefined;
+  this.defaultNextClass      = undefined;
+  this.defaultIndicatorClass = undefined;
+  this.itemSelector          = 'TD.romo-datepicker-day:not(.disabled)';
+  this.calTable              = $();
+  this.date                  = undefined;
+  this.today                 = new Date;
+  this.prevValue             = undefined;
 
   this.doInit();
   this.doBindElem();
@@ -67,6 +68,13 @@ RomoDatepicker.prototype.doBindElem = function() {
     this.elem.after(this.indicatorElem);
   }
 
+  this.prevValue = this.elem.val();
+  this.elem.on('change', $.proxy(function(e) {
+    var newValue = this.elem.val();
+    this.elem.trigger('datepicker:change', [newValue, this.prevValue, this]);
+    this.prevValue = newValue;
+  }, this));
+
   this.elem.on('datepicker:triggerEnable', $.proxy(function(e) {
     this.doEnable();
   }, this));
@@ -76,9 +84,7 @@ RomoDatepicker.prototype.doBindElem = function() {
   this.elem.on('datepicker:triggerSetFormat', $.proxy(function(e) {
     this.doSetFormat();
   }, this));
-  this.elem.on('datepicker:triggerSetDate', $.proxy(function(e, value) {
-    this.doSetDate(value);
-  }, this));
+  this.elem.on('datepicker:triggerSetDate', $.proxy(this.onTriggerSetDate, this));
 }
 
 RomoDatepicker.prototype.doSetFormat = function() {
@@ -201,18 +207,18 @@ RomoDatepicker.prototype.doRefreshToNextMonth = function() {
 }
 
 RomoDatepicker.prototype.doSelectHighlightedItem = function() {
-  var prevValue = this.elem.val();
-  var newValue = this.calTable.find('TD.romo-datepicker-highlight').data('romo-datepicker-value');
+  var newValue  = this.calTable.find('TD.romo-datepicker-highlight').data('romo-datepicker-value');
 
   this.romoDropdown.doPopupClose();
   this.doSetDate(newValue);
   this.elem.focus();
-  this.elem.trigger('datepicker:itemSelected', [newValue, prevValue, this]);
+  this.elem.trigger('datepicker:itemSelected', [newValue, this.prevValue, this]);
+  this._triggerSetDateChangeEvent();
+}
 
-  if (newValue !== prevValue) {
-    this.elem.trigger('change');
-    this.elem.trigger('datepicker:change', [newValue, prevValue, this]);
-  }
+RomoDatepicker.prototype.onTriggerSetDate = function(e, value) {
+  this.doSetDate(value);
+  this._triggerSetDateChangeEvent();
 }
 
 RomoDatepicker.prototype.onElemKeyDown = function(e) {
@@ -296,6 +302,14 @@ RomoDatepicker.prototype.onPopupMouseDown = function(e) {
 
 RomoDatepicker.prototype.onPopupMouseUp = function(e) {
   this.popupMouseDown = false;
+}
+
+// private
+
+RomoDatepicker.prototype._triggerSetDateChangeEvent = function() {
+  if (this.elem.val() !== this.prevValue) {
+    this.elem.trigger('change');
+  }
 }
 
 RomoDatepicker.prototype._clearBlurTimeout = function() {


### PR DESCRIPTION
This adds some consistency to the events that are published on
datepickers.  Before, a 'datepicker:change' event would only fire
when a user selected an date from the popup.  If they manually typed
a new date in, the event wouldn't fire.  This reason is b/c we had
no way to provide the previous value needed for the event.

This switches to manually tracking a previous value and to always
publish a datepicker change event on every underlying elem change
event.  Prefer binding to 'datepicker:change' over 'change' and
get access to the new/prev values plus the datepicker component.
This datepicker change event will now fire in the following  date
change scenarios: date selected in popup, set date event trigger,
and manual user edit.

The only date change scenario that isn't covered is when the `doSetDate`
method is manually called.  The reason is that this is a low-level API
that is used to compose other behavior.  If you are changing the date
via this method, you are responsible for triggering a 'change' event
if needed (which will in turn trigger the datepicker change event.

@jcredding ready for review.
