### PR TITLE
add `RomoWordBoundaryFilter` class

### DIFF
--- a/assets/js/romo/word_boundary_filter.js
+++ b/assets/js/romo/word_boundary_filter.js
@@ -1,0 +1,44 @@
+var RomoWordBoundaryFilter = function(filterString, setElems, getElemTextContentCallback) {
+  this.boundaryCharsRegex = /[\s-_]+/;
+  this.matchingNodes      = [];
+  this.notMatchingNodes   = [];
+  this.filters            = filterString
+                              .trim()
+                              .toLowerCase()
+                              .split(this.boundaryCharsRegex);
+
+  Romo.toArray(setElems).forEach($.proxy(function(node) {
+    var contentStack = getElemTextContentCallback($(node))
+                         .trim()
+                         .toLowerCase()
+                         .split(this.boundaryCharsRegex).reverse();
+
+    var match = this.filters.reduce($.proxy(function(filterMatch, filter) {
+      if (filterMatch === false) {
+        // short-circuit the reduce
+        return false;
+      } else {
+        var contentMatch = false;
+        do {
+          var content = contentStack.pop();
+          if (content !== undefined && content.indexOf(filter) === 0) {
+            contentMatch = true;
+            // we found a match for this filter so we need to
+            // break out of this do...while and go to next filter
+            content = undefined;
+          }
+        } while(content !== undefined);
+        return contentMatch;
+      }
+    }, this), true);
+
+    if (match === true) {
+      this.matchingNodes.push(node);
+    } else {
+      this.notMatchingNodes.push(node);
+    }
+  }, this));
+
+  this.matchingElems    = $(this.matchingNodes);
+  this.notMatchingElems = $(this.notMatchingNodes);
+}

--- a/lib/romo/dassets.rb
+++ b/lib/romo/dassets.rb
@@ -43,6 +43,7 @@ module Romo::Dassets
       ]
       c.combination "js/romo.js", [
         'js/romo/base.js',
+        'js/romo/word_boundary_filter.js',
         'js/romo/invoke.js',
         'js/romo/onkey.js',
         'js/romo/form.js',

--- a/test/unit/dassets_tests.rb
+++ b/test/unit/dassets_tests.rb
@@ -45,6 +45,7 @@ module Romo::Dassets
 
       exp_js_sources = [
         'js/romo/base.js',
+        'js/romo/word_boundary_filter.js',
         'js/romo/invoke.js',
         'js/romo/onkey.js',
         'js/romo/form.js',


### PR DESCRIPTION
This class filters the given `setElems` by a given `filterString`.
The filter groups the set elems into two groups: ones that match
the filter string vs ones that do not match filter string.

The filter matches based on matching "word boundaries", meaning
each word in the filter string needs to match the beginning of a
word in the elem's text content the words must match in the same
order as the filter string.  The word boundaries are anything
that matches `/[\s-_]+/` for now.  This means hyphenated words
and underscored words are treated like space-separated words
which provides more flexibility to the filter without
compromising its "word boundary" nature.

This will be used in a future effort to provide selects with an
input to filter the select options as you type.

@jcredding ready for review.