### PR TITLE
place indicator text input indicator on demand

### DIFF
--- a/assets/css/romo/indicator_text_input.scss
+++ b/assets/css/romo/indicator_text_input.scss
@@ -8,6 +8,7 @@
 .romo-indicator-text-input-indicator {
   display: inline-block;
   position: absolute;
+  top: 0px;
   right: 6px;
   vertical-align: middle;
   cursor: pointer;

--- a/assets/js/romo/indicator_text_input.js
+++ b/assets/js/romo/indicator_text_input.js
@@ -44,22 +44,13 @@ RomoIndicatorTextInput.prototype.doBindElem = function() {
   var indicatorClass = this.elem.data('romo-indicator-text-input-indicator') || this.defaultIndicatorClass;
   if (indicatorClass !== undefined && indicatorClass !== 'none') {
     this.indicatorElem = $('<i class="romo-indicator-text-input-indicator '+indicatorClass+'"></i>');
-    this.indicatorElem.css({'line-height': this.elem.css('height')});
-    if (this.elem.prop('disabled') === true) {
-      this.indicatorElem.addClass('disabled');
-    }
-    if (this.elem.css('display') === 'none') {
-      this._hide(this.indicatorElem);
-    }
-    this.indicatorElem.on('click', $.proxy(this.onIndicatorClick, this));
-
-    var indicatorWidthPx = this.elem.data('romo-indicator-text-input-indicator-width-px') || this.defaultIndicatorWidthPx;
-    // left-side spacing
-    // + indicator width
-    // + right-side spacing
-    var indicatorPaddingPx = 4 + indicatorWidthPx + 4;
-    this.elem.css({'padding-right': indicatorPaddingPx + 'px'});
     this.elem.after(this.indicatorElem);
+    this.indicatorElem.on('click', $.proxy(this.onIndicatorClick, this));
+    this.doPlaceIndicatorElem();
+
+    this.elem.on('indicatorTextInput:triggerPlaceIndicator', $.proxy(function(e) {
+      this.doPlaceIndicatorElem();
+    }, this));
   }
 
   this.elem.on('indicatorTextInput:triggerEnable', $.proxy(function(e) {
@@ -74,6 +65,25 @@ RomoIndicatorTextInput.prototype.doBindElem = function() {
   this.elem.on('indicatorTextInput:triggerHide', $.proxy(function(e) {
     this.doHide();
   }, this));
+}
+
+RomoIndicatorTextInput.prototype.doPlaceIndicatorElem = function() {
+  if (this.indicatorElem !== undefined) {
+    this.indicatorElem.css({'line-height': this.elem.css('height')});
+    if (this.elem.prop('disabled') === true) {
+      this.indicatorElem.addClass('disabled');
+    }
+    if (this.elem.css('display') === 'none') {
+      this._hide(this.indicatorElem);
+    }
+
+    var indicatorWidthPx = this.elem.data('romo-indicator-text-input-indicator-width-px') || this.defaultIndicatorWidthPx;
+    // left-side spacing
+    // + indicator width
+    // + right-side spacing
+    var indicatorPaddingPx = 4 + indicatorWidthPx + 4;
+    this.elem.css({'padding-right': indicatorPaddingPx + 'px'});
+  }
 }
 
 RomoIndicatorTextInput.prototype.doEnable = function() {
@@ -91,6 +101,7 @@ RomoIndicatorTextInput.prototype.doDisable = function() {
 RomoIndicatorTextInput.prototype.doShow = function() {
   this._show(this.elem);
   this._show(this.indicatorElem);
+  this.doPlaceIndicatorElem();
 }
 
 RomoIndicatorTextInput.prototype.doHide = function() {


### PR DESCRIPTION
This adds a method and event trigger to re-place the indicator
for indicator text inputs on demand.  This allows you to re-run
the logic that calculates where to place the indicator UI as
needed (typically do to resizing the input after the logic
initially runs.

Specifically, this is needed for a future effort where we add
filter indicator text inputs to select dropdowns.

@jcredding ready for review.