### PR TITLE
rework "emphasis" text/bg/hover/borders/buttons/labels

### DIFF
--- a/assets/css/romo/_mixins.scss
+++ b/assets/css/romo/_mixins.scss
@@ -360,18 +360,14 @@
 /* Buttons */
 /* ------- */
 
-@mixin button-bg($start, $end, $text) {
+@mixin button-bg($bg, $hover, $text) {
+  background-color: $bg;
   color: $text;
-  border-color: $end $end darken($end, 10%);
+  border-color: $hover $hover darken($hover, 10%);
 
-  background-color: mix($start, $end, 60%);
-  *background-color: $end; /* Darken IE7 buttons by default so they stand out more given they won't have borders */
-
-  /* in these cases the gradient won't cover the background, so we override */
   &:hover, &:focus, &.active, &:active, &.disabled, &[disabled] {
     color: $text;
-    background-color: $end;
-    *background-color: darken($end, 5%);
+    background-color: $hover;
   }
 }
 

--- a/assets/css/romo/_vars.scss
+++ b/assets/css/romo/_vars.scss
@@ -39,15 +39,19 @@ $notAllowedCursor: not-allowed;
 
 $baseColor:     #444;
 $altColor:      #444;
+$inverseColor:  #fff;
 $disabledColor: #999;
 
-$baseBgColor:    #fff;
-$altBgColor:     #ececec;
-$stripedBgColor: #fafafa;
-$bgColorHover:   #f5f5f5;
+$baseBgColor:     #fff;
+$altBgColor:      #ececec;
+$inverseBgColor:  #333;
+$disabledBgColor: #f9f9f9;
+$stripedBgColor:  #fafafa;
+$bgColorHover:    #f5f5f5;
 
-$baseBorderColor:  #ccc;
-$altBorderColor:   #fff;
+$baseBorderColor:    #ccc;
+$altBorderColor:     #fff;
+$inverseBorderColor: #000;
 
 $inputBgColor:          #fff;
 $inputAltBgColor:       #eee;
@@ -85,42 +89,38 @@ $lightBlue:    #96ccff;
 $pastelBlue:   #d9edf7;
 $washedBlue:   #f6fffe;
 
-$linkColor:      #08c;
+$linkColor:      $blue;
 $linkColorHover: darken($linkColor, 15%);
 
 $btnBorder:                     $baseBorderColor;
-$btnBackground:                 $baseBgColor;
+$btnBackground:                 darken($baseBgColor, 3%);
 $btnBackgroundHighlight:        darken($btnBackground, 10%);
 $btnColor:                      $baseColor;
 $btnColorHover:                 #333;
 
-$btnAltBackground:              $altBgColor;
+$btnAltBackground:              darken($altBgColor, 4%);
 $btnAltBackgroundHighlight:     darken($btnAltBackground, 10%);
 $btnAltColor:                   $btnColor;
 
-$btnPrimaryBackground:          $linkColor;
-$btnPrimaryBackgroundHighlight: adjust_hue($btnPrimaryBackground, 20%);
-$btnPrimaryColor:               #fff;
+$btnInverseBackground:          $inverseBgColor;
+$btnInverseBackgroundHighlight: darken($btnInverseBackground, 10%);
+$btnInverseColor:               #fff;
 
-$btnWarningBackgroundHighlight: #f89406;
-$btnWarningBackground:          lighten($btnWarningBackgroundHighlight, 15%);
+$btnWarningBackground:          $orange;
+$btnWarningBackgroundHighlight: darken($btnWarningBackground, 5%);
 $btnWarningColor:               #fff;
 
-$btnDangerBackground:           #ee5f5b;
-$btnDangerBackgroundHighlight:  #bd362f;
+$btnDangerBackground:           $red;
+$btnDangerBackgroundHighlight:  darken($btnDangerBackground, 10%);
 $btnDangerColor:                #fff;
 
-$btnInfoBackground:             #5bc0de;
-$btnInfoBackgroundHighlight:    #2f96b4;
+$btnInfoBackground:             $blue;
+$btnInfoBackgroundHighlight:    darken($btnInfoBackground, 10%);
 $btnInfoColor:                  #fff;
 
-$btnSuccessBackground:          #62c462;
-$btnSuccessBackgroundHighlight: #51a351;
+$btnSuccessBackground:          $green;
+$btnSuccessBackgroundHighlight: darken($btnSuccessBackground, 10%);
 $btnSuccessColor:               #fff;
-
-$btnInverseBackground:          #444;
-$btnInverseBackgroundHighlight: #222;
-$btnInverseColor:               #fff;
 
 $baseText:               $baseColor;
 $baseTextHover:          $baseText;
@@ -134,51 +134,51 @@ $altBackground:          $altBgColor;
 $altBackgroundHover:     $altBackground;
 $altBorder:              $altBorderColor;
 
-$mutedText:              #999999;
+$inverseText:            $inverseColor;
+$inverseTextHover:       darken($inverseText, 10%);
+$inverseBackground:      $inverseBgColor;
+$inverseBackgroundHover: darken($inverseBackground, 5%);
+$inverseBorder:          darken(adjust_hue($inverseBackground, -10), 7%);
+
+$mutedText:              $disabledColor;
 $mutedTextHover:         darken($mutedText, 10%);
-$mutedBackground:        #f9f9f9;
+$mutedBackground:        $disabledBgColor;
 $mutedBackgroundHover:   darken($mutedBackground, 5%);
-$mutedBorder:            darken(adjust_hue($mutedBackground, -10), 5%);
+$mutedBorder:            darken(adjust_hue($mutedBackground, -10), 7%);
 
-$warningText:            #c09853;
+$warningText:            darken($orange, 5%);
 $warningTextHover:       darken($warningText, 10%);
-$warningBackground:      #fcf8e3;
+$warningBackground:      $pastelYellow;
 $warningBackgroundHover: darken($warningBackground, 5%);
-$warningBorder:          darken(adjust_hue($warningBackground, -10), 3%);
+$warningBorder:          darken(adjust_hue($warningBackground, -10), 7%);
 
-$errorText:              #b94a48;
+$errorText:              darken($red, 5%);
 $errorTextHover:         darken($errorText, 10%);
-$errorBackground:        #f2dede;
+$errorBackground:        $pastelRed;
 $errorBackgroundHover:   darken($errorBackground, 5%);
-$errorBorder:            darken(adjust_hue($errorBackground, -10), 3%);
+$errorBorder:            darken(adjust_hue($errorBackground, -10), 7%);
 
-$infoText:               #3a87ad;
+$infoText:               darken($blue, 5%);
 $infoTextHover:          darken($infoText, 10%);
-$infoBackground:         #d9edf7;
+$infoBackground:         $pastelBlue;
 $infoBackgroundHover:    darken($infoBackground, 5%);
 $infoBorder:             darken(adjust_hue($infoBackground, -10), 7%);
 
-$successText:            #468847;
+$successText:            darken($green, 5%);
 $successTextHover:       darken($successText, 10%);
-$successBackground:      #dff0d8;
+$successBackground:      $pastelGreen;
 $successBackgroundHover: darken($successBackground, 5%);
-$successBorder:          darken(adjust_hue($successBackground, -10), 5%);
-
-$inverseText:            #ffffff;
-$inverseTextHover:       darken($inverseText, 10%);
-$inverseBackground:      #444444;
-$inverseBackgroundHover: darken($inverseBackground, 5%);
-$inverseBorder:          darken(adjust_hue($inverseBackground, -10), 3%);
+$successBorder:          darken(adjust_hue($successBackground, -10), 7%);
 
 $tabBgColor:       $altBgColor;
 $tabBgColorHover:  darken($altBgColor, 5%);
-$tabBgColorActive: #222;
+$tabBgColorActive: $inverseBgColor;
 $tabColor:         $baseColor;
-$tabColorActive:   #fff;
+$tabColorActive:   $inverseColor;
 $tabColorDisabled: $disabledColor;
 
-$tooltipBgColor:   #222;
-$tooltipColor:     #eee;
+$tooltipBgColor:   $inverseBgColor;
+$tooltipColor:     $inverseColor;
 
 /* borders */
 

--- a/assets/css/romo/buttons.scss
+++ b/assets/css/romo/buttons.scss
@@ -82,9 +82,9 @@ input[type="button"].romo-btn-block,
 a.romo-btn.romo-btn-alt,
 button.romo-btn.romo-btn-alt,
 .romo-btn.romo-btn-alt     { @include button-bg($btnAltBackground,     $btnAltBackgroundHighlight,     $btnAltColor); }
-a.romo-btn.romo-btn-primary,
-button.romo-btn.romo-btn-primary,
-.romo-btn.romo-btn-primary { @include button-bg($btnPrimaryBackground, $btnPrimaryBackgroundHighlight, $btnPrimaryColor); }
+a.romo-btn.romo-btn-inverse,
+button.romo-btn.romo-btn-inverse,
+.romo-btn.romo-btn-inverse { @include button-bg($btnInverseBackground, $btnInverseBackgroundHighlight, $btnInverseColor); }
 a.romo-btn.romo-btn-warning,
 button.romo-btn.romo-btn-warning,
 .romo-btn.romo-btn-warning { @include button-bg($btnWarningBackground, $btnWarningBackgroundHighlight, $btnWarningColor); }
@@ -100,9 +100,6 @@ button.romo-btn.romo-btn-info,
 a.romo-btn.romo-btn-success,
 button.romo-btn.romo-btn-success,
 .romo-btn.romo-btn-success { @include button-bg($btnSuccessBackground, $btnSuccessBackgroundHighlight, $btnSuccessColor); }
-a.romo-btn.romo-btn-inverse,
-button.romo-btn.romo-btn-inverse,
-.romo-btn.romo-btn-inverse { @include button-bg($btnInverseBackground, $btnInverseBackgroundHighlight, $btnInverseColor); }
 
 a.romo-btn.romo-btn-link,
 button.romo-btn.romo-btn-link,

--- a/assets/css/romo/labels.scss
+++ b/assets/css/romo/labels.scss
@@ -31,11 +31,10 @@
 
 .romo-label-block { display: block; width: 100%; }
 
-.romo-label.romo-label-alt     { background-color: $btnBackground;                 color: $btnColor; }
-.romo-label.romo-label-primary { background-color: $btnPrimaryBackgroundHighlight; color: $btnPrimaryColor; }
-.romo-label.romo-label-warning { background-color: $btnWarningBackgroundHighlight; color: $btnWarningColor; }
+.romo-label.romo-label-alt     { background-color: $btnBackground;        color: $btnColor; }
+.romo-label.romo-label-inverse { background-color: $btnInverseBackground; color: $btnInverseColor; }
+.romo-label.romo-label-warning { background-color: $btnWarningBackground; color: $btnWarningColor; }
 .romo-label.romo-label-error,
-.romo-label.romo-label-danger  { background-color: $btnDangerBackgroundHighlight;  color: $btnDangerColor; }
-.romo-label.romo-label-info    { background-color: $btnInfoBackgroundHighlight;    color: $btnInfoColor; }
-.romo-label.romo-label-success { background-color: $btnSuccessBackgroundHighlight; color: $btnSuccessColor; }
-.romo-label.romo-label-inverse { background-color: $btnInverseBackgroundHighlight; color: $btnInverseColor; }
+.romo-label.romo-label-danger  { background-color: $btnDangerBackground;  color: $btnDangerColor; }
+.romo-label.romo-label-info    { background-color: $btnInfoBackground;    color: $btnInfoColor; }
+.romo-label.romo-label-success { background-color: $btnSuccessBackground; color: $btnSuccessColor; }

--- a/gh-pages/view_handlers/css/buttons.md
+++ b/gh-pages/view_handlers/css/buttons.md
@@ -204,12 +204,12 @@ Use these as an alternative to the default styles and to add color emphasis to b
         <td><code>romo-btn romo-btn-alt</code></td>
       </tr>
       <tr>
-        <td><button href="#" class="romo-btn romo-btn-primary romo-btn-large disabled">Primary</button></td>
-        <td><button href="#" class="romo-btn romo-btn-primary romo-btn-large active">Primary</button></td>
-        <td><button href="#" class="romo-btn romo-btn-primary romo-btn-large">Primary</button></td>
-        <td><button href="#" class="romo-btn romo-btn-primary">Primary</button></td>
-        <td><button href="#" class="romo-btn romo-btn-primary romo-btn-small">Primary</button></td>
-        <td><code>romo-btn romo-btn-primary</code></td>
+        <td><button href="#" class="romo-btn romo-btn-inverse romo-btn-large disabled">Inverse</button></td>
+        <td><button href="#" class="romo-btn romo-btn-inverse romo-btn-large active">Inverse</button></td>
+        <td><button href="#" class="romo-btn romo-btn-inverse romo-btn-large">Inverse</button></td>
+        <td><button href="#" class="romo-btn romo-btn-inverse">Inverse</button></td>
+        <td><button href="#" class="romo-btn romo-btn-inverse romo-btn-small">Inverse</button></td>
+        <td><code>romo-btn romo-btn-inverse</code></td>
       </tr>
       <tr>
         <td><button href="#" class="romo-btn romo-btn-warning romo-btn-large disabled">Warning</button></td>
@@ -242,14 +242,6 @@ Use these as an alternative to the default styles and to add color emphasis to b
         <td><button href="#" class="romo-btn romo-btn-success">Success</button></td>
         <td><button href="#" class="romo-btn romo-btn-success romo-btn-small">Success</button></td>
         <td><code>romo-btn romo-btn-success</code></td>
-      </tr>
-      <tr>
-        <td><button href="#" class="romo-btn romo-btn-inverse romo-btn-large disabled">Inverse</button></td>
-        <td><button href="#" class="romo-btn romo-btn-inverse romo-btn-large active">Inverse</button></td>
-        <td><button href="#" class="romo-btn romo-btn-inverse romo-btn-large">Inverse</button></td>
-        <td><button href="#" class="romo-btn romo-btn-inverse">Inverse</button></td>
-        <td><button href="#" class="romo-btn romo-btn-inverse romo-btn-small">Inverse</button></td>
-        <td><code>romo-btn romo-btn-inverse</code></td>
       </tr>
       <tr>
         <td><button href="#" class="romo-btn romo-btn-link romo-btn-large disabled">Link</button></td>

--- a/gh-pages/view_handlers/css/labels.md
+++ b/gh-pages/view_handlers/css/labels.md
@@ -170,10 +170,10 @@ Use these as an alternative to the default styles and to add color emphasis to l
         <td><code>romo-label romo-label-alt</code></td>
       </tr>
       <tr>
-        <td><span class="romo-label romo-label-primary romo-label-large">Primary</span></td>
-        <td><span class="romo-label romo-label-primary ">Primary</span></td>
-        <td><span class="romo-label romo-label-primary romo-label-small">Primary</span></td>
-        <td><code>romo-label romo-label-primary</code></td>
+        <td><span class="romo-label romo-label-inverse romo-label-large">Inverse</span></td>
+        <td><span class="romo-label romo-label-inverse ">Inverse</span></td>
+        <td><span class="romo-label romo-label-inverse romo-label-small">Inverse</span></td>
+        <td><code>romo-label romo-label-inverse</code></td>
       </tr>
       <tr>
         <td><span class="romo-label romo-label-warning romo-label-large">Warning</span></td>
@@ -198,12 +198,6 @@ Use these as an alternative to the default styles and to add color emphasis to l
         <td><span class="romo-label romo-label-success ">Success</span></td>
         <td><span class="romo-label romo-label-success romo-label-small">Success</span></td>
         <td><code>romo-label romo-label-success</code></td>
-      </tr>
-      <tr>
-        <td><span class="romo-label romo-label-inverse romo-label-large">Inverse</span></td>
-        <td><span class="romo-label romo-label-inverse ">Inverse</span></td>
-        <td><span class="romo-label romo-label-inverse romo-label-small">Inverse</span></td>
-        <td><code>romo-label romo-label-inverse</code></td>
       </tr>
     </tbody>
   </table>


### PR DESCRIPTION
This reworks these elements to be based off of our new color vars.
In general, "warning" is now based off of `$orange`, "info" off of
`$blue`, "error" off of `$red`, and "success" off of `$green`.
This also formally defines a color for "inverse" (black).

The goal of all of this is to minimize color variation in Romo's
default styles.  To help with this, I've also updated other elems
(like tabs and tooltips) to base off of defined colors.  I also
reworked the button handling to not "mix" the bg/highlight colors
and just match the color it was based on exactly.  I chose to
darken the emphasis text colors slightly to help with readability.
Note: I chose to darken the warning button less on highlight than
the other buttons.  This is bc the 10% looked too dark for that
orange color.

I chose to remove the "primary" button/label.  I've felt like these
should be just "info".  Also, they were the only things that had
a "primary" so were kind of outliers.

New:
![after](https://cloud.githubusercontent.com/assets/82110/21529852/14918b58-cd02-11e6-8651-0d747c83c332.jpg)


Old and Busted:
![before](https://cloud.githubusercontent.com/assets/82110/21529847/0962096a-cd02-11e6-8275-4232a4b0aa2c.jpg)


@jcredding ready for review.