### PR TITLE
cleanups to the color-related css, var names, etc

### DIFF
--- a/assets/css/romo/_mixins.scss
+++ b/assets/css/romo/_mixins.scss
@@ -147,91 +147,91 @@
 
 @mixin text-disabled($i:"") { color: $disabledColor #{$i}; }
 
-@mixin text-base($i:"")       {            color: $baseText #{$i}; }
-@mixin text-base-hover($i:"") {            color: $baseTextHover #{$i}; }
-@mixin bg-base($i:"")         { background-color: $baseBackground #{$i}; }
-@mixin bg-base-hover($i:"")   { background-color: $baseBackgroundHover #{$i}; }
-@mixin border-base($i:"")     {     border-color: $baseBorder #{$i}; }
+@mixin text-base($i:"")          {            color: $baseText #{$i}; }
+@mixin text-base-hover($i:"")    {            color: $baseTextHover #{$i}; }
+@mixin bg-base($i:"")            { background-color: $baseBg #{$i}; }
+@mixin bg-base-hover($i:"")      { background-color: $baseBgHover #{$i}; }
+@mixin border-base($i:"")        {     border-color: $baseBorder #{$i}; }
 
-@mixin text-alt($i:"")       {            color: $altText #{$i}; }
-@mixin text-alt-hover($i:"") {            color: $altTextHover #{$i}; }
-@mixin bg-alt($i:"")         { background-color: $altBackground #{$i}; }
-@mixin bg-alt-hover($i:"")   { background-color: $altBackgroundHover #{$i}; }
-@mixin border-alt($i:"")     {     border-color: $altBorder #{$i}; }
+@mixin text-alt($i:"")           {            color: $altText #{$i}; }
+@mixin text-alt-hover($i:"")     {            color: $altTextHover #{$i}; }
+@mixin bg-alt($i:"")             { background-color: $altBg #{$i}; }
+@mixin bg-alt-hover($i:"")       { background-color: $altBgHover #{$i}; }
+@mixin border-alt($i:"")         {     border-color: $altBorder #{$i}; }
 
-@mixin text-muted($i:"")       {            color: $mutedText #{$i}; }
-@mixin text-muted-hover($i:"") {            color: $mutedTextHover #{$i}; }
-@mixin bg-muted($i:"")         { background-color: $mutedBackground #{$i}; }
-@mixin bg-muted-hover($i:"")   { background-color: $mutedBackgroundHover #{$i}; }
-@mixin border-muted($i:"")     {     border-color: $mutedBorder #{$i}; }
+@mixin text-muted($i:"")         {            color: $mutedText #{$i}; }
+@mixin text-muted-hover($i:"")   {            color: $mutedTextHover #{$i}; }
+@mixin bg-muted($i:"")           { background-color: $mutedBg #{$i}; }
+@mixin bg-muted-hover($i:"")     { background-color: $mutedBgHover #{$i}; }
+@mixin border-muted($i:"")       {     border-color: $mutedBorder #{$i}; }
 
 @mixin text-warning($i:"")       {            color: $warningText #{$i}; }
 @mixin text-warning-hover($i:"") {            color: $warningTextHover #{$i}; }
-@mixin bg-warning($i:"")         { background-color: $warningBackground #{$i}; }
-@mixin bg-warning-hover($i:"")   { background-color: $warningBackgroundHover #{$i}; }
+@mixin bg-warning($i:"")         { background-color: $warningBg #{$i}; }
+@mixin bg-warning-hover($i:"")   { background-color: $warningBgHover #{$i}; }
 @mixin border-warning($i:"")     {     border-color: $warningBorder #{$i}; }
 
-@mixin text-error($i:"")       {            color: $errorText #{$i}; }
-@mixin text-error-hover($i:"") {            color: $errorTextHover #{$i}; }
-@mixin bg-error($i:"")         { background-color: $errorBackground #{$i}; }
-@mixin bg-error-hover($i:"")   { background-color: $errorBackgroundHover #{$i}; }
-@mixin border-error($i:"")     {     border-color: $errorBorder #{$i}; }
+@mixin text-danger($i:"")        {            color: $dangerText #{$i}; }
+@mixin text-danger-hover($i:"")  {            color: $dangerTextHover #{$i}; }
+@mixin bg-danger($i:"")          { background-color: $dangerBg #{$i}; }
+@mixin bg-danger-hover($i:"")    { background-color: $dangerBgHover #{$i}; }
+@mixin border-danger($i:"")      {     border-color: $dangerBorder #{$i}; }
 
-@mixin text-info($i:"")       {            color: $infoText #{$i}; }
-@mixin text-info-hover($i:"") {            color: $infoTextHover #{$i}; }
-@mixin bg-info($i:"")         { background-color: $infoBackground #{$i}; }
-@mixin bg-info-hover($i:"")   { background-color: $infoBackgroundHover #{$i}; }
-@mixin border-info($i:"")     {     border-color: $infoBorder #{$i}; }
+@mixin text-info($i:"")          {            color: $infoText #{$i}; }
+@mixin text-info-hover($i:"")    {            color: $infoTextHover #{$i}; }
+@mixin bg-info($i:"")            { background-color: $infoBg #{$i}; }
+@mixin bg-info-hover($i:"")      { background-color: $infoBgHover #{$i}; }
+@mixin border-info($i:"")        {     border-color: $infoBorder #{$i}; }
 
 @mixin text-success($i:"")       {            color: $successText #{$i}; }
 @mixin text-success-hover($i:"") {            color: $successTextHover #{$i}; }
-@mixin bg-success($i:"")         { background-color: $successBackground #{$i}; }
-@mixin bg-success-hover($i:"")   { background-color: $successBackgroundHover #{$i}; }
+@mixin bg-success($i:"")         { background-color: $successBg #{$i}; }
+@mixin bg-success-hover($i:"")   { background-color: $successBgHover #{$i}; }
 @mixin border-success($i:"")     {     border-color: $successBorder #{$i}; }
 
 @mixin text-inverse($i:"")       {            color: $inverseText #{$i}; }
 @mixin text-inverse-hover($i:"") {            color: $inverseTextHover #{$i}; }
-@mixin bg-inverse($i:"")         { background-color: $inverseBackground #{$i}; }
-@mixin bg-inverse-hover($i:"")   { background-color: $inverseBackgroundHover #{$i}; }
+@mixin bg-inverse($i:"")         { background-color: $inverseBg #{$i}; }
+@mixin bg-inverse-hover($i:"")   { background-color: $inverseBgHover #{$i}; }
 @mixin border-inverse($i:"")     {     border-color: $inverseBorder #{$i}; }
 
 /* explicit colors */
 
-@mixin text-dark-red($i:"")   {            color: $darkRed #{$i}; }
-@mixin bg-dark-red($i:"")     { background-color: $darkRed #{$i}; }
-@mixin border-dark-red($i:"") {     border-color: $darkRed #{$i}; }
+@mixin text-dark-red($i:"")        {            color: $darkRed #{$i}; }
+@mixin bg-dark-red($i:"")          { background-color: $darkRed #{$i}; }
+@mixin border-dark-red($i:"")      {     border-color: $darkRed #{$i}; }
 
-@mixin text-red($i:"")   {            color: $red #{$i}; }
-@mixin bg-red($i:"")     { background-color: $red #{$i}; }
-@mixin border-red($i:"") {     border-color: $red #{$i}; }
+@mixin text-red($i:"")             {            color: $red #{$i}; }
+@mixin bg-red($i:"")               { background-color: $red #{$i}; }
+@mixin border-red($i:"")           {     border-color: $red #{$i}; }
 
-@mixin text-light-red($i:"")   {            color: $lightRed #{$i}; }
-@mixin bg-light-red($i:"")     { background-color: $lightRed #{$i}; }
-@mixin border-light-red($i:"") {     border-color: $lightRed #{$i}; }
+@mixin text-light-red($i:"")       {            color: $lightRed #{$i}; }
+@mixin bg-light-red($i:"")         { background-color: $lightRed #{$i}; }
+@mixin border-light-red($i:"")     {     border-color: $lightRed #{$i}; }
 
-@mixin text-pastel-red($i:"")   {            color: $pastelRed #{$i}; }
-@mixin bg-pastel-red($i:"")     { background-color: $pastelRed #{$i}; }
-@mixin border-pastel-red($i:"") {     border-color: $pastelRed #{$i}; }
+@mixin text-pastel-red($i:"")      {            color: $pastelRed #{$i}; }
+@mixin bg-pastel-red($i:"")        { background-color: $pastelRed #{$i}; }
+@mixin border-pastel-red($i:"")    {     border-color: $pastelRed #{$i}; }
 
-@mixin text-washed-red($i:"")   {            color: $washedRed #{$i}; }
-@mixin bg-washed-red($i:"")     { background-color: $washedRed #{$i}; }
-@mixin border-washed-red($i:"") {     border-color: $washedRed #{$i}; }
+@mixin text-washed-red($i:"")      {            color: $washedRed #{$i}; }
+@mixin bg-washed-red($i:"")        { background-color: $washedRed #{$i}; }
+@mixin border-washed-red($i:"")    {     border-color: $washedRed #{$i}; }
 
-@mixin text-dark-orange($i:"")   {            color: $darkOrange #{$i}; }
-@mixin bg-dark-orange($i:"")     { background-color: $darkOrange #{$i}; }
-@mixin border-dark-orange($i:"") {     border-color: $darkOrange #{$i}; }
+@mixin text-dark-orange($i:"")     {            color: $darkOrange #{$i}; }
+@mixin bg-dark-orange($i:"")       { background-color: $darkOrange #{$i}; }
+@mixin border-dark-orange($i:"")   {     border-color: $darkOrange #{$i}; }
 
-@mixin text-orange($i:"")   {            color: $orange #{$i}; }
-@mixin bg-orange($i:"")     { background-color: $orange #{$i}; }
-@mixin border-orange($i:"") {     border-color: $orange #{$i}; }
+@mixin text-orange($i:"")          {            color: $orange #{$i}; }
+@mixin bg-orange($i:"")            { background-color: $orange #{$i}; }
+@mixin border-orange($i:"")        {     border-color: $orange #{$i}; }
 
-@mixin text-yellow($i:"")   {            color: $yellow #{$i}; }
-@mixin bg-yellow($i:"")     { background-color: $yellow #{$i}; }
-@mixin border-yellow($i:"") {     border-color: $yellow #{$i}; }
+@mixin text-yellow($i:"")          {            color: $yellow #{$i}; }
+@mixin bg-yellow($i:"")            { background-color: $yellow #{$i}; }
+@mixin border-yellow($i:"")        {     border-color: $yellow #{$i}; }
 
-@mixin text-light-yellow($i:"")   {            color: $lightYellow #{$i}; }
-@mixin bg-light-yellow($i:"")     { background-color: $lightYellow #{$i}; }
-@mixin border-light-yellow($i:"") {     border-color: $lightYellow #{$i}; }
+@mixin text-light-yellow($i:"")    {            color: $lightYellow #{$i}; }
+@mixin bg-light-yellow($i:"")      { background-color: $lightYellow #{$i}; }
+@mixin border-light-yellow($i:"")  {     border-color: $lightYellow #{$i}; }
 
 @mixin text-pastel-yellow($i:"")   {            color: $pastelYellow #{$i}; }
 @mixin bg-pastel-yellow($i:"")     { background-color: $pastelYellow #{$i}; }
@@ -241,73 +241,73 @@
 @mixin bg-washed-yellow($i:"")     { background-color: $washedYellow #{$i}; }
 @mixin border-washed-yellow($i:"") {     border-color: $washedYellow #{$i}; }
 
-@mixin text-purple($i:"")   {            color: $purple #{$i}; }
-@mixin bg-purple($i:"")     { background-color: $purple #{$i}; }
-@mixin border-purple($i:"") {     border-color: $purple #{$i}; }
+@mixin text-purple($i:"")          {            color: $purple #{$i}; }
+@mixin bg-purple($i:"")            { background-color: $purple #{$i}; }
+@mixin border-purple($i:"")        {     border-color: $purple #{$i}; }
 
-@mixin text-light-purple($i:"")   {            color: $lightPurple #{$i}; }
-@mixin bg-light-purple($i:"")     { background-color: $lightPurple #{$i}; }
-@mixin border-light-purple($i:"") {     border-color: $lightPurple #{$i}; }
+@mixin text-light-purple($i:"")    {            color: $lightPurple #{$i}; }
+@mixin bg-light-purple($i:"")      { background-color: $lightPurple #{$i}; }
+@mixin border-light-purple($i:"")  {     border-color: $lightPurple #{$i}; }
 
-@mixin text-dark-pink($i:"")   {            color: $darkPink #{$i}; }
-@mixin bg-dark-pink($i:"")     { background-color: $darkPink #{$i}; }
-@mixin border-dark-pink($i:"") {     border-color: $darkPink #{$i}; }
+@mixin text-dark-pink($i:"")       {            color: $darkPink #{$i}; }
+@mixin bg-dark-pink($i:"")         { background-color: $darkPink #{$i}; }
+@mixin border-dark-pink($i:"")     {     border-color: $darkPink #{$i}; }
 
-@mixin text-hot-pink($i:"")   {            color: $hotPink #{$i}; }
-@mixin bg-hot-pink($i:"")     { background-color: $hotPink #{$i}; }
-@mixin border-hot-pink($i:"") {     border-color: $hotPink #{$i}; }
+@mixin text-hot-pink($i:"")        {            color: $hotPink #{$i}; }
+@mixin bg-hot-pink($i:"")          { background-color: $hotPink #{$i}; }
+@mixin border-hot-pink($i:"")      {     border-color: $hotPink #{$i}; }
 
-@mixin text-pink($i:"")   {            color: $pink #{$i}; }
-@mixin bg-pink($i:"")     { background-color: $pink #{$i}; }
-@mixin border-pink($i:"") {     border-color: $pink #{$i}; }
+@mixin text-pink($i:"")            {            color: $pink #{$i}; }
+@mixin bg-pink($i:"")              { background-color: $pink #{$i}; }
+@mixin border-pink($i:"")          {     border-color: $pink #{$i}; }
 
-@mixin text-light-pink($i:"")   {            color: $lightPink #{$i}; }
-@mixin bg-light-pink($i:"")     { background-color: $lightPink #{$i}; }
-@mixin border-light-pink($i:"") {     border-color: $lightPink #{$i}; }
+@mixin text-light-pink($i:"")      {            color: $lightPink #{$i}; }
+@mixin bg-light-pink($i:"")        { background-color: $lightPink #{$i}; }
+@mixin border-light-pink($i:"")    {     border-color: $lightPink #{$i}; }
 
-@mixin text-dark-green($i:"")   {            color: $darkGreen #{$i}; }
-@mixin bg-dark-green($i:"")     { background-color: $darkGreen #{$i}; }
-@mixin border-dark-green($i:"") {     border-color: $darkGreen #{$i}; }
+@mixin text-dark-green($i:"")      {            color: $darkGreen #{$i}; }
+@mixin bg-dark-green($i:"")        { background-color: $darkGreen #{$i}; }
+@mixin border-dark-green($i:"")    {     border-color: $darkGreen #{$i}; }
 
-@mixin text-green($i:"")   {            color: $green #{$i}; }
-@mixin bg-green($i:"")     { background-color: $green #{$i}; }
-@mixin border-green($i:"") {     border-color: $green #{$i}; }
+@mixin text-green($i:"")           {            color: $green #{$i}; }
+@mixin bg-green($i:"")             { background-color: $green #{$i}; }
+@mixin border-green($i:"")         {     border-color: $green #{$i}; }
 
-@mixin text-light-green($i:"")   {            color: $lightGreen #{$i}; }
-@mixin bg-light-green($i:"")     { background-color: $lightGreen #{$i}; }
-@mixin border-light-green($i:"") {     border-color: $lightGreen #{$i}; }
+@mixin text-light-green($i:"")     {            color: $lightGreen #{$i}; }
+@mixin bg-light-green($i:"")       { background-color: $lightGreen #{$i}; }
+@mixin border-light-green($i:"")   {     border-color: $lightGreen #{$i}; }
 
-@mixin text-pastel-green($i:"")   {            color: $pastelGreen #{$i}; }
-@mixin bg-pastel-green($i:"")     { background-color: $pastelGreen #{$i}; }
-@mixin border-pastel-green($i:"") {     border-color: $pastelGreen #{$i}; }
+@mixin text-pastel-green($i:"")    {            color: $pastelGreen #{$i}; }
+@mixin bg-pastel-green($i:"")      { background-color: $pastelGreen #{$i}; }
+@mixin border-pastel-green($i:"")  {     border-color: $pastelGreen #{$i}; }
 
-@mixin text-washed-green($i:"")   {            color: $washedGreen #{$i}; }
-@mixin bg-washed-green($i:"")     { background-color: $washedGreen #{$i}; }
-@mixin border-washed-green($i:"") {     border-color: $washedGreen #{$i}; }
+@mixin text-washed-green($i:"")    {            color: $washedGreen #{$i}; }
+@mixin bg-washed-green($i:"")      { background-color: $washedGreen #{$i}; }
+@mixin border-washed-green($i:"")  {     border-color: $washedGreen #{$i}; }
 
-@mixin text-navy($i:"")   {            color: $navy #{$i}; }
-@mixin bg-navy($i:"")     { background-color: $navy #{$i}; }
-@mixin border-navy($i:"") {     border-color: $navy #{$i}; }
+@mixin text-navy($i:"")            {            color: $navy #{$i}; }
+@mixin bg-navy($i:"")              { background-color: $navy #{$i}; }
+@mixin border-navy($i:"")          {     border-color: $navy #{$i}; }
 
-@mixin text-dark-blue($i:"")   {            color: $darkBlue #{$i}; }
-@mixin bg-dark-blue($i:"")     { background-color: $darkBlue #{$i}; }
-@mixin border-dark-blue($i:"") {     border-color: $darkBlue #{$i}; }
+@mixin text-dark-blue($i:"")       {            color: $darkBlue #{$i}; }
+@mixin bg-dark-blue($i:"")         { background-color: $darkBlue #{$i}; }
+@mixin border-dark-blue($i:"")     {     border-color: $darkBlue #{$i}; }
 
-@mixin text-blue($i:"")   {            color: $blue #{$i}; }
-@mixin bg-blue($i:"")     { background-color: $blue #{$i}; }
-@mixin border-blue($i:"") {     border-color: $blue #{$i}; }
+@mixin text-blue($i:"")            {            color: $blue #{$i}; }
+@mixin bg-blue($i:"")              { background-color: $blue #{$i}; }
+@mixin border-blue($i:"")          {     border-color: $blue #{$i}; }
 
-@mixin text-light-blue($i:"")   {            color: $lightBlue #{$i}; }
-@mixin bg-light-blue($i:"")     { background-color: $lightBlue #{$i}; }
-@mixin border-light-blue($i:"") {     border-color: $lightBlue #{$i}; }
+@mixin text-light-blue($i:"")      {            color: $lightBlue #{$i}; }
+@mixin bg-light-blue($i:"")        { background-color: $lightBlue #{$i}; }
+@mixin border-light-blue($i:"")    {     border-color: $lightBlue #{$i}; }
 
-@mixin text-pastel-blue($i:"")   {            color: $pastelBlue #{$i}; }
-@mixin bg-pastel-blue($i:"")     { background-color: $pastelBlue #{$i}; }
-@mixin border-pastel-blue($i:"") {     border-color: $pastelBlue #{$i}; }
+@mixin text-pastel-blue($i:"")     {            color: $pastelBlue #{$i}; }
+@mixin bg-pastel-blue($i:"")       { background-color: $pastelBlue #{$i}; }
+@mixin border-pastel-blue($i:"")   {     border-color: $pastelBlue #{$i}; }
 
-@mixin text-washed-blue($i:"")   {            color: $washedBlue #{$i}; }
-@mixin bg-washed-blue($i:"")     { background-color: $washedBlue #{$i}; }
-@mixin border-washed-blue($i:"") {     border-color: $washedBlue #{$i}; }
+@mixin text-washed-blue($i:"")     {            color: $washedBlue #{$i}; }
+@mixin bg-washed-blue($i:"")       { background-color: $washedBlue #{$i}; }
+@mixin border-washed-blue($i:"")   {     border-color: $washedBlue #{$i}; }
 
 /* Gradients */
 /* --------- */

--- a/assets/css/romo/_vars.scss
+++ b/assets/css/romo/_vars.scss
@@ -92,83 +92,83 @@ $washedBlue:   #f6fffe;
 $linkColor:      $blue;
 $linkColorHover: darken($linkColor, 15%);
 
-$btnBorder:                     $baseBorderColor;
-$btnBackground:                 darken($baseBgColor, 3%);
-$btnBackgroundHighlight:        darken($btnBackground, 10%);
-$btnColor:                      $baseColor;
-$btnColorHover:                 #333;
+$btnBorder:             $baseBorderColor;
+$btnBg:                 darken($baseBgColor, 3%);
+$btnBgHighlight:        darken($btnBg, 10%);
+$btnColor:              $baseColor;
+$btnColorHover:         #333;
 
-$btnAltBackground:              darken($altBgColor, 4%);
-$btnAltBackgroundHighlight:     darken($btnAltBackground, 10%);
-$btnAltColor:                   $btnColor;
+$btnAltBg:              darken($altBgColor, 4%);
+$btnAltBgHighlight:     darken($btnAltBg, 10%);
+$btnAltColor:           $btnColor;
 
-$btnInverseBackground:          $inverseBgColor;
-$btnInverseBackgroundHighlight: darken($btnInverseBackground, 10%);
-$btnInverseColor:               #fff;
+$btnInverseBg:          $inverseBgColor;
+$btnInverseBgHighlight: darken($btnInverseBg, 10%);
+$btnInverseColor:       #fff;
 
-$btnWarningBackground:          $orange;
-$btnWarningBackgroundHighlight: darken($btnWarningBackground, 5%);
-$btnWarningColor:               #fff;
+$btnWarningBg:          $orange;
+$btnWarningBgHighlight: darken($btnWarningBg, 5%);
+$btnWarningColor:       #fff;
 
-$btnDangerBackground:           $red;
-$btnDangerBackgroundHighlight:  darken($btnDangerBackground, 10%);
-$btnDangerColor:                #fff;
+$btnDangerBg:           $red;
+$btnDangerBgHighlight:  darken($btnDangerBg, 10%);
+$btnDangerColor:        #fff;
 
-$btnInfoBackground:             $blue;
-$btnInfoBackgroundHighlight:    darken($btnInfoBackground, 10%);
-$btnInfoColor:                  #fff;
+$btnInfoBg:             $blue;
+$btnInfoBgHighlight:    darken($btnInfoBg, 10%);
+$btnInfoColor:          #fff;
 
-$btnSuccessBackground:          $green;
-$btnSuccessBackgroundHighlight: darken($btnSuccessBackground, 10%);
-$btnSuccessColor:               #fff;
+$btnSuccessBg:          $green;
+$btnSuccessBgHighlight: darken($btnSuccessBg, 10%);
+$btnSuccessColor:       #fff;
 
-$baseText:               $baseColor;
-$baseTextHover:          $baseText;
-$baseBackground:         $baseBgColor;
-$baseBackgroundHover:    $baseBackground;
-$baseBorder:             $baseBorderColor;
+$baseText:         $baseColor;
+$baseTextHover:    $baseText;
+$baseBg:           $baseBgColor;
+$baseBgHover:      $baseBg;
+$baseBorder:       $baseBorderColor;
 
-$altText:                $altColor;
-$altTextHover:           $altColor;
-$altBackground:          $altBgColor;
-$altBackgroundHover:     $altBackground;
-$altBorder:              $altBorderColor;
+$altText:          $altColor;
+$altTextHover:     $altColor;
+$altBg:            $altBgColor;
+$altBgHover:       $altBg;
+$altBorder:        $altBorderColor;
 
-$inverseText:            $inverseColor;
-$inverseTextHover:       darken($inverseText, 10%);
-$inverseBackground:      $inverseBgColor;
-$inverseBackgroundHover: darken($inverseBackground, 5%);
-$inverseBorder:          darken(adjust_hue($inverseBackground, -10), 7%);
+$inverseText:      $inverseColor;
+$inverseTextHover: darken($inverseText, 10%);
+$inverseBg:        $inverseBgColor;
+$inverseBgHover:   darken($inverseBg, 5%);
+$inverseBorder:    darken(adjust_hue($inverseBg, -10), 7%);
 
-$mutedText:              $disabledColor;
-$mutedTextHover:         darken($mutedText, 10%);
-$mutedBackground:        $disabledBgColor;
-$mutedBackgroundHover:   darken($mutedBackground, 5%);
-$mutedBorder:            darken(adjust_hue($mutedBackground, -10), 7%);
+$mutedText:        $disabledColor;
+$mutedTextHover:   darken($mutedText, 10%);
+$mutedBg:          $disabledBgColor;
+$mutedBgHover:     darken($mutedBg, 5%);
+$mutedBorder:      darken(adjust_hue($mutedBg, -10), 7%);
 
-$warningText:            darken($orange, 5%);
-$warningTextHover:       darken($warningText, 10%);
-$warningBackground:      $pastelYellow;
-$warningBackgroundHover: darken($warningBackground, 5%);
-$warningBorder:          darken(adjust_hue($warningBackground, -10), 7%);
+$warningText:      darken($orange, 5%);
+$warningTextHover: darken($warningText, 10%);
+$warningBg:        $pastelYellow;
+$warningBgHover:   darken($warningBg, 5%);
+$warningBorder:    darken(adjust_hue($warningBg, -10), 7%);
 
-$errorText:              darken($red, 5%);
-$errorTextHover:         darken($errorText, 10%);
-$errorBackground:        $pastelRed;
-$errorBackgroundHover:   darken($errorBackground, 5%);
-$errorBorder:            darken(adjust_hue($errorBackground, -10), 7%);
+$dangerText:       darken($red, 5%);
+$dangerTextHover:  darken($dangerText, 10%);
+$dangerBg:         $pastelRed;
+$dangerBgHover:    darken($dangerBg, 5%);
+$dangerBorder:     darken(adjust_hue($dangerBg, -10), 7%);
 
-$infoText:               darken($blue, 5%);
-$infoTextHover:          darken($infoText, 10%);
-$infoBackground:         $pastelBlue;
-$infoBackgroundHover:    darken($infoBackground, 5%);
-$infoBorder:             darken(adjust_hue($infoBackground, -10), 7%);
+$infoText:         darken($blue, 5%);
+$infoTextHover:    darken($infoText, 10%);
+$infoBg:           $pastelBlue;
+$infoBgHover:      darken($infoBg, 5%);
+$infoBorder:       darken(adjust_hue($infoBg, -10), 7%);
 
-$successText:            darken($green, 5%);
-$successTextHover:       darken($successText, 10%);
-$successBackground:      $pastelGreen;
-$successBackgroundHover: darken($successBackground, 5%);
-$successBorder:          darken(adjust_hue($successBackground, -10), 7%);
+$successText:      darken($green, 5%);
+$successTextHover: darken($successText, 10%);
+$successBg:        $pastelGreen;
+$successBgHover:   darken($successBg, 5%);
+$successBorder:    darken(adjust_hue($successBg, -10), 7%);
 
 $tabBgColor:       $altBgColor;
 $tabBgColorHover:  darken($altBgColor, 5%);

--- a/assets/css/romo/base.scss
+++ b/assets/css/romo/base.scss
@@ -236,7 +236,7 @@ h3 { @include text1; }
 .romo-text-alt         { @include text-alt(!important); }
 .romo-text-muted       { @include text-muted(!important); }
 .romo-text-warning     { @include text-warning(!important); }
-.romo-text-error       { @include text-error(!important); }
+.romo-text-danger      { @include text-danger(!important); }
 .romo-text-info        { @include text-info(!important); }
 .romo-text-success     { @include text-success(!important); }
 .romo-text-inverse     { @include text-inverse(!important); }
@@ -253,8 +253,8 @@ h3 { @include text1; }
 .romo-text-warning-hover:hover, a.romo-text-warning:hover, a.romo-text-warning:focus {
   @include text-warning-hover(!important);
 }
-.romo-text-error-hover:hover, a.romo-text-error:hover, a.romo-text-error:focus {
-  @include text-error-hover(!important);
+.romo-text-danger-hover:hover, a.romo-text-danger:hover, a.romo-text-danger:focus {
+  @include text-danger-hover(!important);
 }
 .romo-text-info-hover:hover, a.romo-text-info:hover, a.romo-text-info:focus {
   @include text-info-hover(!important);
@@ -270,7 +270,7 @@ h3 { @include text1; }
 .romo-bg-alt     { @include bg-alt(!important); }
 .romo-bg-muted   { @include bg-muted(!important); }
 .romo-bg-warning { @include bg-warning(!important); }
-.romo-bg-error   { @include bg-error(!important); }
+.romo-bg-danger  { @include bg-danger(!important); }
 .romo-bg-info    { @include bg-info(!important); }
 .romo-bg-success { @include bg-success(!important); }
 .romo-bg-inverse { @include bg-inverse(!important); }
@@ -287,8 +287,8 @@ h3 { @include text1; }
 .romo-bg-warning-hover:hover, a.romo-bg-warning:hover, a.romo-bg-warning:focus {
   @include bg-warning-hover(!important);
 }
-.romo-bg-error-hover:hover, a.romo-bg-error:hover, a.romo-bg-error:focus {
-  @include bg-error-hover(!important);
+.romo-bg-danger-hover:hover, a.romo-bg-danger:hover, a.romo-bg-danger:focus {
+  @include bg-danger-hover(!important);
 }
 .romo-bg-info-hover:hover, a.romo-bg-info:hover, a.romo-bg-info:focus {
   @include bg-info-hover(!important);
@@ -302,7 +302,7 @@ h3 { @include text1; }
 
 .romo-border-muted   { @include border-muted(!important); }
 .romo-border-warning { @include border-warning(!important); }
-.romo-border-error   { @include border-error(!important); }
+.romo-border-danger  { @include border-danger(!important); }
 .romo-border-info    { @include border-info(!important); }
 .romo-border-success { @include border-success(!important); }
 .romo-border-inverse { @include border-inverse(!important); }
@@ -313,8 +313,8 @@ h3 { @include text1; }
 .romo-border-warning-hover:hover, a.romo-border-warning:hover, a.romo-border-warning:focus {
   @include border-warning(!important);
 }
-.romo-border-error-hover:hover, a.romo-border-error:hover, a.romo-border-error:focus {
-  @include border-error(!important);
+.romo-border-danger-hover:hover, a.romo-border-danger:hover, a.romo-border-danger:focus {
+  @include border-danger(!important);
 }
 .romo-border-info-hover:hover, a.romo-border-info:hover, a.romo-border-info:focus {
   @include border-info(!important);

--- a/assets/css/romo/buttons.scss
+++ b/assets/css/romo/buttons.scss
@@ -9,7 +9,7 @@ button.romo-btn,
   @include align-center;
   @include align-middle;
 
-  @include button-bg($btnBackground, $btnBackgroundHighlight, $btnColor);
+  @include button-bg($btnBg, $btnBgHighlight, $btnColor);
   @include border1;
   border-color: $btnBorder;
   border-bottom-color: darken($btnBorder, 10%);
@@ -79,76 +79,44 @@ input[type="reset"].romo-btn-block,
 input[type="button"].romo-btn-block,
 .romo-btn-block { display: block; width: 100%; }
 
-a.romo-btn.romo-btn-alt,
-button.romo-btn.romo-btn-alt,
-.romo-btn.romo-btn-alt     { @include button-bg($btnAltBackground,     $btnAltBackgroundHighlight,     $btnAltColor); }
-a.romo-btn.romo-btn-inverse,
-button.romo-btn.romo-btn-inverse,
-.romo-btn.romo-btn-inverse { @include button-bg($btnInverseBackground, $btnInverseBackgroundHighlight, $btnInverseColor); }
-a.romo-btn.romo-btn-warning,
-button.romo-btn.romo-btn-warning,
-.romo-btn.romo-btn-warning { @include button-bg($btnWarningBackground, $btnWarningBackgroundHighlight, $btnWarningColor); }
-a.romo-btn.romo-btn-error,
-button.romo-btn.romo-btn-error,
-.romo-btn.romo-btn-error,
-a.romo-btn.romo-btn-danger,
-button.romo-btn.romo-btn-danger,
-.romo-btn.romo-btn-danger  { @include button-bg($btnDangerBackground,  $btnDangerBackgroundHighlight,  $btnDangerColor); }
-a.romo-btn.romo-btn-info,
-button.romo-btn.romo-btn-info,
-.romo-btn.romo-btn-info    { @include button-bg($btnInfoBackground,    $btnInfoBackgroundHighlight,    $btnInfoColor); }
-a.romo-btn.romo-btn-success,
-button.romo-btn.romo-btn-success,
-.romo-btn.romo-btn-success { @include button-bg($btnSuccessBackground, $btnSuccessBackgroundHighlight, $btnSuccessColor); }
+/* implicit colored buttons */
 
-a.romo-btn.romo-btn-link,
-button.romo-btn.romo-btn-link,
-.romo-btn.romo-btn-link,
-a.romo-btn.romo-btn-link.active,
-button.romo-btn.romo-btn-link.active,
-.romo-btn.romo-btn-link.active,
-a.romo-btn.romo-btn-link:active,
-button.romo-btn.romo-btn-link:active,
-.romo-btn.romo-btn-link:active,
-a.romo-btn.romo-btn-link.disabled,
-button.romo-btn.romo-btn-link.disabled,
-.romo-btn.romo-btn-link.disabled,
-a.romo-btn.romo-btn-link[disabled],
-button.romo-btn.romo-btn-link[disabled],
-.romo-btn.romo-btn-link[disabled] {
+a.romo-btn.romo-btn-alt,     button.romo-btn.romo-btn-alt,     .romo-btn.romo-btn-alt     { @include button-bg($btnAltBg,     $btnAltBgHighlight,     $btnAltColor);     }
+a.romo-btn.romo-btn-inverse, button.romo-btn.romo-btn-inverse, .romo-btn.romo-btn-inverse { @include button-bg($btnInverseBg, $btnInverseBgHighlight, $btnInverseColor); }
+a.romo-btn.romo-btn-warning, button.romo-btn.romo-btn-warning, .romo-btn.romo-btn-warning { @include button-bg($btnWarningBg, $btnWarningBgHighlight, $btnWarningColor); }
+a.romo-btn.romo-btn-danger,  button.romo-btn.romo-btn-danger,  .romo-btn.romo-btn-danger  { @include button-bg($btnDangerBg,  $btnDangerBgHighlight,  $btnDangerColor);  }
+a.romo-btn.romo-btn-info,    button.romo-btn.romo-btn-info,    .romo-btn.romo-btn-info    { @include button-bg($btnInfoBg,    $btnInfoBgHighlight,    $btnInfoColor);    }
+a.romo-btn.romo-btn-success, button.romo-btn.romo-btn-success, .romo-btn.romo-btn-success { @include button-bg($btnSuccessBg, $btnSuccessBgHighlight, $btnSuccessColor); }
+
+/* link buttons */
+
+a.romo-btn.romo-btn-link,           button.romo-btn.romo-btn-link,           .romo-btn.romo-btn-link,
+a.romo-btn.romo-btn-link.active,    button.romo-btn.romo-btn-link.active,    .romo-btn.romo-btn-link.active,
+a.romo-btn.romo-btn-link:active,    button.romo-btn.romo-btn-link:active,    .romo-btn.romo-btn-link:active,
+a.romo-btn.romo-btn-link.disabled,  button.romo-btn.romo-btn-link.disabled,  .romo-btn.romo-btn-link.disabled,
+a.romo-btn.romo-btn-link[disabled], button.romo-btn.romo-btn-link[disabled], .romo-btn.romo-btn-link[disabled] {
   background-color: transparent;
   background-image: none;
   @include box-shadow(none);
 }
 
-a.romo-btn.romo-btn-link,
-button.romo-btn.romo-btn-link { color: $linkColor; }
-a.romo-btn.romo-btn-link:hover,
-button.romo-btn.romo-btn-link:hover,
-a.romo-btn.romo-btn-link:focus,
-button.romo-btn.romo-btn-link:focus {
+a.romo-btn.romo-btn-link, button.romo-btn.romo-btn-link { color: $linkColor; }
+
+a.romo-btn.romo-btn-link:hover, button.romo-btn.romo-btn-link:hover,
+a.romo-btn.romo-btn-link:focus, button.romo-btn.romo-btn-link:focus {
   color: $linkColorHover;
   text-decoration: underline;
   background-color: transparent;
 }
-a.romo-btn.romo-btn-link.disabled,
-button.romo-btn.romo-btn-link.disabled,
-.romo-btn.romo-btn-link.disabled,
-a.romo-btn.romo-btn-link.disabled:hover,
-button.romo-btn.romo-btn-link.disabled:hover,
-.romo-btn.romo-btn-link.disabled:hover,
-a.romo-btn.romo-btn-link.disabled:focus,
-button.romo-btn.romo-btn-link.disabled:focus,
-.romo-btn.romo-btn-link.disabled:focus,
-a.romo-btn.romo-btn-link[disabled],
-button.romo-btn.romo-btn-link[disabled],
-.romo-btn.romo-btn-link[disabled],
-a.romo-btn.romo-btn-link[disabled]:hover,
-button.romo-btn.romo-btn-link[disabled]:hover,
-.romo-btn.romo-btn-link[disabled]:hover,
-a.romo-btn.romo-btn-link[disabled]:focus,
-button.romo-btn.romo-btn-link[disabled]:focus,
-.romo-btn.romo-btn-link[disabled]:focus { color: $disabledColor; }
+
+a.romo-btn.romo-btn-link.disabled,        button.romo-btn.romo-btn-link.disabled, .romo-btn.romo-btn-link.disabled,
+a.romo-btn.romo-btn-link.disabled:hover,  button.romo-btn.romo-btn-link.disabled:hover, .romo-btn.romo-btn-link.disabled:hover,
+a.romo-btn.romo-btn-link.disabled:focus,  button.romo-btn.romo-btn-link.disabled:focus, .romo-btn.romo-btn-link.disabled:focus,
+a.romo-btn.romo-btn-link[disabled],       button.romo-btn.romo-btn-link[disabled],      .romo-btn.romo-btn-link[disabled],
+a.romo-btn.romo-btn-link[disabled]:hover, button.romo-btn.romo-btn-link[disabled]:hover, .romo-btn.romo-btn-link[disabled]:hover,
+a.romo-btn.romo-btn-link[disabled]:focus, button.romo-btn.romo-btn-link[disabled]:focus, .romo-btn.romo-btn-link[disabled]:focus {
+  color: $disabledColor;
+}
 
 .romo-btn-group { @include display-inline-flex(!important); }
 .romo-btn-group > * { display: inherit; }
@@ -165,8 +133,8 @@ button.romo-btn.romo-btn-link[disabled]:focus,
 .romo-btn-group.romo-btn-group-border0-radius .romo-btn:last-child { @include border0-top-right-radius; @include border0-bottom-right-radius; }
 .romo-btn-group.romo-btn-group-border2-radius .romo-btn:last-child { @include border2-top-right-radius; @include border2-bottom-right-radius; }
 
-.romo-btn-group-vertical { display: inline-block; }
-.romo-btn-group-vertical .romo-btn { display: block; max-width: 100%; }
+.romo-btn-group-vertical                            { display: inline-block; }
+.romo-btn-group-vertical .romo-btn                  { display: block; max-width: 100%; }
 .romo-btn-group-vertical .romo-btn:not(:last-child) { @include rm-border-bottom; }
 
 .romo-btn-group-vertical.romo-btn-group-border-radius  .romo-btn:first-child,
@@ -180,7 +148,7 @@ button.romo-btn.romo-btn-link[disabled]:focus,
 .romo-btn-group-vertical.romo-btn-group-border2-radius .romo-btn:last-child { @include border2-bottom-left-radius; @include border2-bottom-right-radius; }
 
 .romo-btn-group .romo-btn-group-vertical:not(:last-child) .romo-btn { @include rm-border-right; }
-.romo-btn-group .romo-btn-group-vertical:last-child .romo-btn { @include border1-right; }
+.romo-btn-group .romo-btn-group-vertical:last-child       .romo-btn { @include border1-right; }
 
 .romo-btn-group.romo-btn-group-border-radius  .romo-btn-group-vertical .romo-btn,
 .romo-btn-group.romo-btn-group-border1-radius .romo-btn-group-vertical .romo-btn { @include rm-border-radius; }

--- a/assets/css/romo/grid_table.scss
+++ b/assets/css/romo/grid_table.scss
@@ -31,12 +31,12 @@ ol.romo-grid-table { @include list-unstyled(!important); }
 .romo-grid-table-striped.romo-grid-table-header.romo-grid-table-striped-alt > .romo-row:nth-child(even) { @include bg-base; }
 .romo-grid-table-striped.romo-grid-table-striped-alt { @include bg-striped; }
 
-.romo-grid-table .romo-row.romo-base    { @include bg-base(!important); }
-.romo-grid-table .romo-row.romo-alt     { @include bg-alt(!important); }
-.romo-grid-table .romo-row.romo-muted   { @include bg-muted(!important); }
+.romo-grid-table .romo-row.romo-base    { @include bg-base(!important);    }
+.romo-grid-table .romo-row.romo-alt     { @include bg-alt(!important);     }
+.romo-grid-table .romo-row.romo-muted   { @include bg-muted(!important);   }
 .romo-grid-table .romo-row.romo-warning { @include bg-warning(!important); }
-.romo-grid-table .romo-row.romo-error   { @include bg-error(!important); }
-.romo-grid-table .romo-row.romo-info    { @include bg-info(!important); }
+.romo-grid-table .romo-row.romo-danger  { @include bg-danger(!important);  }
+.romo-grid-table .romo-row.romo-info    { @include bg-info(!important);    }
 .romo-grid-table .romo-row.romo-success { @include bg-success(!important); }
 .romo-grid-table .romo-row.romo-inverse { @include bg-inverse(!important); }
 
@@ -48,32 +48,32 @@ ol.romo-grid-table { @include list-unstyled(!important); }
 .romo-grid-table-hover.romo-grid-table-header.romo-grid-table-alt > .romo-row:not(:first-child):hover { @include bg-hover; }
 
 .romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-base:hover,
-.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-base:not(:first-child):hover { @include bg-base-hover(!important); }
+.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-base:not(:first-child):hover    { @include bg-base-hover(!important);    }
 .romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-alt:hover,
-.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-alt:not(:first-child):hover { @include bg-alt-hover(!important); }
+.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-alt:not(:first-child):hover     { @include bg-alt-hover(!important);     }
 .romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-muted:hover,
-.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-muted:not(:first-child):hover { @include bg-muted-hover(!important); }
+.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-muted:not(:first-child):hover   { @include bg-muted-hover(!important);   }
 .romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-warning:hover,
 .romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-warning:not(:first-child):hover { @include bg-warning-hover(!important); }
-.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-error:hover,
-.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-error:not(:first-child):hover { @include bg-error-hover(!important); }
+.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-danger:hover,
+.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-danger:not(:first-child):hover  { @include bg-danger-hover(!important);  }
 .romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-info:hover,
-.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-info:not(:first-child):hover { @include bg-info-hover(!important); }
+.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-info:not(:first-child):hover    { @include bg-info-hover(!important);    }
 .romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-success:hover,
 .romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-success:not(:first-child):hover { @include bg-success-hover(!important); }
 .romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-inverse:hover,
 .romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-inverse:not(:first-child):hover { @include bg-inverse-hover(!important); }
 
 .romo-grid-table-border,
-.romo-grid-table-border1     { @include border1; }
-.romo-grid-table-border0     { @include border0; }
-.romo-grid-table-border2     { @include border2; }
+.romo-grid-table-border1     { @include border1;            }
+.romo-grid-table-border0     { @include border0;            }
+.romo-grid-table-border2     { @include border2;            }
 .romo-grid-table-border-none { @include border-style(none); }
 
 .romo-grid-table.romo-grid-table-border      > .romo-row,
-.romo-grid-table.romo-grid-table-border1     > .romo-row { @include border1-bottom; }
-.romo-grid-table.romo-grid-table-border0     > .romo-row { @include border0-bottom; }
-.romo-grid-table.romo-grid-table-border2     > .romo-row { @include border2-bottom; }
+.romo-grid-table.romo-grid-table-border1     > .romo-row { @include border1-bottom;     }
+.romo-grid-table.romo-grid-table-border0     > .romo-row { @include border0-bottom;     }
+.romo-grid-table.romo-grid-table-border2     > .romo-row { @include border2-bottom;     }
 .romo-grid-table.romo-grid-table-border-none > .romo-row { @include border-style(none); }
 
 .romo-grid-table.romo-grid-table-border      > .romo-row > .romo-span,
@@ -85,56 +85,56 @@ ol.romo-grid-table { @include list-unstyled(!important); }
 .romo-grid-table[class*="romo-grid-table-border"] > .romo-row > .romo-span:last-child { @include rm-border-right; }
 .romo-grid-table[class*="romo-grid-table-border"] > .romo-row:last-child { @include rm-border-bottom; }
 
-.romo-grid-table-border-muted   { @include border-muted; }
+.romo-grid-table-border-muted   { @include border-muted;   }
 .romo-grid-table-border-warning { @include border-warning; }
-.romo-grid-table-border-error   { @include border-error; }
-.romo-grid-table-border-info    { @include border-info; }
+.romo-grid-table-border-danger  { @include border-danger;  }
+.romo-grid-table-border-info    { @include border-info;    }
 .romo-grid-table-border-success { @include border-success; }
 .romo-grid-table-border-inverse { @include border-inverse; }
-.romo-grid-table-border-alt     { @include border-alt; }
+.romo-grid-table-border-alt     { @include border-alt;     }
 
-.romo-grid-table-border-muted   > .romo-row { @include border-muted; }
+.romo-grid-table-border-muted   > .romo-row { @include border-muted;   }
 .romo-grid-table-border-warning > .romo-row { @include border-warning; }
-.romo-grid-table-border-error   > .romo-row { @include border-error; }
-.romo-grid-table-border-info    > .romo-row { @include border-info; }
+.romo-grid-table-border-danger  > .romo-row { @include border-danger;  }
+.romo-grid-table-border-info    > .romo-row { @include border-info;    }
 .romo-grid-table-border-success > .romo-row { @include border-success; }
 .romo-grid-table-border-inverse > .romo-row { @include border-inverse; }
-.romo-grid-table-border-alt     > .romo-row { @include border-alt; }
+.romo-grid-table-border-alt     > .romo-row { @include border-alt;     }
 
-.romo-grid-table-border-muted   > .romo-row > .romo-span { @include border-muted; }
+.romo-grid-table-border-muted   > .romo-row > .romo-span { @include border-muted;   }
 .romo-grid-table-border-warning > .romo-row > .romo-span { @include border-warning; }
-.romo-grid-table-border-error   > .romo-row > .romo-span { @include border-error; }
-.romo-grid-table-border-info    > .romo-row > .romo-span { @include border-info; }
+.romo-grid-table-border-danger  > .romo-row > .romo-span { @include border-danger;  }
+.romo-grid-table-border-info    > .romo-row > .romo-span { @include border-info;    }
 .romo-grid-table-border-success > .romo-row > .romo-span { @include border-success; }
 .romo-grid-table-border-inverse > .romo-row > .romo-span { @include border-inverse; }
-.romo-grid-table-border-alt     > .romo-row > .romo-span { @include border-alt; }
+.romo-grid-table-border-alt     > .romo-row > .romo-span { @include border-alt;     }
 
 .romo-grid-table.romo-grid-table-pad    > .romo-row > .romo-span,
-.romo-grid-table.romo-grid-table-pad1   > .romo-row > .romo-span { @include pad1; }
-.romo-grid-table.romo-grid-table-pad0   > .romo-row > .romo-span { @include pad0; }
-.romo-grid-table.romo-grid-table-pad2   > .romo-row > .romo-span { @include pad2; }
+.romo-grid-table.romo-grid-table-pad1   > .romo-row > .romo-span { @include pad1;   }
+.romo-grid-table.romo-grid-table-pad0   > .romo-row > .romo-span { @include pad0;   }
+.romo-grid-table.romo-grid-table-pad2   > .romo-row > .romo-span { @include pad2;   }
 .romo-grid-table.romo-grid-table-rm-pad > .romo-row > .romo-span { @include rm-pad; }
 
 .romo-grid-table.romo-table-pad-top    > .romo-row > .romo-span,
-.romo-grid-table.romo-table-pad1-top   > .romo-row > .romo-span { @include pad1-top; }
-.romo-grid-table.romo-table-pad0-top   > .romo-row > .romo-span { @include pad0-top; }
-.romo-grid-table.romo-table-pad2-top   > .romo-row > .romo-span { @include pad2-top; }
+.romo-grid-table.romo-table-pad1-top   > .romo-row > .romo-span { @include pad1-top;   }
+.romo-grid-table.romo-table-pad0-top   > .romo-row > .romo-span { @include pad0-top;   }
+.romo-grid-table.romo-table-pad2-top   > .romo-row > .romo-span { @include pad2-top;   }
 .romo-grid-table.romo-table-rm-pad-top > .romo-row > .romo-span { @include rm-pad-top; }
 
 .romo-grid-table.romo-table-pad-right    > .romo-row > .romo-span,
-.romo-grid-table.romo-table-pad1-right   > .romo-row > .romo-span { @include pad1-right; }
-.romo-grid-table.romo-table-pad0-right   > .romo-row > .romo-span { @include pad0-right; }
-.romo-grid-table.romo-table-pad2-right   > .romo-row > .romo-span { @include pad2-right; }
+.romo-grid-table.romo-table-pad1-right   > .romo-row > .romo-span { @include pad1-right;   }
+.romo-grid-table.romo-table-pad0-right   > .romo-row > .romo-span { @include pad0-right;   }
+.romo-grid-table.romo-table-pad2-right   > .romo-row > .romo-span { @include pad2-right;   }
 .romo-grid-table.romo-table-rm-pad-right > .romo-row > .romo-span { @include rm-pad-right; }
 
 .romo-grid-table.romo-table-pad-bottom    > .romo-row > .romo-span,
-.romo-grid-table.romo-table-pad1-bottom   > .romo-row > .romo-span { @include pad1-bottom; }
-.romo-grid-table.romo-table-pad0-bottom   > .romo-row > .romo-span { @include pad0-bottom; }
-.romo-grid-table.romo-table-pad2-bottom   > .romo-row > .romo-span { @include pad2-bottom; }
+.romo-grid-table.romo-table-pad1-bottom   > .romo-row > .romo-span { @include pad1-bottom;   }
+.romo-grid-table.romo-table-pad0-bottom   > .romo-row > .romo-span { @include pad0-bottom;   }
+.romo-grid-table.romo-table-pad2-bottom   > .romo-row > .romo-span { @include pad2-bottom;   }
 .romo-grid-table.romo-table-rm-pad-bottom > .romo-row > .romo-span { @include rm-pad-bottom; }
 
 .romo-grid-table.romo-table-pad-left    > .romo-row > .romo-span,
-.romo-grid-table.romo-table-pad1-left   > .romo-row > .romo-span { @include pad1-left; }
-.romo-grid-table.romo-table-pad0-left   > .romo-row > .romo-span { @include pad0-left; }
-.romo-grid-table.romo-table-pad2-left   > .romo-row > .romo-span { @include pad2-left; }
+.romo-grid-table.romo-table-pad1-left   > .romo-row > .romo-span { @include pad1-left;   }
+.romo-grid-table.romo-table-pad0-left   > .romo-row > .romo-span { @include pad0-left;   }
+.romo-grid-table.romo-table-pad2-left   > .romo-row > .romo-span { @include pad2-left;   }
 .romo-grid-table.romo-table-rm-pad-left > .romo-row > .romo-span { @include rm-pad-left; }

--- a/assets/css/romo/labels.scss
+++ b/assets/css/romo/labels.scss
@@ -2,11 +2,12 @@
 @import 'css/romo/mixins';
 
 .romo-label {
-  display: inline-block;
-  font-size: $baseFontSize;
-  line-height: $baseLineHeight;
-  background-color: $btnAltBackgroundHighlight;
-  color: $btnAltColor;
+  display:          inline-block;
+  font-size:        $baseFontSize;
+  line-height:      $baseLineHeight;
+  background-color: $btnAltBgHighlight;
+  color:            $btnAltColor;
+
   @include label-pad($baseLineHeight);
   @include rm-push;
   @include align-center;
@@ -31,10 +32,9 @@
 
 .romo-label-block { display: block; width: 100%; }
 
-.romo-label.romo-label-alt     { background-color: $btnBackground;        color: $btnColor; }
-.romo-label.romo-label-inverse { background-color: $btnInverseBackground; color: $btnInverseColor; }
-.romo-label.romo-label-warning { background-color: $btnWarningBackground; color: $btnWarningColor; }
-.romo-label.romo-label-error,
-.romo-label.romo-label-danger  { background-color: $btnDangerBackground;  color: $btnDangerColor; }
-.romo-label.romo-label-info    { background-color: $btnInfoBackground;    color: $btnInfoColor; }
-.romo-label.romo-label-success { background-color: $btnSuccessBackground; color: $btnSuccessColor; }
+.romo-label.romo-label-alt     { background-color: $btnBg;        color: $btnColor; }
+.romo-label.romo-label-inverse { background-color: $btnInverseBg; color: $btnInverseColor; }
+.romo-label.romo-label-warning { background-color: $btnWarningBg; color: $btnWarningColor; }
+.romo-label.romo-label-danger  { background-color: $btnDangerBg;  color: $btnDangerColor; }
+.romo-label.romo-label-info    { background-color: $btnInfoBg;    color: $btnInfoColor; }
+.romo-label.romo-label-success { background-color: $btnSuccessBg; color: $btnSuccessColor; }

--- a/assets/css/romo/table.scss
+++ b/assets/css/romo/table.scss
@@ -21,12 +21,12 @@
 .romo-table-striped.romo-table-striped-alt tbody > tr:nth-child(odd) { @include bg-base; }
 .romo-table-striped.romo-table-striped-alt { @include bg-striped; }
 
-.romo-table tr.romo-base    { @include bg-base(!important); }
-.romo-table tr.romo-alt     { @include bg-alt(!important); }
-.romo-table tr.romo-muted   { @include bg-muted(!important); }
+.romo-table tr.romo-base    { @include bg-base(!important);    }
+.romo-table tr.romo-alt     { @include bg-alt(!important);     }
+.romo-table tr.romo-muted   { @include bg-muted(!important);   }
 .romo-table tr.romo-warning { @include bg-warning(!important); }
-.romo-table tr.romo-error   { @include bg-error(!important); }
-.romo-table tr.romo-info    { @include bg-info(!important); }
+.romo-table tr.romo-danger  { @include bg-danger(!important);  }
+.romo-table tr.romo-info    { @include bg-info(!important);    }
 .romo-table tr.romo-success { @include bg-success(!important); }
 .romo-table tr.romo-inverse { @include bg-inverse(!important); }
 
@@ -35,12 +35,12 @@
 .romo-table-hover.romo-table-striped tbody tr:hover,
 .romo-table-hover.romo-table-striped-alt tbody tr:hover { @include bg-hover; }
 
-.romo-table-hover tbody tr.romo-base:hover    { @include bg-base-hover(!important); }
-.romo-table-hover tbody tr.romo-alt:hover     { @include bg-alt-hover(!important); }
-.romo-table-hover tbody tr.romo-muted:hover   { @include bg-muted-hover(!important); }
+.romo-table-hover tbody tr.romo-base:hover    { @include bg-base-hover(!important);    }
+.romo-table-hover tbody tr.romo-alt:hover     { @include bg-alt-hover(!important);     }
+.romo-table-hover tbody tr.romo-muted:hover   { @include bg-muted-hover(!important);   }
 .romo-table-hover tbody tr.romo-warning:hover { @include bg-warning-hover(!important); }
-.romo-table-hover tbody tr.romo-error:hover   { @include bg-error-hover(!important); }
-.romo-table-hover tbody tr.romo-info:hover    { @include bg-info-hover(!important); }
+.romo-table-hover tbody tr.romo-danger:hover  { @include bg-danger-hover(!important);  }
+.romo-table-hover tbody tr.romo-info:hover    { @include bg-info-hover(!important);    }
 .romo-table-hover tbody tr.romo-success:hover { @include bg-success-hover(!important); }
 .romo-table-hover tbody tr.romo-inverse:hover { @include bg-inverse-hover(!important); }
 
@@ -62,50 +62,50 @@
 .romo-table-border2     th, .romo-table-border2     td { @include border2-bottom; @include border2-right; }
 .romo-table-border-none th, .romo-table-border-none td { @include border-style(none); }
 
-.romo-table-border-base    { @include border-base; }
-.romo-table-border-alt     { @include border-alt; }
-.romo-table-border-muted   { @include border-muted; }
+.romo-table-border-base    { @include border-base;    }
+.romo-table-border-alt     { @include border-alt;     }
+.romo-table-border-muted   { @include border-muted;   }
 .romo-table-border-warning { @include border-warning; }
-.romo-table-border-error   { @include border-error; }
-.romo-table-border-info    { @include border-info; }
+.romo-table-border-danger  { @include border-danger;  }
+.romo-table-border-info    { @include border-info;    }
 .romo-table-border-success { @include border-success; }
 .romo-table-border-inverse { @include border-inverse; }
 
-.romo-table-border-base    th, .romo-table-border-base    td { @include border-base; }
-.romo-table-border-alt     th, .romo-table-border-alt     td { @include border-alt; }
-.romo-table-border-muted   th, .romo-table-border-muted   td { @include border-muted; }
+.romo-table-border-base    th, .romo-table-border-base    td { @include border-base;    }
+.romo-table-border-alt     th, .romo-table-border-alt     td { @include border-alt;     }
+.romo-table-border-muted   th, .romo-table-border-muted   td { @include border-muted;   }
 .romo-table-border-warning th, .romo-table-border-warning td { @include border-warning; }
-.romo-table-border-error   th, .romo-table-border-error   td { @include border-error; }
-.romo-table-border-info    th, .romo-table-border-info    td { @include border-info; }
+.romo-table-border-danger  th, .romo-table-border-danger  td { @include border-danger;  }
+.romo-table-border-info    th, .romo-table-border-info    td { @include border-info;    }
 .romo-table-border-success th, .romo-table-border-success td { @include border-success; }
 .romo-table-border-inverse th, .romo-table-border-inverse td { @include border-inverse; }
 
 .romo-table-pad    th, .romo-table-pad    td,
-.romo-table-pad1   th, .romo-table-pad1   td { @include pad1; }
-.romo-table-pad0   th, .romo-table-pad0   td { @include pad0; }
-.romo-table-pad2   th, .romo-table-pad2   td { @include pad2; }
+.romo-table-pad1   th, .romo-table-pad1   td { @include pad1;   }
+.romo-table-pad0   th, .romo-table-pad0   td { @include pad0;   }
+.romo-table-pad2   th, .romo-table-pad2   td { @include pad2;   }
 .romo-table-rm-pad th, .romo-table-rm-pad td { @include rm-pad; }
 
 .romo-table-pad-top    th, .romo-table-pad-top    td,
-.romo-table-pad1-top   th, .romo-table-pad1-top   td { @include pad1-top; }
-.romo-table-pad0-top   th, .romo-table-pad0-top   td { @include pad0-top; }
-.romo-table-pad2-top   th, .romo-table-pad2-top   td { @include pad2-top; }
+.romo-table-pad1-top   th, .romo-table-pad1-top   td { @include pad1-top;   }
+.romo-table-pad0-top   th, .romo-table-pad0-top   td { @include pad0-top;   }
+.romo-table-pad2-top   th, .romo-table-pad2-top   td { @include pad2-top;   }
 .romo-table-rm-pad-top th, .romo-table-rm-pad-top td { @include rm-pad-top; }
 
 .romo-table-pad-right    th, .romo-table-pad-right    td,
-.romo-table-pad1-right   th, .romo-table-pad1-right   td { @include pad1-right; }
-.romo-table-pad0-right   th, .romo-table-pad0-right   td { @include pad0-right; }
-.romo-table-pad2-right   th, .romo-table-pad2-right   td { @include pad2-right; }
+.romo-table-pad1-right   th, .romo-table-pad1-right   td { @include pad1-right;   }
+.romo-table-pad0-right   th, .romo-table-pad0-right   td { @include pad0-right;   }
+.romo-table-pad2-right   th, .romo-table-pad2-right   td { @include pad2-right;   }
 .romo-table-rm-pad-right th, .romo-table-rm-pad-right td { @include rm-pad-right; }
 
 .romo-table-pad-bottom    th, .romo-table-pad-bottom    td,
-.romo-table-pad1-bottom   th, .romo-table-pad1-bottom   td { @include pad1-bottom; }
-.romo-table-pad0-bottom   th, .romo-table-pad0-bottom   td { @include pad0-bottom; }
-.romo-table-pad2-bottom   th, .romo-table-pad2-bottom   td { @include pad2-bottom; }
+.romo-table-pad1-bottom   th, .romo-table-pad1-bottom   td { @include pad1-bottom;   }
+.romo-table-pad0-bottom   th, .romo-table-pad0-bottom   td { @include pad0-bottom;   }
+.romo-table-pad2-bottom   th, .romo-table-pad2-bottom   td { @include pad2-bottom;   }
 .romo-table-rm-pad-bottom th, .romo-table-rm-pad-bottom td { @include rm-pad-bottom; }
 
 .romo-table-pad-left    th, .romo-table-pad-left    td,
-.romo-table-pad1-left   th, .romo-table-pad1-left   td { @include pad1-left; }
-.romo-table-pad0-left   th, .romo-table-pad0-left   td { @include pad0-left; }
-.romo-table-pad2-left   th, .romo-table-pad2-left   td { @include pad2-left; }
+.romo-table-pad1-left   th, .romo-table-pad1-left   td { @include pad1-left;   }
+.romo-table-pad0-left   th, .romo-table-pad0-left   td { @include pad0-left;   }
+.romo-table-pad2-left   th, .romo-table-pad2-left   td { @include pad2-left;   }
 .romo-table-rm-pad-left th, .romo-table-rm-pad-left td { @include rm-pad-left; }

--- a/gh-pages/view_handlers/css/buttons.md
+++ b/gh-pages/view_handlers/css/buttons.md
@@ -223,9 +223,9 @@ Use these as an alternative to the default styles and to add color emphasis to b
         <td><button href="#" class="romo-btn romo-btn-danger romo-btn-large disabled">Danger</button></td>
         <td><button href="#" class="romo-btn romo-btn-danger romo-btn-large active">Danger</button></td>
         <td><button href="#" class="romo-btn romo-btn-danger romo-btn-large">Danger</button></td>
-        <td><button href="#" class="romo-btn romo-btn-error" >Danger</button></td>
-        <td><button href="#" class="romo-btn romo-btn-error romo-btn-small" >Danger</button></td>
-        <td><code>romo-btn romo-btn-danger</code><br/>Or, <code>romo-btn romo-btn-error</code></td>
+        <td><button href="#" class="romo-btn romo-btn-danger">Danger</button></td>
+        <td><button href="#" class="romo-btn romo-btn-danger romo-btn-small" >Danger</button></td>
+        <td><code>romo-btn romo-btn-danger</code></td>
       </tr>
       <tr>
         <td><button href="#" class="romo-btn romo-btn-info romo-btn-large disabled">Info</button></td>

--- a/gh-pages/view_handlers/css/forms.md
+++ b/gh-pages/view_handlers/css/forms.md
@@ -239,7 +239,7 @@ Use `.romo-input-help` spans with color emphasis to show help text
   <form class="romo-form">
     <label for="text3">Input name</label>
     <input id="text3" type="text" placeholder="Type something…" />
-    <span class="romo-input-help romo-text-error">Example error message</span>
+    <span class="romo-input-help romo-text-danger">Example error message</span>
   </form>
 </div>
 
@@ -247,7 +247,7 @@ Use `.romo-input-help` spans with color emphasis to show help text
 <form class="romo-form">
   <label>Input name</label>
   <input type="text" placeholder="Type something…" />
-  <span class="romo-input-help romo-text-error">Example error message</span>
+  <span class="romo-input-help romo-text-danger">Example error message</span>
 </form>
 ```
 

--- a/gh-pages/view_handlers/css/grid_tables.md
+++ b/gh-pages/view_handlers/css/grid_tables.md
@@ -232,7 +232,7 @@ Uses the alternate bg color for the table background.
 </ul>
 ```
 
-### `.romo-row.romo-{muted|warning|error|info|success|inverse}`
+### `.romo-row.romo-{muted|warning|danger|info|success|inverse}`
 
 Add color emphasis to grid table rows.
 
@@ -268,7 +268,7 @@ Add color emphasis to grid table rows.
       <span class="romo-span romo-5-12">jane-doe</span>
       <span class="romo-span romo-1-12">18</span>
     </li>
-    <li class="romo-row romo-error">
+    <li class="romo-row romo-danger">
       <span class="romo-span romo-1-12">3</span>
       <span class="romo-span romo-5-12">Good Corp.</span>
       <span class="romo-span romo-5-12">good-corp</span>
@@ -302,7 +302,7 @@ Add color emphasis to grid table rows.
   <li class="romo-row romo-alt">...</li>
   <li class="romo-row romo-muted">...</li>
   <li class="romo-row romo-warning">...</li>
-  <li class="romo-row romo-error">...</li>
+  <li class="romo-row romo-danger">...</li>
   <li class="romo-row romo-info">...</li>
   <li class="romo-row romo-success">...</li>
   <li class="romo-row romo-inverse romo-text-inverse">...</li>
@@ -548,7 +548,7 @@ Add hover state to rows
       <span class="romo-span romo-5-12">jane-doe</span>
       <span class="romo-span romo-1-12">18</span>
     </li>
-    <li class="romo-row romo-error">
+    <li class="romo-row romo-danger">
       <span class="romo-span romo-1-12">3</span>
       <span class="romo-span romo-5-12">Good Corp.</span>
       <span class="romo-span romo-5-12">good-corp</span>
@@ -581,7 +581,7 @@ Add hover state to rows
   <li class="romo-row romo-alt">...</li>
   <li class="romo-row romo-muted">...</li>
   <li class="romo-row romo-warning">...</li>
-  <li class="romo-row romo-error">...</li>
+  <li class="romo-row romo-danger">...</li>
   <li class="romo-row romo-info">...</li>
   <li class="romo-row romo-success">...</li>
   <li class="romo-row romo-inverse romo-text-inverse">...</li>
@@ -620,7 +620,7 @@ Add hover state to rows
       <span class="romo-span romo-5-12">jane-doe</span>
       <span class="romo-span romo-1-12">18</span>
     </li>
-    <li class="romo-row romo-error">
+    <li class="romo-row romo-danger">
       <span class="romo-span romo-1-12">3</span>
       <span class="romo-span romo-5-12">Good Corp.</span>
       <span class="romo-span romo-5-12">good-corp</span>
@@ -654,7 +654,7 @@ Add hover state to rows
   <li class="romo-row romo-alt">...</li>
   <li class="romo-row romo-muted">...</li>
   <li class="romo-row romo-warning">...</li>
-  <li class="romo-row romo-error">...</li>
+  <li class="romo-row romo-danger">...</li>
   <li class="romo-row romo-info">...</li>
   <li class="romo-row romo-success">...</li>
   <li class="romo-row romo-inverse romo-text-inverse">...</li>
@@ -830,7 +830,7 @@ Remove all borders from the grid table.
 </ul>
 ```
 
-### `.romo-grid-table-border-{muted|warning|error|info|success|inverse}`
+### `.romo-grid-table-border-{muted|warning|danger|info|success|inverse}`
 
 Adds border color emphasis to the entire grid table.
 
@@ -951,7 +951,7 @@ Adds border color emphasis to the entire grid table.
 </div>
 
 <div class="romo-pad2-bottom">
-  <ul class="romo-grid-table romo-grid-table-header romo-grid-table-border2 romo-grid-table-border-error">
+  <ul class="romo-grid-table romo-grid-table-header romo-grid-table-border2 romo-grid-table-border-danger">
     <li class="romo-row">
       <span class="romo-span romo-1-12">#</span>
       <span class="romo-span romo-5-12">Name</span>
@@ -1067,7 +1067,7 @@ Adds border color emphasis to the entire grid table.
 </div>
 
 ```html
-<ul class="romo-grid-table romo-grid-table-border-{base|alt|muted|warning|error|info|success|inverse}">
+<ul class="romo-grid-table romo-grid-table-border-{base|alt|muted|warning|danger|info|success|inverse}">
   ...
 </ul>
 ```
@@ -1277,7 +1277,7 @@ Use any helper style classes in any combination on rows/cells.
       <span class="romo-span romo-1-12">1</span>
       <span class="romo-span romo-5-12 romo-bg-info">Joe Test</span>
       <span class="romo-span romo-5-12">joe-test</span>
-      <span class="romo-span romo-1-12 romo-span romo-1-12 romo-text2 romo-border-error romo-border4">10</span>
+      <span class="romo-span romo-1-12 romo-span romo-1-12 romo-text2 romo-border-danger romo-border4">10</span>
     </li>
     <li class="romo-row">
       <span class="romo-span romo-1-12">2</span>
@@ -1312,7 +1312,7 @@ Use any helper style classes in any combination on rows/cells.
     <span class="romo-span romo-1-12">1</span>
     <span class="romo-span romo-5-12 romo-bg-info">Joe Test</span>
     <span class="romo-span romo-5-12">joe-test</span>
-    <span class="romo-span romo-1-12 romo-span romo-1-12 romo-text2 romo-border-error romo-border4">10</span>
+    <span class="romo-span romo-1-12 romo-span romo-1-12 romo-text2 romo-border-danger romo-border4">10</span>
   </li>
   <li class="romo-row">
     <span class="romo-span romo-1-12">2</span>

--- a/gh-pages/view_handlers/css/helpers.md
+++ b/gh-pages/view_handlers/css/helpers.md
@@ -121,13 +121,13 @@ Add color emphasis to any border configuration
 <div>
   <div class="romo-border-muted romo-border2 romo-push0-bottom">.romo-border-muted</div>
   <div class="romo-border-warning romo-border2 romo-push0-bottom">.romo-border-warning</div>
-  <div class="romo-border-error romo-border2 romo-push0-bottom">.romo-border-error</div>
+  <div class="romo-border-danger romo-border2 romo-push0-bottom">.romo-border-danger</div>
   <div class="romo-border-info romo-border2 romo-push0-bottom">.romo-border-info</div>
   <div class="romo-border-success romo-border2 romo-push0-bottom">.romo-border-success</div>
   <div class="romo-border-inverse romo-border2 romo-push0-bottom">.romo-border-inverse</div>
   <div class="romo-border-muted-hover romo-border2 romo-push0-bottom">.romo-border-muted-hover</div>
   <div class="romo-border-warning-hover romo-border2 romo-push0-bottom">.romo-border-warning-hover</div>
-  <div class="romo-border-error-hover romo-border2 romo-push0-bottom">.romo-border-error-hover</div>
+  <div class="romo-border-danger-hover romo-border2 romo-push0-bottom">.romo-border-danger-hover</div>
   <div class="romo-border-info-hover romo-border2 romo-push0-bottom">.romo-border-info-hover</div>
   <div class="romo-border-success-hover romo-border2 romo-push0-bottom">.romo-border-success-hover</div>
   <div class="romo-border-inverse-hover romo-border2">.romo-border-inverse-hover</div>
@@ -136,13 +136,13 @@ Add color emphasis to any border configuration
 ```html
 <div class="romo-border-muted">...</div>
 <div class="romo-border-warning">...</div>
-<div class="romo-border-error">...</div>
+<div class="romo-border-danger">...</div>
 <div class="romo-border-info">...</div>
 <div class="romo-border-success">...</div>
 <div class="romo-border-inverse">...</div>
 <div class="romo-border-muted-hover">...</div>
 <div class="romo-border-warning-hover">...</div>
-<div class="romo-border-error-hover">...</div>
+<div class="romo-border-danger-hover">...</div>
 <div class="romo-border-info-hover">...</div>
 <div class="romo-border-success-hover">...</div>
 <div class="romo-border-inverse-hover">...</div>

--- a/gh-pages/view_handlers/css/labels.md
+++ b/gh-pages/view_handlers/css/labels.md
@@ -183,9 +183,9 @@ Use these as an alternative to the default styles and to add color emphasis to l
       </tr>
       <tr>
         <td><span class="romo-label romo-label-danger romo-label-large">Danger</span></td>
-        <td><span class="romo-label romo-label-danger ">Danger</span></td>
-        <td><span class="romo-label romo-label-error romo-label-small">Danger</span></td>
-        <td><code>romo-label romo-label-danger</code><br/>Or, <code>romo-label romo-label-error</code></td>
+        <td><span class="romo-label romo-label-danger">Danger</span></td>
+        <td><span class="romo-label romo-label-danger romo-label-small">Danger</span></td>
+        <td><code>romo-label romo-label-danger</code></td>
       </tr>
       <tr>
         <td><span class="romo-label romo-label-info romo-label-large">Info</span></td>

--- a/gh-pages/view_handlers/css/tables.md
+++ b/gh-pages/view_handlers/css/tables.md
@@ -283,7 +283,7 @@ Uses the alternate bg color for the table background.
 </table>
 ```
 
-### `tr.romo-{muted|warning|error|info|success|inverse}`
+### `tr.romo-{muted|warning|danger|info|success|inverse}`
 
 Add color emphasis to rows.
 
@@ -322,7 +322,7 @@ Add color emphasis to rows.
         <td>jane-doe</td>
         <td>18</td>
       </tr>
-      <tr class="romo-error">
+      <tr class="romo-danger">
         <td>3</td>
         <td>Good Corp.</td>
         <td>good-corp</td>
@@ -357,7 +357,7 @@ Add color emphasis to rows.
   <tr class="romo-alt">...</tr>
   <tr class="romo-muted romo-text-muted">...</tr>
   <tr class="romo-warning">...</tr>
-  <tr class="romo-error">...</tr>
+  <tr class="romo-danger">...</tr>
   <tr class="romo-info">...</tr>
   <tr class="romo-success">...</tr>
   <tr class="romo-inverse romo-text-inverse">...</tr>
@@ -553,7 +553,7 @@ Add hover state to rows within a `<tbody>`.
         <td>jane-doe</td>
         <td>18</td>
       </tr>
-      <tr class="romo-error">
+      <tr class="romo-danger">
         <td>3</td>
         <td>Good Corp.</td>
         <td>good-corp</td>
@@ -588,7 +588,7 @@ Add hover state to rows within a `<tbody>`.
   <tr class="romo-alt">...</tr>
   <tr class="romo-muted romo-text-muted">...</tr>
   <tr class="romo-warning">...</tr>
-  <tr class="romo-error">...</tr>
+  <tr class="romo-danger">...</tr>
   <tr class="romo-info">...</tr>
   <tr class="romo-success">...</tr>
   <tr class="romo-inverse romo-text-inverse">...</tr>
@@ -795,7 +795,7 @@ Remove all borders from the table.
 </table>
 ```
 
-### `.romo-table-border-{muted|warning|error|info|success|inverse}`
+### `.romo-table-border-{muted|warning|danger|info|success|inverse}`
 
 Adds border color empasis to the entire table.
 
@@ -932,7 +932,7 @@ Adds border color empasis to the entire table.
 </div>
 
 <div class="romo-push2-bottom">
-  <table class="romo-table romo-table-border2 romo-table-border-error">
+  <table class="romo-table romo-table-border2 romo-table-border-danger">
     <thead>
       <tr>
         <th>#</th>
@@ -1064,7 +1064,7 @@ Adds border color empasis to the entire table.
 </div>
 
 ```html
-<table class="romo-table romo-table-border2 romo-table-border-{base|alt|muted|warning|error|info|success|inverse}">
+<table class="romo-table romo-table-border2 romo-table-border-{base|alt|muted|warning|danger|info|success|inverse}">
   ...
 </table>
 ```
@@ -1248,7 +1248,7 @@ Use any helper style classes in any combination on rows/cells.
         <td>1</td>
         <td class="romo-bg-info">Joe Test</td>
         <td>joe-test</td>
-        <td class="romo-1-12 romo-text2 romo-border-error romo-border4">10</td>
+        <td class="romo-1-12 romo-text2 romo-border-danger romo-border4">10</td>
       </tr>
       <tr>
         <td>2</td>
@@ -1281,7 +1281,7 @@ Use any helper style classes in any combination on rows/cells.
       <td>1</td>
       <td class="romo-bg-info">Joe Test</td>
       <td>joe-test</td>
-      <td class="romo-1-12 romo-text2 romo-border-error romo-border4">10</td>
+      <td class="romo-1-12 romo-text2 romo-border-danger romo-border4">10</td>
     </tr>
     <tr>
       <td>2</td>

--- a/gh-pages/view_handlers/css/typography.md
+++ b/gh-pages/view_handlers/css/typography.md
@@ -249,7 +249,7 @@ Use style classes to add color to text.
   <span class="romo-text-alt">Fusce dapibus, tellus ac cursus commodo, tortor mauris nibh.</span><br />
   <span class="romo-text-muted">Fusce dapibus, tellus ac cursus commodo, tortor mauris nibh.</span><br />
   <span class="romo-text-warning">Etiam porta sem malesuada magna mollis euismod.</span><br />
-  <span class="romo-text-error">Donec ullamcorper nulla non metus auctor fringilla.</span><br />
+  <span class="romo-text-danger">Donec ullamcorper nulla non metus auctor fringilla.</span><br />
   <span class="romo-text-info">Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis.</span><br />
   <span class="romo-text-success">Duis mollis, est non commodo luctus, nisi erat porttitor ligula.</span><br />
   <span class="romo-text-inverse">Duis mollis, est non commodo luctus, nisi erat porttitor ligula.</span><br />
@@ -260,7 +260,7 @@ Use style classes to add color to text.
 <span class="romo-text-alt">...</span><br />
 <span class="romo-text-muted">...</span><br />
 <span class="romo-text-warning">...</span><br />
-<span class="romo-text-error">...</span><br />
+<span class="romo-text-danger">...</span><br />
 <span class="romo-text-info">...</span><br />
 <span class="romo-text-success">...</span><br />
 <span class="romo-text-inverse">...</span><br />
@@ -273,7 +273,7 @@ Or, to links.
   <a href="#" class="romo-text-alt">Fusce dapibus, tellus ac cursus commodo, tortor mauris nibh.</a><br />
   <a href="#" class="romo-text-muted">Fusce dapibus, tellus ac cursus commodo, tortor mauris nibh.</a><br />
   <a href="#" class="romo-text-warning">Etiam porta sem malesuada magna mollis euismod.</a><br />
-  <a href="#" class="romo-text-error">Donec ullamcorper nulla non metus auctor fringilla.</a><br />
+  <a href="#" class="romo-text-danger">Donec ullamcorper nulla non metus auctor fringilla.</a><br />
   <a href="#" class="romo-text-info">Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis.</a><br />
   <a href="#" class="romo-text-success">Duis mollis, est non commodo luctus, nisi erat porttitor ligula.</a><br />
   <a href="#" class="romo-text-inverse">Duis mollis, est non commodo luctus, nisi erat porttitor ligula.</a><br />
@@ -284,7 +284,7 @@ Or, to links.
 <a href="#" class="romo-text-alt">...</a><br />
 <a href="#" class="romo-text-muted">...</a><br />
 <a href="#" class="romo-text-warning">...</a><br />
-<a href="#" class="romo-text-error">...</a><br />
+<a href="#" class="romo-text-danger">...</a><br />
 <a href="#" class="romo-text-info">...</a><br />
 <a href="#" class="romo-text-success">...</a><br />
 <a href="#" class="romo-text-inverse">...</a><br />
@@ -297,7 +297,7 @@ Or, on hover only (non-links).
   <span class="romo-text-alt-hover">Fusce dapibus, tellus ac cursus commodo, tortor mauris nibh.</span><br />
   <span class="romo-text-muted-hover">Fusce dapibus, tellus ac cursus commodo, tortor mauris nibh.</span><br />
   <span class="romo-text-warning-hover">Etiam porta sem malesuada magna mollis euismod.</span><br />
-  <span class="romo-text-error-hover">Donec ullamcorper nulla non metus auctor fringilla.</span><br />
+  <span class="romo-text-danger-hover">Donec ullamcorper nulla non metus auctor fringilla.</span><br />
   <span class="romo-text-info-hover">Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis.</span><br />
   <span class="romo-text-success-hover">Duis mollis, est non commodo luctus, nisi erat porttitor ligula.</span><br />
   <span class="romo-text-inverse-hover">Duis mollis, est non commodo luctus, nisi erat porttitor ligula.</span><br />
@@ -308,7 +308,7 @@ Or, on hover only (non-links).
 <span class="romo-text-alt-hover">...</span><br />
 <span class="romo-text-muted-hover">...</span><br />
 <span class="romo-text-warning-hover">...</span><br />
-<span class="romo-text-error-hover">...</span><br />
+<span class="romo-text-danger-hover">...</span><br />
 <span class="romo-text-info-hover">...</span><br />
 <span class="romo-text-success-hover">...</span><br />
 <span class="romo-text-inverse-hover">...</span><br />
@@ -321,7 +321,7 @@ Or, to the background instead of the text.
   <span class="romo-bg-alt">Fusce dapibus, tellus ac cursus commodo, tortor mauris nibh.</span><br />
   <span class="romo-bg-muted">Fusce dapibus, tellus ac cursus commodo, tortor mauris nibh.</span><br />
   <span class="romo-bg-warning">Etiam porta sem malesuada magna mollis euismod.</span><br />
-  <span class="romo-bg-error">Donec ullamcorper nulla non metus auctor fringilla.</span><br />
+  <span class="romo-bg-danger">Donec ullamcorper nulla non metus auctor fringilla.</span><br />
   <span class="romo-bg-info">Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis.</span><br />
   <span class="romo-bg-success">Duis mollis, est non commodo luctus, nisi erat porttitor ligula.</span><br />
   <span class="romo-bg-inverse">Duis mollis, est non commodo luctus, nisi erat porttitor ligula.</span><br />
@@ -332,7 +332,7 @@ Or, to the background instead of the text.
 <span class="romo-bg-alt">...</span><br />
 <span class="romo-bg-muted">...</span><br />
 <span class="romo-bg-warning">...</span><br />
-<span class="romo-bg-error">...</span><br />
+<span class="romo-bg-danger">...</span><br />
 <span class="romo-bg-info">...</span><br />
 <span class="romo-bg-success">...</span><br />
 <span class="romo-bg-inverse">...</span><br />
@@ -345,7 +345,7 @@ Or, to the background instead of the text on hover only.
   <span class="romo-bg-alt-hover">Fusce dapibus, tellus ac cursus commodo, tortor mauris nibh.</span><br />
   <span class="romo-bg-muted-hover">Fusce dapibus, tellus ac cursus commodo, tortor mauris nibh.</span><br />
   <span class="romo-bg-warning-hover">Etiam porta sem malesuada magna mollis euismod.</span><br />
-  <span class="romo-bg-error-hover">Donec ullamcorper nulla non metus auctor fringilla.</span><br />
+  <span class="romo-bg-danger-hover">Donec ullamcorper nulla non metus auctor fringilla.</span><br />
   <span class="romo-bg-info-hover">Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis.</span><br />
   <span class="romo-bg-success-hover">Duis mollis, est non commodo luctus, nisi erat porttitor ligula.</span><br />
   <span class="romo-bg-inverse-hover">Duis mollis, est non commodo luctus, nisi erat porttitor ligula.</span><br />
@@ -356,7 +356,7 @@ Or, to the background instead of the text on hover only.
 <span class="romo-bg-alt-hover">...</span><br />
 <span class="romo-bg-muted-hover">...</span><br />
 <span class="romo-bg-warning-hover">...</span><br />
-<span class="romo-bg-error-hover">...</span><br />
+<span class="romo-bg-danger-hover">...</span><br />
 <span class="romo-bg-info-hover">...</span><br />
 <span class="romo-bg-success-hover">...</span><br />
 <span class="romo-bg-inverse-hover">...</span><br />
@@ -367,9 +367,9 @@ Or, combine in any number of ways.
 <div>
   <span class="romo-text-inverse romo-bg-inverse">Duis mollis, est non commodo luctus, nisi erat porttitor ligula.</span><br />
   <span class="romo-text-success romo-bg-info">Etiam porta sem malesuada magna mollis euismod.</span><br />
-  <span class="romo-text-error romo-bg-warning">Donec ullamcorper nulla non metus auctor fringilla.</span><br />
+  <span class="romo-text-danger romo-bg-warning">Donec ullamcorper nulla non metus auctor fringilla.</span><br />
   <span class="romo-text-info romo-bg-inverse-hover">Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis.</span><br />
-  <span class="romo-text-error-hover romo-bg-success-hover">Duis mollis, est non commodo luctus, nisi erat porttitor ligula.</span><br />
+  <span class="romo-text-danger-hover romo-bg-success-hover">Duis mollis, est non commodo luctus, nisi erat porttitor ligula.</span><br />
   <span class="romo-text-warning-hover romo-bg-base-hover">Duis mollis, est non commodo luctus, nisi erat porttitor ligula.</span><br />
   <a href="#" class="romo-text-inverse romo-bg-inverse">Duis mollis, est non commodo luctus, nisi erat porttitor ligula.</a><br />
 </div>
@@ -377,9 +377,9 @@ Or, combine in any number of ways.
 ```html
 <span class="romo-text-inverse romo-bg-inverse">...</span><br />
 <span class="romo-text-success romo-bg-info">...</span><br />
-<span class="romo-text-error romo-bg-warning">...</span><br />
+<span class="romo-text-danger romo-bg-warning">...</span><br />
 <span class="romo-text-info romo-bg-inverse-hover">...</span><br />
-<span class="romo-text-error-hover romo-bg-success-hover">...</span><br />
+<span class="romo-text-danger-hover romo-bg-success-hover">...</span><br />
 <span class="romo-text-warning-hover romo-bg-base-hover">...</span><br />
 <a href="#" class="romo-text-inverse romo-bg-inverse">...</a><br />
 ```


### PR DESCRIPTION
This is some tedious cleanup in prep for adding color classes
for the buttons, labels, tables, and grid-tables.  I did a bunch
of things here:

* renamed some "Background" vars to "Bg".  I wanted shorter var
  names bc less typing and also I want to reformat some styles to
  have more on a single line and be vertically aligned.
* vertically align button/label class defs related to emphasis
  colors.  It is easier to mass edit when vertically aligned. This
  will help when I go add twenty-something color-related classes
  here.
* removed and `-error` style classes; renamed to `-danger`.  This
  goes for vars too.  I want to simplify the API so if you want
  "red" something, use "danger".  I preferred "danger" over "error"
  bc it is more friendly and doesn't imply you did something wrong
  like "error" does.
* I did a bunch of style cleanups and tried to align vertically
  where possible.  This helps with reading and mass editing.

@jcredding ready for review.  You cool with me removing "-error" style classes in favor of "-danger".  It will be a pain to rollout to our apps but I like the API simplification.