### PR TITLE
selects/datepickers: better handle dynamic carets/indicators

### DIFF
--- a/assets/css/romo/select.scss
+++ b/assets/css/romo/select.scss
@@ -39,7 +39,7 @@
 }
 .romo-select-caret {
   position: absolute;
-  right: 6px;
+  right: 4px + 1px; /* 4 px for desired spacing + 1 px select styling optical illusion */
   vertical-align: middle;
 }
 

--- a/assets/js/romo/datepicker.js
+++ b/assets/js/romo/datepicker.js
@@ -11,14 +11,15 @@ var RomoDatepicker = function(element) {
     "January", "February", "March", "April", "May", "June",
     "July", "August", "September", "October", "November", "December"
   ]
-  this.defaultPrevClass      = undefined;
-  this.defaultNextClass      = undefined;
-  this.defaultIndicatorClass = undefined;
-  this.itemSelector          = 'TD.romo-datepicker-day:not(.disabled)';
-  this.calTable              = $();
-  this.date                  = undefined;
-  this.today                 = new Date;
-  this.prevValue             = undefined;
+  this.defaultPrevClass        = undefined;
+  this.defaultNextClass        = undefined;
+  this.defaultIndicatorClass   = undefined;
+  this.defaultIndicatorWidthPx = 0;
+  this.itemSelector            = 'TD.romo-datepicker-day:not(.disabled)';
+  this.calTable                = $();
+  this.date                    = undefined;
+  this.today                   = new Date;
+  this.prevValue               = undefined;
 
   this.doInit();
   this.doBindElem();
@@ -67,7 +68,13 @@ RomoDatepicker.prototype.doBindElem = function() {
       this._hide(this.indicatorElem);
     }
     this.indicatorElem.on('click', $.proxy(this.onIndicatorClick, this));
-    this.elem.css({'padding-right': '22px'});
+
+    var indicatorWidthPx   = this.elem.data('romo-datepicker-indicator-width-px') || this.defaultIndicatorWidthPx;
+    // left-side spacing
+    // + indicator width
+    // + right-side spacing
+    var indicatorPaddingPx = 4 + indicatorWidthPx + 4;
+    this.elem.css({'padding-right': indicatorPaddingPx + 'px'});
     this.elem.after(this.indicatorElem);
   }
 

--- a/assets/js/romo/select.js
+++ b/assets/js/romo/select.js
@@ -7,6 +7,9 @@ $.fn.romoSelect = function() {
 var RomoSelect = function(element) {
   this.elem = $(element);
 
+  this.defaultCaretClass   = undefined;
+  this.defaultCaretWidthPx = 0;
+
   this.doInit();
   this.doBindSelectDropdown();
   this.doRefreshUI();
@@ -144,7 +147,14 @@ RomoSelect.prototype._buildSelectDropdownElem = function() {
     var caret = $('<i class="romo-select-caret '+caretClass+'"></i>');
     caret.css({'line-height': romoSelectDropdownElem.css('line-height')});
     caret.on('click', $.proxy(this.onCaretClick, this));
-    romoSelectDropdownElem.css({'padding-right': '22px'});
+
+    var caretWidthPx   = this.elem.data('romo-select-caret-width-px') || this.defaultCaretWidthPx;
+    // left-side spacing
+    // + caret width
+    // - 1 px select styling optical illusion
+    // + right-side spacing
+    var caretPaddingPx = 4 + caretWidthPx - 1 + 4;
+    romoSelectDropdownElem.css({'padding-right': caretPaddingPx + 'px'});
     romoSelectDropdownElem.append(caret);
   }
 

--- a/assets/js/romo/select_dropdown.js
+++ b/assets/js/romo/select_dropdown.js
@@ -6,7 +6,6 @@ $.fn.romoSelectDropdown = function(optionElemsParent) {
 
 var RomoSelectDropdown = function(element, optionElemsParent) {
   this.elem = $(element);
-  this.defaultCaretClass = '';
   this.itemSelector = 'LI[data-romo-select-item="opt"]:not(.disabled)';
   this.prevValue = undefined;
 


### PR DESCRIPTION
We allow you to set custom caret/indicator style classes (which in
turn have custom widths) but we were hard-coding `22px` of padding
to make room for the caret/indicator UI.  This is incosistent and
brittle as it is too easy to "cut off" the UI b/c the custom class
specified UI that is wider than 22px.

This adds additional API to both components that allows specifying
a width in pixels in additon to the style class.  Romo now calculates
the necessary padding to show the UI based on this custom value
(accounting for padding on the left/right sides).

Note: the "1px optical illusion I reference in the select code is
due to how Romo renders selects.  The select UI has a border that
is not at the true right edge of the element - there is an additional
1px "shadow".  The shadow is the actual edge of the element.  However,
our eyes see the border as the edge of the element so we need to
account for this in the padding/positioning calculations.

Note: this also moves defaulting the select caret values to the 
select js file.  It was previously in the select dropdown file by
mistake.

@jcredding ready for review

@Criptak FYI
