### PR TITLE
get working in modern ruby versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,12 +5,12 @@ gemspec
 gem 'pry', "~> 0.9.0"
 
 gem 'rack'
-gem "deas",         "~> 0.27"
-gem "dassets",      '~> 0.11'
-gem "dassets-sass", "~> 0.3"
-gem "dassets-erb",  "~> 0.1"
-gem "kramdown",     "~> 1.4"
-gem "scmd",         "~> 2.3"
+gem "deas",         "~> 0.40.0"
+gem "dassets",      "~> 0.13.2"
+gem "dassets-sass", "~> 0.3.0"
+gem "dassets-erb",  "~> 0.1.0"
+gem "scmd",         "~> 3.0.2"
+gem "kramdown",     "~> 1.10"
 
 # lock in sass to 3.4.21 as 3.5+ will no longer support ruby 1.8.7
 # also 3.4.22 adds a huge deprecation warning that we don't care about

--- a/romo.gemspec
+++ b/romo.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_development_dependency("assert", ["~> 2.15.0"])
+  gem.add_development_dependency("assert", ["~> 2.16.1"])
 
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -6,3 +6,14 @@ $LOAD_PATH.unshift(File.expand_path("../..", __FILE__))
 
 # require pry for debugging (`binding.pry`)
 require 'pry'
+
+require 'test/support/factory'
+
+# 1.8.7 backfills
+
+# Array#sample
+if !(a = Array.new).respond_to?(:sample) && a.respond_to?(:choice)
+  class Array
+    alias_method :sample, :choice
+  end
+end

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -1,0 +1,6 @@
+require 'assert/factory'
+
+module Factory
+  extend Assert::Factory
+
+end


### PR DESCRIPTION
This updates the gem dependencies to bring in the latest versions
(which also now work in modern ruby versions) and updates the test
suite to get up to convention for working in modern ruby versions.
This includes backfilling Array#sample so it works in 1.8.7.

Note: I also added a test support factory and switched to "vanity
versioning" in the Gemfile.  Both of these changes just get the
code up to our latest conventions.

@jcredding ready for review.
