### PR TITLE
add raw color style classes based on Tachyons colors

### DIFF
--- a/assets/css/romo/_mixins.scss
+++ b/assets/css/romo/_mixins.scss
@@ -147,53 +147,155 @@
 
 @mixin text-disabled($i:"") { color: $disabledColor #{$i}; }
 
-@mixin text-base($i:"")       { color: $baseText #{$i}; }
-@mixin text-base-hover($i:"") { color: $baseTextHover #{$i}; }
+@mixin text-base($i:"")       {            color: $baseText #{$i}; }
+@mixin text-base-hover($i:"") {            color: $baseTextHover #{$i}; }
 @mixin bg-base($i:"")         { background-color: $baseBackground #{$i}; }
 @mixin bg-base-hover($i:"")   { background-color: $baseBackgroundHover #{$i}; }
 @mixin border-base($i:"")     {     border-color: $baseBorder #{$i}; }
 
-@mixin text-alt($i:"")       { color: $altText #{$i}; }
-@mixin text-alt-hover($i:"") { color: $altTextHover #{$i}; }
+@mixin text-alt($i:"")       {            color: $altText #{$i}; }
+@mixin text-alt-hover($i:"") {            color: $altTextHover #{$i}; }
 @mixin bg-alt($i:"")         { background-color: $altBackground #{$i}; }
 @mixin bg-alt-hover($i:"")   { background-color: $altBackgroundHover #{$i}; }
 @mixin border-alt($i:"")     {     border-color: $altBorder #{$i}; }
 
-@mixin text-muted($i:"")       { color: $mutedText #{$i}; }
-@mixin text-muted-hover($i:"") { color: $mutedTextHover #{$i}; }
+@mixin text-muted($i:"")       {            color: $mutedText #{$i}; }
+@mixin text-muted-hover($i:"") {            color: $mutedTextHover #{$i}; }
 @mixin bg-muted($i:"")         { background-color: $mutedBackground #{$i}; }
 @mixin bg-muted-hover($i:"")   { background-color: $mutedBackgroundHover #{$i}; }
 @mixin border-muted($i:"")     {     border-color: $mutedBorder #{$i}; }
 
-@mixin text-warning($i:"")       { color: $warningText #{$i}; }
-@mixin text-warning-hover($i:"") { color: $warningTextHover #{$i}; }
+@mixin text-warning($i:"")       {            color: $warningText #{$i}; }
+@mixin text-warning-hover($i:"") {            color: $warningTextHover #{$i}; }
 @mixin bg-warning($i:"")         { background-color: $warningBackground #{$i}; }
 @mixin bg-warning-hover($i:"")   { background-color: $warningBackgroundHover #{$i}; }
 @mixin border-warning($i:"")     {     border-color: $warningBorder #{$i}; }
 
-@mixin text-error($i:"")       { color: $errorText #{$i}; }
-@mixin text-error-hover($i:"") { color: $errorTextHover #{$i}; }
+@mixin text-error($i:"")       {            color: $errorText #{$i}; }
+@mixin text-error-hover($i:"") {            color: $errorTextHover #{$i}; }
 @mixin bg-error($i:"")         { background-color: $errorBackground #{$i}; }
 @mixin bg-error-hover($i:"")   { background-color: $errorBackgroundHover #{$i}; }
 @mixin border-error($i:"")     {     border-color: $errorBorder #{$i}; }
 
-@mixin text-info($i:"")       { color: $infoText #{$i}; }
-@mixin text-info-hover($i:"") { color: $infoTextHover #{$i}; }
+@mixin text-info($i:"")       {            color: $infoText #{$i}; }
+@mixin text-info-hover($i:"") {            color: $infoTextHover #{$i}; }
 @mixin bg-info($i:"")         { background-color: $infoBackground #{$i}; }
 @mixin bg-info-hover($i:"")   { background-color: $infoBackgroundHover #{$i}; }
 @mixin border-info($i:"")     {     border-color: $infoBorder #{$i}; }
 
-@mixin text-success($i:"")       { color: $successText #{$i}; }
-@mixin text-success-hover($i:"") { color: $successTextHover #{$i}; }
+@mixin text-success($i:"")       {            color: $successText #{$i}; }
+@mixin text-success-hover($i:"") {            color: $successTextHover #{$i}; }
 @mixin bg-success($i:"")         { background-color: $successBackground #{$i}; }
 @mixin bg-success-hover($i:"")   { background-color: $successBackgroundHover #{$i}; }
 @mixin border-success($i:"")     {     border-color: $successBorder #{$i}; }
 
-@mixin text-inverse($i:"")       { color: $inverseText #{$i}; }
-@mixin text-inverse-hover($i:"") { color: $inverseTextHover #{$i}; }
+@mixin text-inverse($i:"")       {            color: $inverseText #{$i}; }
+@mixin text-inverse-hover($i:"") {            color: $inverseTextHover #{$i}; }
 @mixin bg-inverse($i:"")         { background-color: $inverseBackground #{$i}; }
 @mixin bg-inverse-hover($i:"")   { background-color: $inverseBackgroundHover #{$i}; }
 @mixin border-inverse($i:"")     {     border-color: $inverseBorder #{$i}; }
+
+/* specific colors */
+
+@mixin text-dark-red($i:"")   {            color: $darkRed #{$i}; }
+@mixin bg-dark-red($i:"")     { background-color: $darkRed #{$i}; }
+@mixin border-dark-red($i:"") {     border-color: $darkRed #{$i}; }
+
+@mixin text-red($i:"")   {            color: $red #{$i}; }
+@mixin bg-red($i:"")     { background-color: $red #{$i}; }
+@mixin border-red($i:"") {     border-color: $red #{$i}; }
+
+@mixin text-light-red($i:"")   {            color: $lightRed #{$i}; }
+@mixin bg-light-red($i:"")     { background-color: $lightRed #{$i}; }
+@mixin border-light-red($i:"") {     border-color: $lightRed #{$i}; }
+
+@mixin text-orange($i:"")   {            color: $orange #{$i}; }
+@mixin bg-orange($i:"")     { background-color: $orange #{$i}; }
+@mixin border-orange($i:"") {     border-color: $orange #{$i}; }
+
+@mixin text-gold($i:"")   {            color: $gold #{$i}; }
+@mixin bg-gold($i:"")     { background-color: $gold #{$i}; }
+@mixin border-gold($i:"") {     border-color: $gold #{$i}; }
+
+@mixin text-yellow($i:"")   {            color: $yellow #{$i}; }
+@mixin bg-yellow($i:"")     { background-color: $yellow #{$i}; }
+@mixin border-yellow($i:"") {     border-color: $yellow #{$i}; }
+
+@mixin text-light-yellow($i:"")   {            color: $lightYellow #{$i}; }
+@mixin bg-light-yellow($i:"")     { background-color: $lightYellow #{$i}; }
+@mixin border-light-yellow($i:"") {     border-color: $lightYellow #{$i}; }
+
+@mixin text-purple($i:"")   {            color: $purple #{$i}; }
+@mixin bg-purple($i:"")     { background-color: $purple #{$i}; }
+@mixin border-purple($i:"") {     border-color: $purple #{$i}; }
+
+@mixin text-light-purple($i:"")   {            color: $lightPurple #{$i}; }
+@mixin bg-light-purple($i:"")     { background-color: $lightPurple #{$i}; }
+@mixin border-light-purple($i:"") {     border-color: $lightPurple #{$i}; }
+
+@mixin text-dark-pink($i:"")   {            color: $darkPink #{$i}; }
+@mixin bg-dark-pink($i:"")     { background-color: $darkPink #{$i}; }
+@mixin border-dark-pink($i:"") {     border-color: $darkPink #{$i}; }
+
+@mixin text-hot-pink($i:"")   {            color: $hotPink #{$i}; }
+@mixin bg-hot-pink($i:"")     { background-color: $hotPink #{$i}; }
+@mixin border-hot-pink($i:"") {     border-color: $hotPink #{$i}; }
+
+@mixin text-pink($i:"")   {            color: $pink #{$i}; }
+@mixin bg-pink($i:"")     { background-color: $pink #{$i}; }
+@mixin border-pink($i:"") {     border-color: $pink #{$i}; }
+
+@mixin text-light-pink($i:"")   {            color: $lightPink #{$i}; }
+@mixin bg-light-pink($i:"")     { background-color: $lightPink #{$i}; }
+@mixin border-light-pink($i:"") {     border-color: $lightPink #{$i}; }
+
+@mixin text-dark-green($i:"")   {            color: $darkGreen #{$i}; }
+@mixin bg-dark-green($i:"")     { background-color: $darkGreen #{$i}; }
+@mixin border-dark-green($i:"") {     border-color: $darkGreen #{$i}; }
+
+@mixin text-green($i:"")   {            color: $green #{$i}; }
+@mixin bg-green($i:"")     { background-color: $green #{$i}; }
+@mixin border-green($i:"") {     border-color: $green #{$i}; }
+
+@mixin text-light-green($i:"")   {            color: $lightGreen #{$i}; }
+@mixin bg-light-green($i:"")     { background-color: $lightGreen #{$i}; }
+@mixin border-light-green($i:"") {     border-color: $lightGreen #{$i}; }
+
+@mixin text-navy($i:"")   {            color: $navy #{$i}; }
+@mixin bg-navy($i:"")     { background-color: $navy #{$i}; }
+@mixin border-navy($i:"") {     border-color: $navy #{$i}; }
+
+@mixin text-dark-blue($i:"")   {            color: $darkBlue #{$i}; }
+@mixin bg-dark-blue($i:"")     { background-color: $darkBlue #{$i}; }
+@mixin border-dark-blue($i:"") {     border-color: $darkBlue #{$i}; }
+
+@mixin text-blue($i:"")   {            color: $blue #{$i}; }
+@mixin bg-blue($i:"")     { background-color: $blue #{$i}; }
+@mixin border-blue($i:"") {     border-color: $blue #{$i}; }
+
+@mixin text-light-blue($i:"")   {            color: $lightBlue #{$i}; }
+@mixin bg-light-blue($i:"")     { background-color: $lightBlue #{$i}; }
+@mixin border-light-blue($i:"") {     border-color: $lightBlue #{$i}; }
+
+@mixin text-lightest-blue($i:"")   {            color: $lightestBlue #{$i}; }
+@mixin bg-lightest-blue($i:"")     { background-color: $lightestBlue #{$i}; }
+@mixin border-lightest-blue($i:"") {     border-color: $lightestBlue #{$i}; }
+
+@mixin text-washed-blue($i:"")   {            color: $washedBlue #{$i}; }
+@mixin bg-washed-blue($i:"")     { background-color: $washedBlue #{$i}; }
+@mixin border-washed-blue($i:"") {     border-color: $washedBlue #{$i}; }
+
+@mixin text-washed-green($i:"")   {            color: $washedGreen #{$i}; }
+@mixin bg-washed-green($i:"")     { background-color: $washedGreen #{$i}; }
+@mixin border-washed-green($i:"") {     border-color: $washedGreen #{$i}; }
+
+@mixin text-washed-yellow($i:"")   {            color: $washedYellow #{$i}; }
+@mixin bg-washed-yellow($i:"")     { background-color: $washedYellow #{$i}; }
+@mixin border-washed-yellow($i:"") {     border-color: $washedYellow #{$i}; }
+
+@mixin text-washed-red($i:"")   {            color: $washedRed #{$i}; }
+@mixin bg-washed-red($i:"")     { background-color: $washedRed #{$i}; }
+@mixin border-washed-red($i:"") {     border-color: $washedRed #{$i}; }
 
 /* Gradients */
 /* --------- */

--- a/assets/css/romo/_vars.scss
+++ b/assets/css/romo/_vars.scss
@@ -49,15 +49,41 @@ $bgColorHover:   #f5f5f5;
 $baseBorderColor:  #ccc;
 $altBorderColor:   #fff;
 
-$linkColor:      #08c;
-$linkColorHover: darken($linkColor, 15%);
-
 $inputBgColor:          #fff;
 $inputAltBgColor:       #eee;
 $inputColor:            #444;
 $inputDisabledColor:    #eee;
 $inputFocusColor:       rgba(82, 168, 236, 0.8);
 $inputHighlightBgColor: #3c83c7;
+
+$darkRed:      #e7040f;
+$red:          #ff4136;
+$lightRed:     #ff725c;
+$orange:       #ff6300;
+$gold:         #ffb700;
+$yellow:       #ffde37;
+$lightYellow:  #fbf1a9;
+$purple:       #5e2ca5;
+$lightPurple:  #a463f2;
+$darkPink:     #d5008f;
+$hotPink:      #ff41b4;
+$pink:         #ff80cc;
+$lightPink:    #ffa3d7;
+$darkGreen:    #137752;
+$green:        #19a974;
+$lightGreen:   #9eebcf;
+$navy:         #001b44;
+$darkBlue:     #00449e;
+$blue:         #357edd;
+$lightBlue:    #96ccff;
+$lightestBlue: #cdecff;
+$washedBlue:   #f6fffe;
+$washedGreen:  #e8fdf5;
+$washedYellow: #fffceb;
+$washedRed:    #ffdfdf;
+
+$linkColor:      #08c;
+$linkColorHover: darken($linkColor, 15%);
 
 $btnBorder:                     $baseBorderColor;
 $btnBackground:                 $baseBgColor;

--- a/assets/css/romo/colors.scss
+++ b/assets/css/romo/colors.scss
@@ -1,0 +1,158 @@
+@import 'css/romo/vars';
+@import 'css/romo/mixins';
+
+.romo-text-dark-red      { @include text-dark-red(!important);      }
+.romo-text-red           { @include text-red(!important);           }
+.romo-text-light-red     { @include text-light-red(!important);     }
+.romo-text-orange        { @include text-orange(!important);        }
+.romo-text-gold          { @include text-gold(!important);          }
+.romo-text-yellow        { @include text-yellow(!important);        }
+.romo-text-light-yellow  { @include text-light-yellow(!important);  }
+.romo-text-purple        { @include text-purple(!important);        }
+.romo-text-light-purple  { @include text-light-purple(!important);  }
+.romo-text-dark-pink     { @include text-dark-pink(!important);     }
+.romo-text-hot-pink      { @include text-hot-pink(!important);      }
+.romo-text-pink          { @include text-pink(!important);          }
+.romo-text-light-pink    { @include text-light-pink(!important);    }
+.romo-text-dark-green    { @include text-dark-green(!important);    }
+.romo-text-green         { @include text-green(!important);         }
+.romo-text-light-green   { @include text-light-green(!important);   }
+.romo-text-navy          { @include text-navy(!important);          }
+.romo-text-dark-blue     { @include text-dark-blue(!important);     }
+.romo-text-blue          { @include text-blue(!important);          }
+.romo-text-light-blue    { @include text-light-blue(!important);    }
+.romo-text-lightest-blue { @include text-lightest-blue(!important); }
+.romo-text-washed-blue   { @include text-washed-blue(!important);   }
+.romo-text-washed-green  { @include text-washed-green(!important);  }
+.romo-text-washed-yellow { @include text-washed-yellow(!important); }
+.romo-text-washed-red    { @include text-washed-red(!important);    }
+
+.romo-text-dark-red-hover:hover,      a.romo-text-dark-red-hover:hover,      a.romo-text-dark-red-hover:focus      { @include text-dark-red(!important);      }
+.romo-text-red-hover:hover,           a.romo-text-red-hover:hover,           a.romo-text-red-hover:focus           { @include text-red(!important);           }
+.romo-text-light-red-hover:hover,     a.romo-text-light-red-hover:hover,     a.romo-text-light-red-hover:focus     { @include text-light-red(!important);     }
+.romo-text-orange-hover:hover,        a.romo-text-orange-hover:hover,        a.romo-text-orange-hover:focus        { @include text-orange(!important);        }
+.romo-text-gold-hover:hover,          a.romo-text-gold-hover:hover,          a.romo-text-gold-hover:focus          { @include text-gold(!important);          }
+.romo-text-yellow-hover:hover,        a.romo-text-yellow-hover:hover,        a.romo-text-yellow-hover:focus        { @include text-yellow(!important);        }
+.romo-text-light-yellow-hover:hover,  a.romo-text-light-yellow-hover:hover,  a.romo-text-light-yellow-hover:focus  { @include text-light-yellow(!important);  }
+.romo-text-purple-hover:hover,        a.romo-text-purple-hover:hover,        a.romo-text-purple-hover:focus        { @include text-purple(!important);        }
+.romo-text-light-purple-hover:hover,  a.romo-text-light-purple-hover:hover,  a.romo-text-light-purple-hover:focus  { @include text-light-purple(!important);  }
+.romo-text-dark-pink-hover:hover,     a.romo-text-dark-pink-hover:hover,     a.romo-text-dark-pink-hover:focus     { @include text-dark-pink(!important);     }
+.romo-text-hot-pink-hover:hover,      a.romo-text-hot-pink-hover:hover,      a.romo-text-hot-pink-hover:focus      { @include text-hot-pink(!important);      }
+.romo-text-pink-hover:hover,          a.romo-text-pink-hover:hover,          a.romo-text-pink-hover:focus          { @include text-pink(!important);          }
+.romo-text-light-pink-hover:hover,    a.romo-text-light-pink-hover:hover,    a.romo-text-light-pink-hover:focus    { @include text-light-pink(!important);    }
+.romo-text-dark-green-hover:hover,    a.romo-text-dark-green-hover:hover,    a.romo-text-dark-green-hover:focus    { @include text-dark-green(!important);    }
+.romo-text-green-hover:hover,         a.romo-text-green-hover:hover,         a.romo-text-green-hover:focus         { @include text-green(!important);         }
+.romo-text-light-green-hover:hover,   a.romo-text-light-green-hover:hover,   a.romo-text-light-green-hover:focus   { @include text-light-green(!important);   }
+.romo-text-navy-hover:hover,          a.romo-text-navy-hover:hover,          a.romo-text-navy-hover:focus          { @include text-navy(!important);          }
+.romo-text-dark-blue-hover:hover,     a.romo-text-dark-blue-hover:hover,     a.romo-text-dark-blue-hover:focus     { @include text-dark-blue(!important);     }
+.romo-text-blue-hover:hover,          a.romo-text-blue-hover:hover,          a.romo-text-blue-hover:focus          { @include text-blue(!important);          }
+.romo-text-light-blue-hover:hover,    a.romo-text-light-blue-hover:hover,    a.romo-text-light-blue-hover:focus    { @include text-light-blue(!important);    }
+.romo-text-lightest-blue-hover:hover, a.romo-text-lightest-blue-hover:hover, a.romo-text-lightest-blue-hover:focus { @include text-lightest-blue(!important); }
+.romo-text-washed-blue-hover:hover,   a.romo-text-washed-blue-hover:hover,   a.romo-text-washed-blue-hover:focus   { @include text-washed-blue(!important);   }
+.romo-text-washed-green-hover:hover,  a.romo-text-washed-green-hover:hover,  a.romo-text-washed-green-hover:focus  { @include text-washed-green(!important);  }
+.romo-text-washed-yellow-hover:hover, a.romo-text-washed-yellow-hover:hover, a.romo-text-washed-yellow-hover:focus { @include text-washed-yellow(!important); }
+.romo-text-washed-red-hover:hover,    a.romo-text-washed-red-hover:hover,    a.romo-text-washed-red-hover:focus    { @include text-washed-red(!important);    }
+
+.romo-bg-dark-red      { @include bg-dark-red(!important);      }
+.romo-bg-red           { @include bg-red(!important);           }
+.romo-bg-light-red     { @include bg-light-red(!important);     }
+.romo-bg-orange        { @include bg-orange(!important);        }
+.romo-bg-gold          { @include bg-gold(!important);          }
+.romo-bg-yellow        { @include bg-yellow(!important);        }
+.romo-bg-light-yellow  { @include bg-light-yellow(!important);  }
+.romo-bg-purple        { @include bg-purple(!important);        }
+.romo-bg-light-purple  { @include bg-light-purple(!important);  }
+.romo-bg-dark-pink     { @include bg-dark-pink(!important);     }
+.romo-bg-hot-pink      { @include bg-hot-pink(!important);      }
+.romo-bg-pink          { @include bg-pink(!important);          }
+.romo-bg-light-pink    { @include bg-light-pink(!important);    }
+.romo-bg-dark-green    { @include bg-dark-green(!important);    }
+.romo-bg-green         { @include bg-green(!important);         }
+.romo-bg-light-green   { @include bg-light-green(!important);   }
+.romo-bg-navy          { @include bg-navy(!important);          }
+.romo-bg-dark-blue     { @include bg-dark-blue(!important);     }
+.romo-bg-blue          { @include bg-blue(!important);          }
+.romo-bg-light-blue    { @include bg-light-blue(!important);    }
+.romo-bg-lightest-blue { @include bg-lightest-blue(!important); }
+.romo-bg-washed-blue   { @include bg-washed-blue(!important);   }
+.romo-bg-washed-green  { @include bg-washed-green(!important);  }
+.romo-bg-washed-yellow { @include bg-washed-yellow(!important); }
+.romo-bg-washed-red    { @include bg-washed-red(!important);    }
+
+.romo-bg-dark-red-hover:hover,      a.romo-bg-dark-red-hover:hover,      a.romo-bg-dark-red-hover:focus      { @include bg-dark-red(!important);      }
+.romo-bg-red-hover:hover,           a.romo-bg-red-hover:hover,           a.romo-bg-red-hover:focus           { @include bg-red(!important);           }
+.romo-bg-light-red-hover:hover,     a.romo-bg-light-red-hover:hover,     a.romo-bg-light-red-hover:focus     { @include bg-light-red(!important);     }
+.romo-bg-orange-hover:hover,        a.romo-bg-orange-hover:hover,        a.romo-bg-orange-hover:focus        { @include bg-orange(!important);        }
+.romo-bg-gold-hover:hover,          a.romo-bg-gold-hover:hover,          a.romo-bg-gold-hover:focus          { @include bg-gold(!important);          }
+.romo-bg-yellow-hover:hover,        a.romo-bg-yellow-hover:hover,        a.romo-bg-yellow-hover:focus        { @include bg-yellow(!important);        }
+.romo-bg-light-yellow-hover:hover,  a.romo-bg-light-yellow-hover:hover,  a.romo-bg-light-yellow-hover:focus  { @include bg-light-yellow(!important);  }
+.romo-bg-purple-hover:hover,        a.romo-bg-purple-hover:hover,        a.romo-bg-purple-hover:focus        { @include bg-purple(!important);        }
+.romo-bg-light-purple-hover:hover,  a.romo-bg-light-purple-hover:hover,  a.romo-bg-light-purple-hover:focus  { @include bg-light-purple(!important);  }
+.romo-bg-dark-pink-hover:hover,     a.romo-bg-dark-pink-hover:hover,     a.romo-bg-dark-pink-hover:focus     { @include bg-dark-pink(!important);     }
+.romo-bg-hot-pink-hover:hover,      a.romo-bg-hot-pink-hover:hover,      a.romo-bg-hot-pink-hover:focus      { @include bg-hot-pink(!important);      }
+.romo-bg-pink-hover:hover,          a.romo-bg-pink-hover:hover,          a.romo-bg-pink-hover:focus          { @include bg-pink(!important);          }
+.romo-bg-light-pink-hover:hover,    a.romo-bg-light-pink-hover:hover,    a.romo-bg-light-pink-hover:focus    { @include bg-light-pink(!important);    }
+.romo-bg-dark-green-hover:hover,    a.romo-bg-dark-green-hover:hover,    a.romo-bg-dark-green-hover:focus    { @include bg-dark-green(!important);    }
+.romo-bg-green-hover:hover,         a.romo-bg-green-hover:hover,         a.romo-bg-green-hover:focus         { @include bg-green(!important);         }
+.romo-bg-light-green-hover:hover,   a.romo-bg-light-green-hover:hover,   a.romo-bg-light-green-hover:focus   { @include bg-light-green(!important);   }
+.romo-bg-navy-hover:hover,          a.romo-bg-navy-hover:hover,          a.romo-bg-navy-hover:focus          { @include bg-navy(!important);          }
+.romo-bg-dark-blue-hover:hover,     a.romo-bg-dark-blue-hover:hover,     a.romo-bg-dark-blue-hover:focus     { @include bg-dark-blue(!important);     }
+.romo-bg-blue-hover:hover,          a.romo-bg-blue-hover:hover,          a.romo-bg-blue-hover:focus          { @include bg-blue(!important);          }
+.romo-bg-light-blue-hover:hover,    a.romo-bg-light-blue-hover:hover,    a.romo-bg-light-blue-hover:focus    { @include bg-light-blue(!important);    }
+.romo-bg-lightest-blue-hover:hover, a.romo-bg-lightest-blue-hover:hover, a.romo-bg-lightest-blue-hover:focus { @include bg-lightest-blue(!important); }
+.romo-bg-washed-blue-hover:hover,   a.romo-bg-washed-blue-hover:hover,   a.romo-bg-washed-blue-hover:focus   { @include bg-washed-blue(!important);   }
+.romo-bg-washed-green-hover:hover,  a.romo-bg-washed-green-hover:hover,  a.romo-bg-washed-green-hover:focus  { @include bg-washed-green(!important);  }
+.romo-bg-washed-yellow-hover:hover, a.romo-bg-washed-yellow-hover:hover, a.romo-bg-washed-yellow-hover:focus { @include bg-washed-yellow(!important); }
+.romo-bg-washed-red-hover:hover,    a.romo-bg-washed-red-hover:hover,    a.romo-bg-washed-red-hover:focus    { @include bg-washed-red(!important);    }
+
+.romo-border-dark-red      { @include border-dark-red(!important);      }
+.romo-border-red           { @include border-red(!important);           }
+.romo-border-light-red     { @include border-light-red(!important);     }
+.romo-border-orange        { @include border-orange(!important);        }
+.romo-border-gold          { @include border-gold(!important);          }
+.romo-border-yellow        { @include border-yellow(!important);        }
+.romo-border-light-yellow  { @include border-light-yellow(!important);  }
+.romo-border-purple        { @include border-purple(!important);        }
+.romo-border-light-purple  { @include border-light-purple(!important);  }
+.romo-border-dark-pink     { @include border-dark-pink(!important);     }
+.romo-border-hot-pink      { @include border-hot-pink(!important);      }
+.romo-border-pink          { @include border-pink(!important);          }
+.romo-border-light-pink    { @include border-light-pink(!important);    }
+.romo-border-dark-green    { @include border-dark-green(!important);    }
+.romo-border-green         { @include border-green(!important);         }
+.romo-border-light-green   { @include border-light-green(!important);   }
+.romo-border-navy          { @include border-navy(!important);          }
+.romo-border-dark-blue     { @include border-dark-blue(!important);     }
+.romo-border-blue          { @include border-blue(!important);          }
+.romo-border-light-blue    { @include border-light-blue(!important);    }
+.romo-border-lightest-blue { @include border-lightest-blue(!important); }
+.romo-border-washed-blue   { @include border-washed-blue(!important);   }
+.romo-border-washed-green  { @include border-washed-green(!important);  }
+.romo-border-washed-yellow { @include border-washed-yellow(!important); }
+.romo-border-washed-red    { @include border-washed-red(!important);    }
+
+.romo-border-dark-red-hover:hover,      a.romo-border-dark-red-hover:hover,      a.romo-border-dark-red-hover:focus      { @include border-dark-red(!important);      }
+.romo-border-red-hover:hover,           a.romo-border-red-hover:hover,           a.romo-border-red-hover:focus           { @include border-red(!important);           }
+.romo-border-light-red-hover:hover,     a.romo-border-light-red-hover:hover,     a.romo-border-light-red-hover:focus     { @include border-light-red(!important);     }
+.romo-border-orange-hover:hover,        a.romo-border-orange-hover:hover,        a.romo-border-orange-hover:focus        { @include border-orange(!important);        }
+.romo-border-gold-hover:hover,          a.romo-border-gold-hover:hover,          a.romo-border-gold-hover:focus          { @include border-gold(!important);          }
+.romo-border-yellow-hover:hover,        a.romo-border-yellow-hover:hover,        a.romo-border-yellow-hover:focus        { @include border-yellow(!important);        }
+.romo-border-light-yellow-hover:hover,  a.romo-border-light-yellow-hover:hover,  a.romo-border-light-yellow-hover:focus  { @include border-light-yellow(!important);  }
+.romo-border-purple-hover:hover,        a.romo-border-purple-hover:hover,        a.romo-border-purple-hover:focus        { @include border-purple(!important);        }
+.romo-border-light-purple-hover:hover,  a.romo-border-light-purple-hover:hover,  a.romo-border-light-purple-hover:focus  { @include border-light-purple(!important);  }
+.romo-border-dark-pink-hover:hover,     a.romo-border-dark-pink-hover:hover,     a.romo-border-dark-pink-hover:focus     { @include border-dark-pink(!important);     }
+.romo-border-hot-pink-hover:hover,      a.romo-border-hot-pink-hover:hover,      a.romo-border-hot-pink-hover:focus      { @include border-hot-pink(!important);      }
+.romo-border-pink-hover:hover,          a.romo-border-pink-hover:hover,          a.romo-border-pink-hover:focus          { @include border-pink(!important);          }
+.romo-border-light-pink-hover:hover,    a.romo-border-light-pink-hover:hover,    a.romo-border-light-pink-hover:focus    { @include border-light-pink(!important);    }
+.romo-border-dark-green-hover:hover,    a.romo-border-dark-green-hover:hover,    a.romo-border-dark-green-hover:focus    { @include border-dark-green(!important);    }
+.romo-border-green-hover:hover,         a.romo-border-green-hover:hover,         a.romo-border-green-hover:focus         { @include border-green(!important);         }
+.romo-border-light-green-hover:hover,   a.romo-border-light-green-hover:hover,   a.romo-border-light-green-hover:focus   { @include border-light-green(!important);   }
+.romo-border-navy-hover:hover,          a.romo-border-navy-hover:hover,          a.romo-border-navy-hover:focus          { @include border-navy(!important);          }
+.romo-border-dark-blue-hover:hover,     a.romo-border-dark-blue-hover:hover,     a.romo-border-dark-blue-hover:focus     { @include border-dark-blue(!important);     }
+.romo-border-blue-hover:hover,          a.romo-border-blue-hover:hover,          a.romo-border-blue-hover:focus          { @include border-blue(!important);          }
+.romo-border-light-blue-hover:hover,    a.romo-border-light-blue-hover:hover,    a.romo-border-light-blue-hover:focus    { @include border-light-blue(!important);    }
+.romo-border-lightest-blue-hover:hover, a.romo-border-lightest-blue-hover:hover, a.romo-border-lightest-blue-hover:focus { @include border-lightest-blue(!important); }
+.romo-border-washed-blue-hover:hover,   a.romo-border-washed-blue-hover:hover,   a.romo-border-washed-blue-hover:focus   { @include border-washed-blue(!important);   }
+.romo-border-washed-green-hover:hover,  a.romo-border-washed-green-hover:hover,  a.romo-border-washed-green-hover:focus  { @include border-washed-green(!important);  }
+.romo-border-washed-yellow-hover:hover, a.romo-border-washed-yellow-hover:hover, a.romo-border-washed-yellow-hover:focus { @include border-washed-yellow(!important); }
+.romo-border-washed-red-hover:hover,    a.romo-border-washed-red-hover:hover,    a.romo-border-washed-red-hover:focus    { @include border-washed-red(!important);    }


### PR DESCRIPTION
This adds style classes for coloring the text/bg/border (both
always or hover-only) for a given set of human-named colors.  The
color set is based on the color set from Tachyons CSS toolkit (see
http://tachyons.io/#colors for reference).

The goal here is to color UI in an explicit manner instead of
relying on the more implicit "emphasis" color classes we already
have available.  The implicit are still needed as the color used
for each "emphasis" can be customized.  This just adds the explicit
couterpart for coloring.  In a future effort, I'm going to change
the implicit "emphasis" colors to be based on the closest matching
explicit color variable.  This will provide some consistency to
the color set Romo offers.

@jcredding ready for review.