### PR TITLE
make select options filterable

### DIFF
--- a/assets/css/romo/_vars.scss
+++ b/assets/css/romo/_vars.scss
@@ -27,6 +27,8 @@ $spacingSize0: $spacingSize1 * 0.35;
 $spacingSize2: $spacingSize1 * 2;
 
 $inputHeight: ($baseLineHeight / 2) * 3; /* 30px */
+$inputFilterHeight: $baseLineHeight;     /* 20px */
+
 $inputSize1: 220px;
 $inputSize0: $inputSize1 - 120px;
 $inputSize2: $inputSize1 + 120px;

--- a/assets/css/romo/forms.scss
+++ b/assets/css/romo/forms.scss
@@ -26,7 +26,8 @@ label { display: block; }
 
 .romo-form input,
 .romo-form select,
-.romo-form textarea {
+.romo-form textarea,
+input.romo-select-dropdown-option-filter {
   font-size: 100%;
   @include rm-push;
   @include align-middle;
@@ -42,8 +43,15 @@ label { display: block; }
   }
 }
 
-.romo-form input    { *overflow: visible; line-height: normal; }
-.romo-form textarea {  overflow: auto; @include align-top; }
+.romo-form input,
+input.romo-select-dropdown-option-filter {
+  *overflow: visible;
+  line-height: normal;
+}
+
+.romo-form textarea {
+  overflow: auto; @include align-top;
+}
 
 .romo-form label,
 .romo-form select,
@@ -58,7 +66,9 @@ label { display: block; }
 .romo-form textarea[disabled],
 .romo-form input[readonly],
 .romo-form select[readonly],
