### PR TITLE
have RomoDatepicker compose RomoIndicatorTextInput

### DIFF
--- a/assets/js/romo/indicator_text_input.js
+++ b/assets/js/romo/indicator_text_input.js
@@ -38,8 +38,6 @@ RomoIndicatorTextInput.prototype.doBindElem = function() {
     Romo.parentChildElems.add(this.elem, [elemWrapper]);
   }, this), 1);
 
-  this.elem.attr('autocomplete', 'off');
-
   this.indicatorElem = $();
   var indicatorClass = this.elem.data('romo-indicator-text-input-indicator') || this.defaultIndicatorClass;
   if (indicatorClass !== undefined && indicatorClass !== 'none') {
@@ -116,6 +114,7 @@ RomoIndicatorTextInput.prototype.onIndicatorClick = function(e) {
   }
   if (this.elem.prop('disabled') === false) {
     this.elem.focus();
+    this.elem.trigger('indicatorTextInput:indicatorClick');
   }
 }
 

--- a/assets/js/romo/select.js
+++ b/assets/js/romo/select.js
@@ -116,6 +116,9 @@ RomoSelect.prototype._buildSelectDropdownElem = function() {
   if (this.elem.data('romo-select-filter-indicator') !== undefined) {
     romoSelectDropdownElem.attr('data-romo-select-dropdown-filter-indicator', this.elem.data('romo-select-filter-indicator'));
   }
+  if (this.elem.data('romo-select-filter-indicator-width-px') !== undefined) {
+    romoSelectDropdownElem.attr('data-romo-select-dropdown-filter-indicator-width-px', this.elem.data('romo-select-filter-indicator-width-px'));
+  }
   if (this.elem.data('romo-select-no-filter') !== undefined) {
     romoSelectDropdownElem.attr('data-romo-select-dropdown-no-filter', this.elem.data('romo-select-no-filter'));
   }

--- a/assets/js/romo/select_dropdown.js
+++ b/assets/js/romo/select_dropdown.js
@@ -388,8 +388,13 @@ RomoSelectDropdown.prototype._buildOptionFilter = function() {
   if (this.elem.data('romo-select-dropdown-filter-indicator') !== undefined) {
     filter.attr('data-romo-indicator-text-input-indicator', this.elem.data('romo-select-dropdown-filter-indicator'));
   }
+  if (this.elem.data('romo-select-dropdown-filter-indicator-width-px') !== undefined) {
+    filter.attr('data-romo-indicator-text-input-indicator-width-px', this.elem.data('romo-select-dropdown-filter-indicator-width-px'));
+  }
   filter.attr('data-romo-form-disable-enter-submit', "true");
   filter.attr('data-romo-onkey-on', "keydown");
+
+  filter.attr('autocomplete', 'off');
 
   return filter;
 }


### PR DESCRIPTION
The RomoIndicatorTextInput was extracted from RomoDatepicker
originally and has become its own sub-component (used in the
RomoSelectDropdown filter UI for example).  This completes the
extraction from RomoDatepicker by having the date picker use the
indicator text input component. This also proxies the necessary
settings api and event api.

This also handles a few smaller tweaks:

* the indicator text input no longer turns off autocomplete. this
  should never have been done b/c it is too low level for this
  type of setting.  the select option filter and datepicker
  manually set this option b/c they need it but we don't want to
  force it on all indicator text inputs.
* the indicator text input triggers an event when the indicator
  is clicked.  the datepicker needs to bind behavior to this event.
* the select and select dropdown proxy filter indicator width px
  value.  this allows specifying how much width the indicator ui
  takes to prevent having text flow behind the indicator ui.

@jcredding ready for review.  I've tested out the new datepicker in our apps, both in standard forms and in our timesheet app that places it in a toolbar row.  Everything seems to work as before.