### PR TITLE
tooltip: have tooltips intelligently choose top vs bottom pos

### DIFF
--- a/assets/css/romo/tooltip.scss
+++ b/assets/css/romo/tooltip.scss
@@ -30,28 +30,28 @@
   border-style: solid;
 }
 
-.romo-tooltip-popup[data-romo-tooltip-position="top"] .romo-tooltip-arrow {
+.romo-tooltip-popup[data-romo-tooltip-arrow-position="top"] .romo-tooltip-arrow {
   border-width: 6px 6px 0;
   bottom: -6px;
   left: 50%;
   margin-left: -6px;
 }
 
-.romo-tooltip-popup[data-romo-tooltip-position="right"] .romo-tooltip-arrow {
+.romo-tooltip-popup[data-romo-tooltip-arrow-position="right"] .romo-tooltip-arrow {
   border-width: 6px 6px 6px 0;
   left: -6px;
   top: 50%;
   margin-top: -6px;
 }
 
-.romo-tooltip-popup[data-romo-tooltip-position="bottom"] .romo-tooltip-arrow {
+.romo-tooltip-popup[data-romo-tooltip-arrow-position="bottom"] .romo-tooltip-arrow {
   border-width: 0 6px 6px;
   top: -6px;
   left: 50%;
   margin-left: -6px;
 }
 
-.romo-tooltip-popup[data-romo-tooltip-position="left"] .romo-tooltip-arrow {
+.romo-tooltip-popup[data-romo-tooltip-arrow-position="left"] .romo-tooltip-arrow {
   border-width: 6px 0 6px 6px;
   right: -6px;
   top: 50%;
@@ -75,15 +75,15 @@
   color: $tooltipColor;
 }
 
-.romo-tooltip-popup[data-romo-tooltip-position="top"] .romo-tooltip-arrow {
+.romo-tooltip-popup[data-romo-tooltip-arrow-position="top"] .romo-tooltip-arrow {
   border-top-color: $tooltipBgColor;
 }
-.romo-tooltip-popup[data-romo-tooltip-position="right"] .romo-tooltip-arrow {
+.romo-tooltip-popup[data-romo-tooltip-arrow-position="right"] .romo-tooltip-arrow {
   border-right-color: $tooltipBgColor;
 }
-.romo-tooltip-popup[data-romo-tooltip-position="bottom"] .romo-tooltip-arrow {
+.romo-tooltip-popup[data-romo-tooltip-arrow-position="bottom"] .romo-tooltip-arrow {
   border-bottom-color: $tooltipBgColor;
 }
-.romo-tooltip-popup[data-romo-tooltip-position="left"] .romo-tooltip-arrow {
+.romo-tooltip-popup[data-romo-tooltip-arrow-position="left"] .romo-tooltip-arrow {
   border-left-color: $tooltipBgColor;
 }


### PR DESCRIPTION
This is similar behavior to the dropdowns.  If a tooltip is set
to position top or bottom, it will first check to make sure there
is enough room to position itself that way.  If not, it will
switch to the opposite pos as it is assumed there will be enough
room that way.

The only wrinkle that is different from dropdowns is the tooltip
arrow UI.  I had to unbind the CSS for positioning the arrow from
the element configured position setting.  It now needs to be based
on a specific arrow position setting we set on the popup once we
determine the live position of the popup.

This only applies to top/bottom positioning.  We chose not to
implement auto left/right positioning as it comes up so less
frequently and can be designed around in almost all cases.  We
may choose to add it later as specific needs arise.  This all is
true for dropdowns.

@jcredding ready for review.
