### PR TITLE
refine dropdown placement logic

### DIFF
--- a/assets/js/romo/dropdown.js
+++ b/assets/js/romo/dropdown.js
@@ -333,7 +333,6 @@ RomoDropdown.prototype.onResizeWindow = function(e) {
 RomoDropdown.prototype.doPlacePopupElem = function() {
   if (this.elem.parents('.romo-modal-popup').size() !== 0) {
     this.popupElem.css({'position': 'fixed'});
-    this.popupElem.offset(this.elem.offset());
   }
 
   var pos = $.extend({}, this.elem[0].getBoundingClientRect(), this.elem.offset());
@@ -360,6 +359,9 @@ RomoDropdown.prototype.doPlacePopupElem = function() {
       configHeight = bottomAvailHeight;
     }
 
+    // remove any height difference between the popup and content elems
+    // assumes popup height always greater than or equal to content height
+    configHeight = configHeight - (h - this.contentElem[0].offsetHeight);
     this.contentElem.css({'max-height': configHeight.toString() + 'px'});
   }
 
@@ -386,6 +388,10 @@ RomoDropdown.prototype.doPlacePopupElem = function() {
       break;
   }
 
+  $.extend(offset, {
+    top:  this._roundPosOffsetVal(offset['top']),
+    left: this._roundPosOffsetVal(offset['left'])
+  });
   this.popupElem.offset(offset);
 }
 
@@ -418,6 +424,10 @@ RomoDropdown.prototype._getPopupMaxAvailableHeight = function(position) {
 
 RomoDropdown.prototype._getPopupMaxHeightDetectPad = function(position) {
   return this.elem.data('romo-dropdown-max-height-detect-pad-'+position) || this.elem.data('romo-dropdown-max-height-detect-pad') || 10;
+}
+
+RomoDropdown.prototype._roundPosOffsetVal = function(value) {
+  return Math.round(value*100) / 100;
 }
 
 Romo.onInitUI(function(e) {


### PR DESCRIPTION
This switches to rounding the top/left pixel values to the nearest
100th place value.  This prevents "jitter" as you call to place
the popup as repeated calls with overly precise values will not
necessarily calculate the same overly precise value on subsequent
calcs.  This occured when I had the new select option filters call
to place the dropdown popup each time the options were filtered.
In some cases the popup would "jitter" and slightly update its
position as I was pressing keys to filter the results.  Using
less precise values sacrifices nothing on position accuracy while
making the placement values deterministic.

This also updates the placement calcs to account for the popup
and content elems not being the same height.  This is also prep
for adding in option filter UI to the select dropdowns.  This UI
will be adding to the popup but not in the content area.  The
content gets max-height added so that overflow content can be
scrolled.  This filter UI should never be overflowed and should
always be visible.  This updates the calcs to account for any
elem height differences and builds that into the overflow height
handling logic.

@jcredding ready for review.