### PR TITLE
add a `toArray` helper global function

### DIFF
--- a/assets/js/romo/base.js
+++ b/assets/js/romo/base.js
@@ -156,9 +156,7 @@
     }
 
     // for the case where z-index is inherited from a parent elem
-    var parentIndexes = $.map(elem.parents(), function(item) {
-      return item; // converts the collection to an array
-    }).reduce($.proxy(function(prev, curr) {
+    var parentIndexes = this.toArray(elem.parents()).reduce($.proxy(function(prev, curr) {
       var pval = this.parseElemZIndex($(curr));
       if (pval !== 0) {
         prev.push(pval);
@@ -175,6 +173,13 @@
       return val;
     }
     return 0;
+  }
+
+  // elem handling
+
+  Romo.prototype.toArray = function(elems) {
+    // converts a collection of elements (`$()`) to an array of nodes
+    return $.map(elems, function(node){ return node; })
   }
 
   // private

--- a/assets/js/romo/form.js
+++ b/assets/js/romo/form.js
@@ -209,9 +209,7 @@ RomoForm.prototype._getSerializeObj = function() {
 }
 
 RomoForm.prototype._getListValueInputNamesDelims = function() {
-  return $.map(this.elem.find('[data-romo-form-list-values="true"]'), function(item){
-    return item; // converts the collection to an array
-  }).reduce($.proxy(function(prev, curr) {
+  return Romo.toArray(this.elem.find('[data-romo-form-list-values="true"]')).reduce($.proxy(function(prev, curr) {
     prev[$(curr).attr('name')] = $(curr).data('romo-form-list-values-delim') || this.defaultListValuesDelim;
     return prev;
   }, this), {});


### PR DESCRIPTION
This commonizes a couple places where we've manually converted a
jQuery-style element collection to a vanilla js array of nodes.
I chose to implement this function in pure js instead of relying
on the jQuery-specific `toArray` method on collections.  I am
trying to move to using vanilla js whenever possible as we are
targeting modern browsers and they are getting pretty good these
days.

This will also be needed in a coming effort to implement a method
to do word-boundary filtering on collections of elements.

@jcredding ready for review.
