### PR TITLE
tweak sortable to allow `onInit` overrides to add markup settings

### DIFF
--- a/assets/js/romo/datepicker.js
+++ b/assets/js/romo/datepicker.js
@@ -6,11 +6,12 @@ $.fn.romoDatepicker = function() {
 
 var RomoDatepicker = function(element) {
   this.elem = $(element);
-  this.defaultFormat = 'yyyy-mm-dd'
   this.monthNames = [
     "January", "February", "March", "April", "May", "June",
     "July", "August", "September", "October", "November", "December"
   ]
+
+  this.defaultFormat    = 'yyyy-mm-dd'
   this.defaultPrevClass = undefined;
   this.defaultNextClass = undefined;
   this.itemSelector     = 'TD.romo-datepicker-day:not(.disabled)';

--- a/assets/js/romo/sortable.js
+++ b/assets/js/romo/sortable.js
@@ -10,15 +10,28 @@ var RomoSortable = function(element) {
   this.draggableSelector = '[data-romo-sortable-item="true"]';
   this.handleSelector = '[data-romo-sortable-handle="true"]';
 
-  this.draggableElems = this.elem.find(this.draggableSelector);
-  this.draggableElems.prop('draggable', 'true');
-
-  this.draggingClass = this.elem.data('romo-sortable-dragging-class') || '';
-  this.dragOverClass = this.elem.data('romo-sortable-dragover-class') || '';
-  this.placeholderClass = this.elem.data('romo-sortable-placeholder-class') || '';
-
   this.draggedElem = this.draggedIndex = this.draggableSelected = null;
   this.draggedOverElem = this.dragDirection = this.lastY = null;
+
+  this.doInit();
+  this.doBindDraggables();
+  this.doInitPlaceholder();
+  this._resetGrabClasses();
+
+  this.elem.trigger('sortable:ready', [this]);
+}
+
+RomoSortable.prototype.doInit = function() {
+  // override as needed
+}
+
+RomoSortable.prototype.doBindDraggables = function() {
+  this.draggingClass    = this.elem.data('romo-sortable-dragging-class') || '';
+  this.dragOverClass    = this.elem.data('romo-sortable-dragover-class') || '';
+  this.placeholderClass = this.elem.data('romo-sortable-placeholder-class') || '';
+
+  this.draggableElems = this.elem.find(this.draggableSelector);
+  this.draggableElems.prop('draggable', 'true');
 
   this.elem.on('dragenter', $.proxy(this.onDragEnter, this));
   this.elem.on('dragover',  $.proxy(this.onDragOver,  this));
@@ -36,16 +49,6 @@ var RomoSortable = function(element) {
   handleElems.on('mousedown', $.proxy(this.onHandleMouseDown, this));
 
   $('body').on('mouseup', $.proxy(this.onWindowBodyMouseUp, this));
-
-  this._resetGrabClasses();
-  this.doInit();
-  this.doInitPlaceholder();
-
-  this.elem.trigger('sortable:ready', [this]);
-}
-
-RomoSortable.prototype.doInit = function() {
-  // override as needed
 }
 
 RomoSortable.prototype.doInitPlaceholder = function() {


### PR DESCRIPTION
This reorganized the init logic to break out a "bind draggables"
method that is run post `onInit`.  This delays grabbing the
markup settings values until after any user-custom init logic so
that logic is able to set markup settings if needed.

Note: this also includes a really minor datepicker tweak to better
organize default settings.  I noticed this cleanup while doing
this effort.

@jcredding ready for review.