### PR TITLE
select: allow "empty" options to be properly selected

### DIFF
--- a/assets/js/romo/select_dropdown.js
+++ b/assets/js/romo/select_dropdown.js
@@ -5,13 +5,13 @@ $.fn.romoSelectDropdown = function(optionElemsParent) {
 }
 
 var RomoSelectDropdown = function(element, optionElemsParent) {
-  this.elem = $(element);
+  this.elem         = $(element);
   this.itemSelector = 'LI[data-romo-select-item="opt"]:not(.disabled)';
-  this.prevValue = undefined;
+  this.prevValue    = '';
 
-  var optsParent = (optionElemsParent || this.elem.find('.romo-select-dropdown-options-parent'));
+  var optsParent   = (optionElemsParent || this.elem.find('.romo-select-dropdown-options-parent'));
   this.optionElems = optsParent.children();
-  this.optionList = this._buildOptionList(this.optionElems);
+  this.optionList  = this._buildOptionList(this.optionElems);
 
   this.doInit();
   this.doBindDropdown();
@@ -88,7 +88,7 @@ RomoSelectDropdown.prototype.doBindDropdown = function() {
 
 RomoSelectDropdown.prototype.doSelectHighlightedItem = function() {
   var prevValue = this.prevValue;
-  var newValue = this.romoDropdown.bodyElem.find('LI.romo-select-highlight').data('romo-select-option-value');
+  var newValue  = this.romoDropdown.bodyElem.find('LI.romo-select-highlight').data('romo-select-option-value');
 
   this.romoDropdown.doPopupClose();
   this.elem.trigger('selectDropdown:itemSelected', [newValue, prevValue, this]);
@@ -232,13 +232,15 @@ RomoSelectDropdown.prototype._buildOptionList = function(optionElems, listClass)
 }
 
 RomoSelectDropdown.prototype._buildOptionListItem = function(optionElem) {
-  var opt = $(optionElem);
-  var item = $('<li data-romo-select-item="opt"></li>');
+  var opt   = $(optionElem);
+  var item  = $('<li data-romo-select-item="opt"></li>');
+  var value = opt.attr('value') || '';
 
-  item.attr('data-romo-select-option-value', opt.attr('value'));
+  item.attr('data-romo-select-option-value', value);
   item.html(opt.text().trim() || '&nbsp;');
   if (opt.prop('selected')) {
     item.addClass('selected');
+    this.prevValue = value; // the last option marked selected is used
   }
   if (opt.attr('disabled') !== undefined) {
     item.addClass('disabled');


### PR DESCRIPTION
This solves a weird edge-case issue with the selects.  If you
had an option with a value marked as selected, you couldn't
select an "empty" option (one that has no value).  You'd have to
first select a different option that had a value and then select
the empty option.

The problem was all do to the component not properly setting up
state on initialize.  First, if the options had no value, their
value would be seen as `undefined`.  Second, the `this.prevValue`
component state was always `undefined`.  This caused selecting
the empty value first to be seen as a "no change" operation b/c
the prev value `undefined` was equal to the selected value's
`undefined`.

This updates to properly set the prev value to the last option
marked as selected (and also defaults it to `''` if no options
are selected.  This removes the `undefined` handling for the prev
value.  This also changes to using `''` for the value of options
that have no value.  This is a better default and also removes
`undefined` from option value handling.

Finally, this does some minor style cleanups to get the code
up to our latest conventions.

@jcredding ready for review.
