### PR TITLE
datepicker: honor timezone when determining today's date

### DIFF
--- a/assets/js/romo/datepicker.js
+++ b/assets/js/romo/datepicker.js
@@ -18,7 +18,7 @@ var RomoDatepicker = function(element) {
   this.itemSelector            = 'TD.romo-datepicker-day:not(.disabled)';
   this.calTable                = $();
   this.date                    = undefined;
-  this.today                   = new Date;
+  this.today                   = this._getTodaysDate();
   this.prevValue               = undefined;
 
   this.doInit();
@@ -593,6 +593,15 @@ RomoDatepicker.prototype._regexMatches = function(value, regex) {
 
 RomoDatepicker.prototype._currentYear = function() {
   return (new Date).getUTCFullYear();
+}
+
+RomoDatepicker.prototype._getTodaysDate = function() {
+  var today = new Date();
+  var dd    = today.getDate();
+  var mm    = today.getMonth();
+  var yyyy  = today.getFullYear();
+
+  return this._UTCDate(yyyy, mm, dd);
 }
 
 RomoDatepicker.prototype._UTCDate = function(year, month, day) {


### PR DESCRIPTION
This updates how today's date is calculated to properly honor
time zones.  Datepicker uses UTC dates for comparisons.  Before
we were assuming `new Date()` was a UTC date for today when in
fact it was a time zoned date.  This uses the timezoned date info
to build a UTC date for the date as perceived in the current time
zone.  Then this new UTC date is used for the "today" comparisons.

![romo-datepicker-today-fix](https://cloud.githubusercontent.com/assets/82110/19692528/e3f6c79c-9a9d-11e6-9c07-12bd52d400c2.jpg)

@jcredding ready for review.  I noticed this while using the datepicker late at night.  Noticed the screenshot with the simulated late time but the correct "today" date.
