### PR TITLE
datepicker: add API to show/hide datepickers

### DIFF
--- a/assets/css/romo/datepicker.scss
+++ b/assets/css/romo/datepicker.scss
@@ -6,6 +6,7 @@
 }
 
 .romo-datepicker-indicator {
+  display: inline-block;
   position: absolute;
   right: 6px;
   vertical-align: middle;

--- a/assets/js/romo/datepicker.js
+++ b/assets/js/romo/datepicker.js
@@ -63,6 +63,9 @@ RomoDatepicker.prototype.doBindElem = function() {
     if (this.elem.prop('disabled') === true) {
       this.indicatorElem.addClass('disabled');
     }
+    if (this.elem.css('display') === 'none') {
+      this._hide(this.indicatorElem);
+    }
     this.indicatorElem.on('click', $.proxy(this.onIndicatorClick, this));
     this.elem.css({'padding-right': '22px'});
     this.elem.after(this.indicatorElem);
@@ -80,6 +83,12 @@ RomoDatepicker.prototype.doBindElem = function() {
   }, this));
   this.elem.on('datepicker:triggerDisable', $.proxy(function(e) {
     this.doDisable();
+  }, this));
+  this.elem.on('datepicker:triggerShow', $.proxy(function(e) {
+    this.doShow();
+  }, this));
+  this.elem.on('datepicker:triggerHide', $.proxy(function(e) {
+    this.doHide();
   }, this));
   this.elem.on('datepicker:triggerSetFormat', $.proxy(function(e) {
     this.doSetFormat();
@@ -111,6 +120,16 @@ RomoDatepicker.prototype.doDisable = function() {
   this.elem.prop('disabled', true);
   this.elem.addClass('disabled');
   this.indicatorElem.addClass('disabled');
+}
+
+RomoDatepicker.prototype.doShow = function() {
+  this._show(this.elem);
+  this._show(this.indicatorElem);
+}
+
+RomoDatepicker.prototype.doHide = function() {
+  this._hide(this.elem);
+  this._hide(this.indicatorElem);
 }
 
 RomoDatepicker.prototype.doBindDropdown = function() {
@@ -305,6 +324,14 @@ RomoDatepicker.prototype.onPopupMouseUp = function(e) {
 }
 
 // private
+
+RomoDatepicker.prototype._show = function(elem) {
+  elem.css('display', '');
+}
+
+RomoDatepicker.prototype._hide = function(elem) {
+  elem.css('display', 'none');
+}
 
 RomoDatepicker.prototype._triggerSetDateChangeEvent = function() {
   if (this.elem.val() !== this.prevValue) {


### PR DESCRIPTION
Special handling is needed due to the elem wrapper and the indicator
elem.  This follows the pattern of the enable/disable API.

Note: I had to use `css` instead of `show`/`hide`.  Show sets
`display:block` which breaks the indicator element UI so I want to
be safe and just remove the explicit display setting.  I also added
display inline block to the indicator's formal styles since it is
needed.

@jcredding ready for review.
