### PR TITLE
add `data-romo-form-disable-enter-submit` option to forms/inputs

### DIFF
--- a/assets/js/romo/form.js
+++ b/assets/js/romo/form.js
@@ -66,11 +66,13 @@ RomoForm.prototype.doBindForm = function() {
 
 RomoForm.prototype.onFormKeyPress = function(e) {
   if (this.elem.data('romo-form-disable-keypress') !== true) {
-    var target = $(e.target);
-
-    if (target.is(':not(TEXTAREA)') && e.keyCode === 13 /* Enter */) {
+    var targetElem = $(e.target);
+    if (targetElem.is(':not(TEXTAREA)') && e.keyCode === 13 /* Enter */) {
       e.preventDefault();
-      this.onSubmitClick();
+      if (this.elem.data('romo-form-disable-enter-submit') !== true &&
+          targetElem.data('romo-form-disable-enter-submit') !== true) {
+        this.onSubmitClick();
+      }
     }
   }
 }


### PR DESCRIPTION
This allows users to turn off the default "hit enter to submit the
form" behavior both form-wide and on a per-input basis.  This
came up in an app we have where there is a form with an input but
the input is used to just filter the checkboxes shown and should
not be used to submit the form.

@jcredding ready for review.