-.romo-form textarea[readonly] { cursor: $notAllowedCursor; }
+.romo-form textarea[readonly],
+input.romo-select-dropdown-option-filter[disabled],
+input.romo-select-dropdown-option-filter[readonly] { cursor: $notAllowedCursor; }
 
 .romo-form select {
   font-weight: normal;
@@ -82,7 +92,8 @@ label { display: block; }
 .romo-form input[type="url"],
 .romo-form input[type="search"],
 .romo-form input[type="tel"],
-.romo-form input[type="color"] {
+.romo-form input[type="color"],
+input.romo-select-dropdown-option-filter {
   font-weight: normal;
   background-color: $inputBgColor;
   @include border1;
@@ -104,7 +115,8 @@ label { display: block; }
 .romo-form input[type="url"]:focus,
 .romo-form input[type="search"]:focus,
 .romo-form input[type="tel"]:focus,
-.romo-form input[type="color"]:focus {
+.romo-form input[type="color"]:focus,
+input.romo-select-dropdown-option-filter:focus {
   @include input-focus;
 }
 
@@ -113,7 +125,9 @@ label { display: block; }
 .romo-form textarea[disabled],
 .romo-form input[readonly],
 .romo-form select[readonly],
-.romo-form textarea[readonly] { background-color: $inputDisabledColor; }
+.romo-form textarea[readonly],
+input.romo-select-dropdown-option-filter[disabled],
+input.romo-select-dropdown-option-filter[readonly] { background-color: $inputDisabledColor; }
 
 .romo-form input[type="radio"][disabled],
 .romo-form input[type="checkbox"][disabled],
@@ -134,10 +148,15 @@ label { display: block; }
 .romo-form input[type="url"],
 .romo-form input[type="search"],
 .romo-form input[type="tel"],
-.romo-form input[type="color"] {
+.romo-form input[type="color"],
+input.romo-select-dropdown-option-filter {
   height: $inputHeight;
   line-height: $baseLineHeight;
   @include align-middle;
+}
+
+input.romo-select-dropdown-option-filter {
+  height: $inputFilterHeight;
 }
 
 .romo-form textarea,
@@ -154,10 +173,16 @@ label { display: block; }
 .romo-form input[type="url"],
 .romo-form input[type="search"],
 .romo-form input[type="tel"],
-.romo-form input[type="color"] {
+.romo-form input[type="color"],
+input.romo-select-dropdown-option-filter {
   display: inline-block;
   padding: 4px 6px;
   color: $inputColor;
+}
+
+input.romo-select-dropdown-option-filter {
+  display: block;
+  width: 100%;
 }
 
 .romo-form textarea,

--- a/assets/css/romo/select.scss
+++ b/assets/css/romo/select.scss
@@ -22,7 +22,8 @@
   padding-right: 6px;
 }
 
-.romo-select:focus{ @include input-focus; }
+.romo-select:focus,
+.romo-select.romo-select-focus { @include input-focus; }
 
 .romo-select:active,
 .romo-select.active {
@@ -41,6 +42,12 @@
   position: absolute;
   right: 4px + 1px; /* 4 px for desired spacing + 1 px select styling optical illusion */
   vertical-align: middle;
+}
+
+.romo-select-dropdown-option-filter-wrapper {
+  @include border1-bottom();
+  padding: 4px 0;
+  margin: 0 4px;
 }
 
 .romo-select-option-list {

--- a/assets/js/romo/base.js
+++ b/assets/js/romo/base.js
@@ -212,6 +212,49 @@
     return el;
   }
 
+  // input handling
+
+  Romo.prototype.nonInputTextKeyCodes = function() {
+    // https://css-tricks.com/snippets/javascript/javascript-keycodes/
+    return [
+      9,   /* tab */
+      13,  /* enter */
+      16,  /* shift */
+      17,  /* ctrl */
+      18,  /* alt */
+      19,  /* pausebreak */
+      20,  /* capslock */
+      27,  /* escape */
+      33,  /* pageup */
+      34,  /* pagedown */
+      35,  /* end */
+      36,  /* home */
+      37,  /* leftarrow */
+      38,  /* uparrow */
+      39,  /* rightarrow */
+      40,  /* downarrow */
+      45,  /* insert */
+      46,  /* delete */
+      91,  /* leftwindowkey */
+      92,  /* rightwindowkey */
+      93,  /* selectkey */
+      112, /* f1 */
+      113, /* f2 */
+      114, /* f3 */
+      115, /* f4 */
+      116, /* f5 */
+      117, /* f6 */
+      118, /* f7 */
+      119, /* f8 */
+      120, /* f9 */
+      121, /* f10 */
+      122, /* f11 */
+      123, /* f12 */
+      144, /* numlock */
+      145, /* scrolllock */
+    ];
+  }
+
   // private
 
   Romo.prototype._addEventCallback = function(name, callback) {

--- a/assets/js/romo/dropdown.js
+++ b/assets/js/romo/dropdown.js
@@ -278,6 +278,7 @@ RomoDropdown.prototype.onElemKeyUp = function(e) {
     if (this.popupElem.hasClass('romo-dropdown-open')) {
       if(e.keyCode === 27 /* Esc */ ) {
         this.doPopupClose();
+        this.elem.trigger('dropdown:popupClosedByEsc', [this]);
         return false;
       } else {
         return true;
@@ -321,6 +322,7 @@ RomoDropdown.prototype.doUnBindWindowBodyKeyUp = function() {
 RomoDropdown.prototype.onWindowBodyKeyUp = function(e) {
   if (e.keyCode === 27 /* Esc */) {
     this.doPopupClose();
+    this.elem.trigger('dropdown:popupClosedByEsc', [this]);
   }
   return true;
 }

--- a/assets/js/romo/select.js
+++ b/assets/js/romo/select.js
@@ -110,6 +110,15 @@ RomoSelect.prototype._buildSelectDropdownElem = function() {
   if (romoSelectDropdownElem.data('romo-dropdown-max-height') === undefined) {
     romoSelectDropdownElem.attr('data-romo-dropdown-max-height', 'detect');
   }
+  if (this.elem.data('romo-select-filter-placeholder') !== undefined) {
+    romoSelectDropdownElem.attr('data-romo-select-dropdown-filter-placeholder', this.elem.data('romo-select-filter-placeholder'));
+  }
+  if (this.elem.data('romo-select-filter-indicator') !== undefined) {
+    romoSelectDropdownElem.attr('data-romo-select-dropdown-filter-indicator', this.elem.data('romo-select-filter-indicator'));
+  }
+  if (this.elem.data('romo-select-no-filter') !== undefined) {
+    romoSelectDropdownElem.attr('data-romo-select-dropdown-no-filter', this.elem.data('romo-select-no-filter'));
+  }
 
   var classList = this.elem.attr('class') !== undefined ? this.elem.attr('class').split(/\s+/) : [];
   $.each(classList, function(idx, classItem) {
@@ -148,7 +157,7 @@ RomoSelect.prototype._buildSelectDropdownElem = function() {
     caret.css({'line-height': romoSelectDropdownElem.css('line-height')});
     caret.on('click', $.proxy(this.onCaretClick, this));
 
-    var caretWidthPx   = this.elem.data('romo-select-caret-width-px') || this.defaultCaretWidthPx;
+    var caretWidthPx = this.elem.data('romo-select-caret-width-px') || this.defaultCaretWidthPx;
     // left-side spacing
     // + caret width
     // - 1 px select styling optical illusion


### PR DESCRIPTION
This adds a RomoIndicatorTextInput for filtering select options
in the select dropdown.  This allows you to type on selects when
focused and get presented with a filtered set of options matching
what you typed.  You can then cycle the filtered set and select
one as you would on the full set.

This is intended to be an enhancement on standard select handling
when you type in them.  By default, selects allow you to type
on them and select the first elem that matches what you type.
There are a few disadvantages though:

* you don't see what you've typed
* you have to type in the option value exactly
* it only highlights the first option matching what you typed -
  you don't have any idea of how many other things match as well
* to reset you have to wait an unknown amount of time and know to
  start over fresh from the beginning

The improves on that default behavior in a few ways.  First, you
have a separate text input embedded in the select's dropdown so
you see what you've typed and can intuitively change that or
clear it on demand.  Second, it filters the options removing any
that don't match what you've typed.  This allows you to see all
matching options and cycle over them like you would the full set.
Third, the filter uses the RomoWordBoundaryFilter to filter the
options.  This allows more friendly filtering as you don't have
to type the full option names and instead just quickly type the
beginnings of option value words.

One big concern here is how to handle the filter input especially
for selects in forms.  This adds extra css and js logic to make
the select still *seem* focused while the filter input is focused
and css to emulate the text input styles for the option filter.
The option filter also has no `name` attr so it won't be submitted
in forms.  There is logic to properly re-focsus the select when the
dropdown is closed and/or an option is selected, including a new
dropdown event fired when the Esc key is pressed specifically
so we know to re-focuse the select.

This adds a utility function to Romo defining what keycodes are
not input text.  This is used to determine if key input on the
selects should trigger opening the dropdown and filling in the
filter or not.  We want to auto filter when typing on selects but
not for control chars like tab, etc.

The filter is added to the popup outside of the popup content.
This is so the filter is always shown even if the content
overflows the popup available height.

Finally there is a settings API, both for Selects and
SelectDropdowns that allows you to customize the filter
placeholder text, the filter indicator, and to not use a filter.

![gif](https://cloud.githubusercontent.com/assets/82110/20072162/f38717da-a4ec-11e6-89fd-f44b8577546e.gif)

![gif1](https://cloud.githubusercontent.com/assets/82110/20072202/19277ec6-a4ed-11e6-82fe-731814c6b124.gif)

@jcredding ready for review.