### PR TITLE
apply color style classes to buttons, label, tables, grid-tables

### DIFF
--- a/assets/css/romo/_vars.scss
+++ b/assets/css/romo/_vars.scss
@@ -129,23 +129,23 @@ $mutedBorder:      darken(adjust_hue($mutedBg, -10), 7%);
 
 $btnWarningBg:      $orange;
 $btnWarningBgHover: darken($btnWarningBg, 5%);
-$btnWarningColor:   #fff;
+$btnWarningColor:   $inverseColor;
 
 $btnDangerBg:       $red;
 $btnDangerBgHover:  darken($btnDangerBg, 10%);
-$btnDangerColor:    #fff;
+$btnDangerColor:    $inverseColor;
 
 $btnInfoBg:         $blue;
 $btnInfoBgHover:    darken($btnInfoBg, 10%);
-$btnInfoColor:      #fff;
+$btnInfoColor:      $inverseColor;
 
 $btnSuccessBg:      $green;
 $btnSuccessBgHover: darken($btnSuccessBg, 10%);
-$btnSuccessColor:   #fff;
+$btnSuccessColor:   $inverseColor;
 
 $btnInverseBg:      $inverseBgColor;
 $btnInverseBgHover: darken($btnInverseBg, 10%);
-$btnInverseColor:   #fff;
+$btnInverseColor:   $inverseColor;
 
 $warningText:      darken($orange, 5%);
 $warningTextHover: darken($warningText, 10%);
@@ -177,7 +177,7 @@ $inverseBg:        $inverseBgColor;
 $inverseBgHover:   darken($inverseBg, 5%);
 $inverseBorder:    darken(adjust_hue($inverseBg, -10), 7%);
 
-/* explicit hover colors */
+/* explicit colors */
 
 $darkRedTextHover:      darken($darkRed, 10%);
 $darkRedBgHover:        darken($darkRed, 5%);
@@ -223,6 +223,95 @@ $lightBlueTextHover:    darken($lightBlue, 10%);
 $lightBlueBgHover:      darken($lightBlue, 5%);
 $pastelBlueTextHover:   darken($pastelBlue, 10%);
 $pastelBlueBgHover:     darken($pastelBlue, 5%);
+
+
+$btnDarkRedBg:           $darkRed;
+$btnDarkRedBgHover:      $darkRedBgHover;
+$btnDarkRedColor:        $inverseColor;
+
+$btnRedBg:               $red;
+$btnRedBgHover:          $redBgHover;
+$btnRedColor:            $inverseColor;
+
+$btnLightRedBg:          $lightRed;
+$btnLightRedBgHover:     $lightRedBgHover;
+$btnLightRedColor:       $inverseColor;
+
+$btnPastelRedBg:         $pastelRed;
+$btnPastelRedBgHover:    $pastelRedBgHover;
+$btnPastelRedColor:      $baseColor;
+
+$btnDarkOrangeBg:        $darkOrange;
+$btnDarkOrangeBgHover:   $darkOrangeBgHover;
+$btnDarkOrangeColor:     $inverseColor;
+
+$btnOrangeBg:            $orange;
+$btnOrangeBgHover:       $orangeBgHover;
+$btnOrangeColor:         $inverseColor;
+
+$btnYellowBg:            $yellow;
+$btnYellowBgHover:       $yellowBgHover;
+$btnYellowColor:         $baseColor;
+
+$btnPastelYellowBg:      $pastelYellow;
+$btnPastelYellowBgHover: $pastelYellowBgHover;
+$btnPastelYellowColor:   $baseColor;
+
+$btnPurpleBg:            $purple;
+$btnPurpleBgHover:       $purpleBgHover;
+$btnPurpleColor:         $inverseColor;
+
+$btnLightPurpleBg:       $lightPurple;
+$btnLightPurpleBgHover:  $lightPurpleBgHover;
+$btnLightPurpleColor:    $inverseColor;
+
+$btnDarkPinkBg:          $darkPink;
+$btnDarkPinkBgHover:     $darkPinkBgHover;
+$btnDarkPinkColor:       $inverseColor;
+
+$btnHotPinkBg:           $hotPink;
+$btnHotPinkBgHover:      $hotPinkBgHover;
+$btnHotPinkColor:        $inverseColor;
+
+$btnPinkBg:              $pink;
+$btnPinkBgHover:         $pinkBgHover;
+$btnPinkColor:           $inverseColor;
+
+$btnDarkGreenBg:         $darkGreen;
+$btnDarkGreenBgHover:    $darkGreenBgHover;
+$btnDarkGreenColor:      $inverseColor;
+
+$btnGreenBg:             $green;
+$btnGreenBgHover:        $greenBgHover;
+$btnGreenColor:          $inverseColor;
+
+$btnLightGreenBg:        $lightGreen;
+$btnLightGreenBgHover:   $lightGreenBgHover;
+$btnLightGreenColor:     $baseColor;
+
+$btnPastelGreenBg:       $pastelGreen;
+$btnPastelGreenBgHover:  $pastelGreenBgHover;
+$btnPastelGreenColor:    $baseColor;
+
+$btnNavyBg:              $navy;
+$btnNavyBgHover:         $navyBgHover;
+$btnNavyColor:           $inverseColor;
+
+$btnDarkBlueBg:          $darkBlue;
+$btnDarkBlueBgHover:     $darkBlueBgHover;
+$btnDarkBlueColor:       $inverseColor;
+
+$btnBlueBg:              $blue;
+$btnBlueBgHover:         $blueBgHover;
+$btnBlueColor:           $inverseColor;
+
+$btnLightBlueBg:         $lightBlue;
+$btnLightBlueBgHover:    $lightBlueBgHover;
+$btnLightBlueColor:      $inverseColor;
+
+$btnPastelBlueBg:        $pastelBlue;
+$btnPastelBlueBgHover:   $pastelBlueBgHover;
+$btnPastelBlueColor:     $baseColor;
 
 /* borders */
 

--- a/assets/css/romo/buttons.scss
+++ b/assets/css/romo/buttons.scss
@@ -79,7 +79,7 @@ input[type="reset"].romo-btn-block,
 input[type="button"].romo-btn-block,
 .romo-btn-block { display: block; width: 100%; }
 
-/* implicit colored buttons */
+/* emphasis colored buttons */
 
 a.romo-btn.romo-btn-alt,     button.romo-btn.romo-btn-alt,     .romo-btn.romo-btn-alt     { @include button-bg($btnAltBg,     $btnAltBgHover,     $btnAltColor);     }
 a.romo-btn.romo-btn-inverse, button.romo-btn.romo-btn-inverse, .romo-btn.romo-btn-inverse { @include button-bg($btnInverseBg, $btnInverseBgHover, $btnInverseColor); }
@@ -87,6 +87,31 @@ a.romo-btn.romo-btn-warning, button.romo-btn.romo-btn-warning, .romo-btn.romo-bt
 a.romo-btn.romo-btn-danger,  button.romo-btn.romo-btn-danger,  .romo-btn.romo-btn-danger  { @include button-bg($btnDangerBg,  $btnDangerBgHover,  $btnDangerColor);  }
 a.romo-btn.romo-btn-info,    button.romo-btn.romo-btn-info,    .romo-btn.romo-btn-info    { @include button-bg($btnInfoBg,    $btnInfoBgHover,    $btnInfoColor);    }
 a.romo-btn.romo-btn-success, button.romo-btn.romo-btn-success, .romo-btn.romo-btn-success { @include button-bg($btnSuccessBg, $btnSuccessBgHover, $btnSuccessColor); }
+
+/* explicit colored buttons */
+
+a.romo-btn.romo-btn-dark-red,      button.romo-btn.romo-btn-dark-red,      .romo-btn.romo-btn-dark-red      { @include button-bg($btnDarkRedBg,      $btnDarkRedBgHover,      $btnDarkRedColor);      }
+a.romo-btn.romo-btn-red,           button.romo-btn.romo-btn-red,           .romo-btn.romo-btn-red           { @include button-bg($btnRedBg,          $btnRedBgHover,          $btnRedColor);          }
+a.romo-btn.romo-btn-light-red,     button.romo-btn.romo-btn-light-red,     .romo-btn.romo-btn-light-red     { @include button-bg($btnLightRedBg,     $btnLightRedBgHover,     $btnLightRedColor);     }
+a.romo-btn.romo-btn-pastel-red,    button.romo-btn.romo-btn-pastel-red,    .romo-btn.romo-btn-pastel-red    { @include button-bg($btnPastelRedBg,    $btnPastelRedBgHover,    $btnPastelRedColor);    }
+a.romo-btn.romo-btn-dark-orange,   button.romo-btn.romo-btn-dark-orange,   .romo-btn.romo-btn-dark-orange   { @include button-bg($btnDarkOrangeBg,   $btnDarkOrangeBgHover,   $btnDarkOrangeColor);   }
+a.romo-btn.romo-btn-orange,        button.romo-btn.romo-btn-orange,        .romo-btn.romo-btn-orange        { @include button-bg($btnOrangeBg,       $btnOrangeBgHover,       $btnOrangeColor);       }
+a.romo-btn.romo-btn-yellow,        button.romo-btn.romo-btn-yellow,        .romo-btn.romo-btn-yellow        { @include button-bg($btnYellowBg,       $btnYellowBgHover,       $btnYellowColor);       }
+a.romo-btn.romo-btn-pastel-yellow, button.romo-btn.romo-btn-pastel-yellow, .romo-btn.romo-btn-pastel-yellow { @include button-bg($btnPastelYellowBg, $btnPastelYellowBgHover, $btnPastelYellowColor); }
+a.romo-btn.romo-btn-purple,        button.romo-btn.romo-btn-purple,        .romo-btn.romo-btn-purple        { @include button-bg($btnPurpleBg,       $btnPurpleBgHover,       $btnPurpleColor);       }
+a.romo-btn.romo-btn-light-purple,  button.romo-btn.romo-btn-light-purple,  .romo-btn.romo-btn-light-purple  { @include button-bg($btnLightPurpleBg,  $btnLightPurpleBgHover,  $btnLightPurpleColor);  }
+a.romo-btn.romo-btn-dark-pink,     button.romo-btn.romo-btn-dark-pink,     .romo-btn.romo-btn-dark-pink     { @include button-bg($btnDarkPinkBg,     $btnDarkPinkBgHover,     $btnDarkPinkColor);     }
+a.romo-btn.romo-btn-hot-pink,      button.romo-btn.romo-btn-hot-pink,      .romo-btn.romo-btn-hot-pink      { @include button-bg($btnHotPinkBg,      $btnHotPinkBgHover,      $btnHotPinkColor);      }
+a.romo-btn.romo-btn-pink,          button.romo-btn.romo-btn-pink,          .romo-btn.romo-btn-pink          { @include button-bg($btnPinkBg,         $btnPinkBgHover,         $btnPinkColor);         }
+a.romo-btn.romo-btn-dark-green,    button.romo-btn.romo-btn-dark-green,    .romo-btn.romo-btn-dark-green    { @include button-bg($btnDarkGreenBg,    $btnDarkGreenBgHover,    $btnDarkGreenColor);    }
+a.romo-btn.romo-btn-green,         button.romo-btn.romo-btn-green,         .romo-btn.romo-btn-green         { @include button-bg($btnGreenBg,        $btnGreenBgHover,        $btnGreenColor);        }
+a.romo-btn.romo-btn-light-green,   button.romo-btn.romo-btn-light-green,   .romo-btn.romo-btn-light-green   { @include button-bg($btnLightGreenBg,   $btnLightGreenBgHover,   $btnLightGreenColor);   }
+a.romo-btn.romo-btn-pastel-green,  button.romo-btn.romo-btn-pastel-green,  .romo-btn.romo-btn-pastel-green  { @include button-bg($btnPastelGreenBg,  $btnPastelGreenBgHover,  $btnPastelGreenColor);  }
+a.romo-btn.romo-btn-navy,          button.romo-btn.romo-btn-navy,          .romo-btn.romo-btn-navy          { @include button-bg($btnNavyBg,         $btnNavyBgHover,         $btnNavyColor);         }
+a.romo-btn.romo-btn-dark-blue,     button.romo-btn.romo-btn-dark-blue,     .romo-btn.romo-btn-dark-blue     { @include button-bg($btnDarkBlueBg,     $btnDarkBlueBgHover,     $btnDarkBlueColor);     }
+a.romo-btn.romo-btn-blue,          button.romo-btn.romo-btn-blue,          .romo-btn.romo-btn-blue          { @include button-bg($btnBlueBg,         $btnBlueBgHover,         $btnBlueColor);         }
+a.romo-btn.romo-btn-light-blue,    button.romo-btn.romo-btn-light-blue,    .romo-btn.romo-btn-light-blue    { @include button-bg($btnLightBlueBg,    $btnLightBlueBgHover,    $btnLightBlueColor);    }
+a.romo-btn.romo-btn-pastel-blue,   button.romo-btn.romo-btn-pastel-blue,   .romo-btn.romo-btn-pastel-blue   { @include button-bg($btnPastelBlueBg,   $btnPastelBlueBgHover,   $btnPastelBlueColor);   }
 
 /* link buttons */
 

--- a/assets/css/romo/grid_table.scss
+++ b/assets/css/romo/grid_table.scss
@@ -31,38 +31,12 @@ ol.romo-grid-table { @include list-unstyled(!important); }
 .romo-grid-table-striped.romo-grid-table-header.romo-grid-table-striped-alt > .romo-row:nth-child(even) { @include bg-base; }
 .romo-grid-table-striped.romo-grid-table-striped-alt { @include bg-striped; }
 
-.romo-grid-table .romo-row.romo-base    { @include bg-base(!important);    }
-.romo-grid-table .romo-row.romo-alt     { @include bg-alt(!important);     }
-.romo-grid-table .romo-row.romo-muted   { @include bg-muted(!important);   }
-.romo-grid-table .romo-row.romo-warning { @include bg-warning(!important); }
-.romo-grid-table .romo-row.romo-danger  { @include bg-danger(!important);  }
-.romo-grid-table .romo-row.romo-info    { @include bg-info(!important);    }
-.romo-grid-table .romo-row.romo-success { @include bg-success(!important); }
-.romo-grid-table .romo-row.romo-inverse { @include bg-inverse(!important); }
-
 .romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row:hover,
 .romo-grid-table-hover:not(.romo-grid-table-header).romo-grid-table-alt > .romo-row:hover,
 .romo-grid-table-hover:not(.romo-grid-table-header).romo-grid-table-striped > .romo-row:hover,
 .romo-grid-table-hover:not(.romo-grid-table-header).romo-grid-table-striped-alt > .romo-row:hover { @include bg-hover; }
 .romo-grid-table-hover.romo-grid-table-header > .romo-row:not(:first-child):hover,
 .romo-grid-table-hover.romo-grid-table-header.romo-grid-table-alt > .romo-row:not(:first-child):hover { @include bg-hover; }
-
-.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-base:hover,
-.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-base:not(:first-child):hover    { @include bg-base-hover(!important);    }
-.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-alt:hover,
-.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-alt:not(:first-child):hover     { @include bg-alt-hover(!important);     }
-.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-muted:hover,
-.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-muted:not(:first-child):hover   { @include bg-muted-hover(!important);   }
-.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-warning:hover,
-.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-warning:not(:first-child):hover { @include bg-warning-hover(!important); }
-.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-danger:hover,
-.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-danger:not(:first-child):hover  { @include bg-danger-hover(!important);  }
-.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-info:hover,
-.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-info:not(:first-child):hover    { @include bg-info-hover(!important);    }
-.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-success:hover,
-.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-success:not(:first-child):hover { @include bg-success-hover(!important); }
-.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-inverse:hover,
-.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-inverse:not(:first-child):hover { @include bg-inverse-hover(!important); }
 
 .romo-grid-table-border,
 .romo-grid-table-border1     { @include border1;            }
@@ -84,30 +58,6 @@ ol.romo-grid-table { @include list-unstyled(!important); }
 
 .romo-grid-table[class*="romo-grid-table-border"] > .romo-row > .romo-span:last-child { @include rm-border-right; }
 .romo-grid-table[class*="romo-grid-table-border"] > .romo-row:last-child { @include rm-border-bottom; }
-
-.romo-grid-table-border-muted   { @include border-muted;   }
-.romo-grid-table-border-warning { @include border-warning; }
-.romo-grid-table-border-danger  { @include border-danger;  }
-.romo-grid-table-border-info    { @include border-info;    }
-.romo-grid-table-border-success { @include border-success; }
-.romo-grid-table-border-inverse { @include border-inverse; }
-.romo-grid-table-border-alt     { @include border-alt;     }
-
-.romo-grid-table-border-muted   > .romo-row { @include border-muted;   }
-.romo-grid-table-border-warning > .romo-row { @include border-warning; }
-.romo-grid-table-border-danger  > .romo-row { @include border-danger;  }
-.romo-grid-table-border-info    > .romo-row { @include border-info;    }
-.romo-grid-table-border-success > .romo-row { @include border-success; }
-.romo-grid-table-border-inverse > .romo-row { @include border-inverse; }
-.romo-grid-table-border-alt     > .romo-row { @include border-alt;     }
-
-.romo-grid-table-border-muted   > .romo-row > .romo-span { @include border-muted;   }
-.romo-grid-table-border-warning > .romo-row > .romo-span { @include border-warning; }
-.romo-grid-table-border-danger  > .romo-row > .romo-span { @include border-danger;  }
-.romo-grid-table-border-info    > .romo-row > .romo-span { @include border-info;    }
-.romo-grid-table-border-success > .romo-row > .romo-span { @include border-success; }
-.romo-grid-table-border-inverse > .romo-row > .romo-span { @include border-inverse; }
-.romo-grid-table-border-alt     > .romo-row > .romo-span { @include border-alt;     }
 
 .romo-grid-table.romo-grid-table-pad    > .romo-row > .romo-span,
 .romo-grid-table.romo-grid-table-pad1   > .romo-row > .romo-span { @include pad1;   }
@@ -138,3 +88,198 @@ ol.romo-grid-table { @include list-unstyled(!important); }
 .romo-grid-table.romo-table-pad0-left   > .romo-row > .romo-span { @include pad0-left;   }
 .romo-grid-table.romo-table-pad2-left   > .romo-row > .romo-span { @include pad2-left;   }
 .romo-grid-table.romo-table-rm-pad-left > .romo-row > .romo-span { @include rm-pad-left; }
+
+/* emphasis colored rows */
+
+.romo-grid-table .romo-row.romo-base    { @include bg-base(!important);    }
+.romo-grid-table .romo-row.romo-alt     { @include bg-alt(!important);     }
+.romo-grid-table .romo-row.romo-muted   { @include bg-muted(!important);   }
+.romo-grid-table .romo-row.romo-warning { @include bg-warning(!important); }
+.romo-grid-table .romo-row.romo-danger  { @include bg-danger(!important);  }
+.romo-grid-table .romo-row.romo-info    { @include bg-info(!important);    }
+.romo-grid-table .romo-row.romo-success { @include bg-success(!important); }
+.romo-grid-table .romo-row.romo-inverse { @include bg-inverse(!important); }
+
+.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-base:hover,
+.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-base:not(:first-child):hover    { @include bg-base-hover(!important);    }
+.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-alt:hover,
+.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-alt:not(:first-child):hover     { @include bg-alt-hover(!important);     }
+.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-muted:hover,
+.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-muted:not(:first-child):hover   { @include bg-muted-hover(!important);   }
+.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-warning:hover,
+.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-warning:not(:first-child):hover { @include bg-warning-hover(!important); }
+.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-danger:hover,
+.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-danger:not(:first-child):hover  { @include bg-danger-hover(!important);  }
+.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-info:hover,
+.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-info:not(:first-child):hover    { @include bg-info-hover(!important);    }
+.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-success:hover,
+.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-success:not(:first-child):hover { @include bg-success-hover(!important); }
+.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-inverse:hover,
+.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-inverse:not(:first-child):hover { @include bg-inverse-hover(!important); }
+
+/* explicit colored rows */
+
+.romo-grid-table .romo-row.romo-dark-red      { @include bg-dark-red(!important);      }
+.romo-grid-table .romo-row.romo-red           { @include bg-red(!important);           }
+.romo-grid-table .romo-row.romo-light-red     { @include bg-light-red(!important);     }
+.romo-grid-table .romo-row.romo-pastel-red    { @include bg-pastel-red(!important);    }
+.romo-grid-table .romo-row.romo-dark-orange   { @include bg-dark-orange(!important);   }
+.romo-grid-table .romo-row.romo-orange        { @include bg-orange(!important);        }
+.romo-grid-table .romo-row.romo-yellow        { @include bg-yellow(!important);        }
+.romo-grid-table .romo-row.romo-pastel-yellow { @include bg-pastel-yellow(!important); }
+.romo-grid-table .romo-row.romo-purple        { @include bg-purple(!important);        }
+.romo-grid-table .romo-row.romo-light-purple  { @include bg-light-purple(!important);  }
+.romo-grid-table .romo-row.romo-dark-pink     { @include bg-dark-pink(!important);     }
+.romo-grid-table .romo-row.romo-hot-pink      { @include bg-hot-pink(!important);      }
+.romo-grid-table .romo-row.romo-pink          { @include bg-pink(!important);          }
+.romo-grid-table .romo-row.romo-dark-green    { @include bg-dark-green(!important);    }
+.romo-grid-table .romo-row.romo-green         { @include bg-green(!important);         }
+.romo-grid-table .romo-row.romo-light-green   { @include bg-light-green(!important);   }
+.romo-grid-table .romo-row.romo-pastel-green  { @include bg-pastel-green(!important);  }
+.romo-grid-table .romo-row.romo-navy          { @include bg-navy(!important);          }
+.romo-grid-table .romo-row.romo-dark-blue     { @include bg-dark-blue(!important);     }
+.romo-grid-table .romo-row.romo-blue          { @include bg-blue(!important);          }
+.romo-grid-table .romo-row.romo-light-blue    { @include bg-light-blue(!important);    }
+.romo-grid-table .romo-row.romo-pastel-blue   { @include bg-pastel-blue(!important);   }
+
+.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-dark-red:hover,
+.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-dark-red:not(:first-child):hover      { @include bg-dark-red-hover(!important);      }
+.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-red:hover,
+.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-red:not(:first-child):hover           { @include bg-red-hover(!important);           }
+.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-light-red:hover,
+.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-light-red:not(:first-child):hover     { @include bg-light-red-hover(!important);     }
+.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-pastel-red:hover,
+.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-pastel-red:not(:first-child):hover    { @include bg-pastel-red-hover(!important);    }
+.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-dark-orange:hover,
+.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-dark-orange:not(:first-child):hover   { @include bg-dark-orange-hover(!important);   }
+.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-orange:hover,
+.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-orange:not(:first-child):hover        { @include bg-orange-hover(!important);        }
+.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-yellow:hover,
+.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-yellow:not(:first-child):hover        { @include bg-yellow-hover(!important);        }
+.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-pastel-yellow:hover,
+.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-pastel-yellow:not(:first-child):hover { @include bg-pastel-yellow-hover(!important); }
+.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-purple:hover,
+.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-purple:not(:first-child):hover        { @include bg-purple-hover(!important);        }
+.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-light-purple:hover,
+.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-light-purple:not(:first-child):hover  { @include bg-light-purple-hover(!important);  }
+.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-dark-pink:hover,
+.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-dark-pink:not(:first-child):hover     { @include bg-dark-pink-hover(!important);     }
+.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-hot-pink:hover,
+.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-hot-pink:not(:first-child):hover      { @include bg-hot-pink-hover(!important);      }
+.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-pink:hover,
+.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-pink:not(:first-child):hover          { @include bg-pink-hover(!important);          }
+.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-dark-green:hover,
+.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-dark-green:not(:first-child):hover    { @include bg-dark-green-hover(!important);    }
+.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-green:hover,
+.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-green:not(:first-child):hover         { @include bg-green-hover(!important);         }
+.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-light-green:hover,
+.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-light-green:not(:first-child):hover   { @include bg-light-green-hover(!important);   }
+.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-pastel-green:hover,
+.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-pastel-green:not(:first-child):hover  { @include bg-pastel-green-hover(!important);  }
+.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-navy:hover,
+.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-navy:not(:first-child):hover          { @include bg-navy-hover(!important);          }
+.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-dark-blue:hover,
+.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-dark-blue:not(:first-child):hover     { @include bg-dark-blue-hover(!important);     }
+.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-blue:hover,
+.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-blue:not(:first-child):hover          { @include bg-blue-hover(!important);          }
+.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-light-blue:hover,
+.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-light-blue:not(:first-child):hover    { @include bg-light-blue-hover(!important);    }
+.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-pastel-blue:hover,
+.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-pastel-blue:not(:first-child):hover   { @include bg-pastel-blue-hover(!important);   }
+
+/* emphasis colored borders */
+
+.romo-grid-table-border-muted   { @include border-muted;   }
+.romo-grid-table-border-warning { @include border-warning; }
+.romo-grid-table-border-danger  { @include border-danger;  }
+.romo-grid-table-border-info    { @include border-info;    }
+.romo-grid-table-border-success { @include border-success; }
+.romo-grid-table-border-inverse { @include border-inverse; }
+.romo-grid-table-border-alt     { @include border-alt;     }
+
+.romo-grid-table-border-muted   > .romo-row { @include border-muted;   }
+.romo-grid-table-border-warning > .romo-row { @include border-warning; }
+.romo-grid-table-border-danger  > .romo-row { @include border-danger;  }
+.romo-grid-table-border-info    > .romo-row { @include border-info;    }
+.romo-grid-table-border-success > .romo-row { @include border-success; }
+.romo-grid-table-border-inverse > .romo-row { @include border-inverse; }
+.romo-grid-table-border-alt     > .romo-row { @include border-alt;     }
+
+.romo-grid-table-border-muted   > .romo-row > .romo-span { @include border-muted;   }
+.romo-grid-table-border-warning > .romo-row > .romo-span { @include border-warning; }
+.romo-grid-table-border-danger  > .romo-row > .romo-span { @include border-danger;  }
+.romo-grid-table-border-info    > .romo-row > .romo-span { @include border-info;    }
+.romo-grid-table-border-success > .romo-row > .romo-span { @include border-success; }
+.romo-grid-table-border-inverse > .romo-row > .romo-span { @include border-inverse; }
+.romo-grid-table-border-alt     > .romo-row > .romo-span { @include border-alt;     }
+
+/* explicit colored borders */
+
+.romo-grid-table-border-dark-red      { @include border-dark-red;      }
+.romo-grid-table-border-red           { @include border-red;           }
+.romo-grid-table-border-light-red     { @include border-light-red;     }
+.romo-grid-table-border-pastel-red    { @include border-pastel-red;    }
+.romo-grid-table-border-dark-orange   { @include border-dark-orange;   }
+.romo-grid-table-border-orange        { @include border-orange;        }
+.romo-grid-table-border-yellow        { @include border-yellow;        }
+.romo-grid-table-border-pastel-yellow { @include border-pastel-yellow; }
+.romo-grid-table-border-purple        { @include border-purple;        }
+.romo-grid-table-border-light-purple  { @include border-light-purple;  }
+.romo-grid-table-border-dark-pink     { @include border-dark-pink;     }
+.romo-grid-table-border-hot-pink      { @include border-hot-pink;      }
+.romo-grid-table-border-pink          { @include border-pink;          }
+.romo-grid-table-border-dark-green    { @include border-dark-green;    }
+.romo-grid-table-border-green         { @include border-green;         }
+.romo-grid-table-border-light-green   { @include border-light-green;   }
+.romo-grid-table-border-pastel-green  { @include border-pastel-green;  }
+.romo-grid-table-border-navy          { @include border-navy;          }
+.romo-grid-table-border-dark-blue     { @include border-dark-blue;     }
+.romo-grid-table-border-blue          { @include border-blue;          }
+.romo-grid-table-border-light-blue    { @include border-light-blue;    }
+.romo-grid-table-border-pastel-blue   { @include border-pastel-blue;   }
+
+.romo-grid-table-border-dark-red      > .romo-row { @include border-dark-red;      }
+.romo-grid-table-border-red           > .romo-row { @include border-red;           }
+.romo-grid-table-border-light-red     > .romo-row { @include border-light-red;     }
+.romo-grid-table-border-pastel-red    > .romo-row { @include border-pastel-red;    }
+.romo-grid-table-border-dark-orange   > .romo-row { @include border-dark-orange;   }
+.romo-grid-table-border-orange        > .romo-row { @include border-orange;        }
+.romo-grid-table-border-yellow        > .romo-row { @include border-yellow;        }
+.romo-grid-table-border-pastel-yellow > .romo-row { @include border-pastel-yellow; }
+.romo-grid-table-border-purple        > .romo-row { @include border-purple;        }
+.romo-grid-table-border-light-purple  > .romo-row { @include border-light-purple;  }
+.romo-grid-table-border-dark-pink     > .romo-row { @include border-dark-pink;     }
+.romo-grid-table-border-hot-pink      > .romo-row { @include border-hot-pink;      }
+.romo-grid-table-border-pink          > .romo-row { @include border-pink;          }
+.romo-grid-table-border-dark-green    > .romo-row { @include border-dark-green;    }
+.romo-grid-table-border-green         > .romo-row { @include border-green;         }
+.romo-grid-table-border-light-green   > .romo-row { @include border-light-green;   }
+.romo-grid-table-border-pastel-green  > .romo-row { @include border-pastel-green;  }
+.romo-grid-table-border-navy          > .romo-row { @include border-navy;          }
+.romo-grid-table-border-dark-blue     > .romo-row { @include border-dark-blue;     }
+.romo-grid-table-border-blue          > .romo-row { @include border-blue;          }
+.romo-grid-table-border-light-blue    > .romo-row { @include border-light-blue;    }
+.romo-grid-table-border-pastel-blue   > .romo-row { @include border-pastel-blue;   }
+
+.romo-grid-table-border-dark-red      > .romo-row > .romo-span { @include border-dark-red;      }
+.romo-grid-table-border-red           > .romo-row > .romo-span { @include border-red;           }
+.romo-grid-table-border-light-red     > .romo-row > .romo-span { @include border-light-red;     }
+.romo-grid-table-border-pastel-red    > .romo-row > .romo-span { @include border-pastel-red;    }
+.romo-grid-table-border-dark-orange   > .romo-row > .romo-span { @include border-dark-orange;   }
+.romo-grid-table-border-orange        > .romo-row > .romo-span { @include border-orange;        }
+.romo-grid-table-border-yellow        > .romo-row > .romo-span { @include border-yellow;        }
+.romo-grid-table-border-pastel-yellow > .romo-row > .romo-span { @include border-pastel-yellow; }
+.romo-grid-table-border-purple        > .romo-row > .romo-span { @include border-purple;        }
+.romo-grid-table-border-light-purple  > .romo-row > .romo-span { @include border-light-purple;  }
+.romo-grid-table-border-dark-pink     > .romo-row > .romo-span { @include border-dark-pink;     }
+.romo-grid-table-border-hot-pink      > .romo-row > .romo-span { @include border-hot-pink;      }
+.romo-grid-table-border-pink          > .romo-row > .romo-span { @include border-pink;          }
+.romo-grid-table-border-dark-green    > .romo-row > .romo-span { @include border-dark-green;    }
+.romo-grid-table-border-green         > .romo-row > .romo-span { @include border-green;         }
+.romo-grid-table-border-light-green   > .romo-row > .romo-span { @include border-light-green;   }
+.romo-grid-table-border-pastel-green  > .romo-row > .romo-span { @include border-pastel-green;  }
+.romo-grid-table-border-navy          > .romo-row > .romo-span { @include border-navy;          }
+.romo-grid-table-border-dark-blue     > .romo-row > .romo-span { @include border-dark-blue;     }
+.romo-grid-table-border-blue          > .romo-row > .romo-span { @include border-blue;          }
+.romo-grid-table-border-light-blue    > .romo-row > .romo-span { @include border-light-blue;    }
+.romo-grid-table-border-pastel-blue   > .romo-row > .romo-span { @include border-pastel-blue;   }

--- a/assets/css/romo/labels.scss
+++ b/assets/css/romo/labels.scss
@@ -32,9 +32,36 @@
 
 .romo-label-block { display: block; width: 100%; }
 
-.romo-label.romo-label-alt     { background-color: $btnBg;        color: $btnColor; }
+/* emphasis colored labels */
+
+.romo-label.romo-label-alt     { background-color: $btnBg;        color: $btnColor;        }
 .romo-label.romo-label-inverse { background-color: $btnInverseBg; color: $btnInverseColor; }
 .romo-label.romo-label-warning { background-color: $btnWarningBg; color: $btnWarningColor; }
-.romo-label.romo-label-danger  { background-color: $btnDangerBg;  color: $btnDangerColor; }
-.romo-label.romo-label-info    { background-color: $btnInfoBg;    color: $btnInfoColor; }
+.romo-label.romo-label-danger  { background-color: $btnDangerBg;  color: $btnDangerColor;  }
+.romo-label.romo-label-info    { background-color: $btnInfoBg;    color: $btnInfoColor;    }
 .romo-label.romo-label-success { background-color: $btnSuccessBg; color: $btnSuccessColor; }
+
+/* explicit colored labels */
+
+.romo-label.romo-label-dark-red      { background-color: $btnDarkRedBg;      color: $btnDarkRedColor;      }
+.romo-label.romo-label-red           { background-color: $btnRedBg;          color: $btnRedColor;          }
+.romo-label.romo-label-light-red     { background-color: $btnLightRedBg;     color: $btnLightRedColor;     }
+.romo-label.romo-label-pastel-red    { background-color: $btnPastelRedBg;    color: $btnPastelRedColor;    }
+.romo-label.romo-label-dark-orange   { background-color: $btnDarkOrangeBg;   color: $btnDarkOrangeColor;   }
+.romo-label.romo-label-orange        { background-color: $btnOrangeBg;       color: $btnOrangeColor;       }
+.romo-label.romo-label-yellow        { background-color: $btnYellowBg;       color: $btnYellowColor;       }
+.romo-label.romo-label-pastel-yellow { background-color: $btnPastelYellowBg; color: $btnPastelYellowColor; }
+.romo-label.romo-label-purple        { background-color: $btnPurpleBg;       color: $btnPurpleColor;       }
+.romo-label.romo-label-light-purple  { background-color: $btnLightPurpleBg;  color: $btnLightPurpleColor;  }
+.romo-label.romo-label-dark-pink     { background-color: $btnDarkPinkBg;     color: $btnDarkPinkColor;     }
+.romo-label.romo-label-hot-pink      { background-color: $btnHotPinkBg;      color: $btnHotPinkColor;      }
+.romo-label.romo-label-pink          { background-color: $btnPinkBg;         color: $btnPinkColor;         }
+.romo-label.romo-label-dark-green    { background-color: $btnDarkGreenBg;    color: $btnDarkGreenColor;    }
+.romo-label.romo-label-green         { background-color: $btnGreenBg;        color: $btnGreenColor;        }
+.romo-label.romo-label-light-green   { background-color: $btnLightGreenBg;   color: $btnLightGreenColor;   }
+.romo-label.romo-label-pastel-green  { background-color: $btnPastelGreenBg;  color: $btnPastelGreenColor;  }
+.romo-label.romo-label-navy          { background-color: $btnNavyBg;         color: $btnNavyColor;         }
+.romo-label.romo-label-dark-blue     { background-color: $btnDarkBlueBg;     color: $btnDarkBlueColor;     }
+.romo-label.romo-label-blue          { background-color: $btnBlueBg;         color: $btnBlueColor;         }
+.romo-label.romo-label-light-blue    { background-color: $btnLightBlueBg;    color: $btnLightBlueColor;    }
+.romo-label.romo-label-pastel-blue   { background-color: $btnPastelBlueBg;   color: $btnPastelBlueColor;   }

--- a/assets/css/romo/table.scss
+++ b/assets/css/romo/table.scss
@@ -21,28 +21,10 @@
 .romo-table-striped.romo-table-striped-alt tbody > tr:nth-child(odd) { @include bg-base; }
 .romo-table-striped.romo-table-striped-alt { @include bg-striped; }
 
-.romo-table tr.romo-base    { @include bg-base(!important);    }
-.romo-table tr.romo-alt     { @include bg-alt(!important);     }
-.romo-table tr.romo-muted   { @include bg-muted(!important);   }
-.romo-table tr.romo-warning { @include bg-warning(!important); }
-.romo-table tr.romo-danger  { @include bg-danger(!important);  }
-.romo-table tr.romo-info    { @include bg-info(!important);    }
-.romo-table tr.romo-success { @include bg-success(!important); }
-.romo-table tr.romo-inverse { @include bg-inverse(!important); }
-
 .romo-table-hover tbody tr:hover,
 .romo-table-hover.romo-table-alt tbody tr:hover,
 .romo-table-hover.romo-table-striped tbody tr:hover,
 .romo-table-hover.romo-table-striped-alt tbody tr:hover { @include bg-hover; }
-
-.romo-table-hover tbody tr.romo-base:hover    { @include bg-base-hover(!important);    }
-.romo-table-hover tbody tr.romo-alt:hover     { @include bg-alt-hover(!important);     }
-.romo-table-hover tbody tr.romo-muted:hover   { @include bg-muted-hover(!important);   }
-.romo-table-hover tbody tr.romo-warning:hover { @include bg-warning-hover(!important); }
-.romo-table-hover tbody tr.romo-danger:hover  { @include bg-danger-hover(!important);  }
-.romo-table-hover tbody tr.romo-info:hover    { @include bg-info-hover(!important);    }
-.romo-table-hover tbody tr.romo-success:hover { @include bg-success-hover(!important); }
-.romo-table-hover tbody tr.romo-inverse:hover { @include bg-inverse-hover(!important); }
 
 .romo-table-border,
 .romo-table-border0,
@@ -61,24 +43,6 @@
 .romo-table-border0     th, .romo-table-border0     td { @include border0-bottom; @include border0-right; }
 .romo-table-border2     th, .romo-table-border2     td { @include border2-bottom; @include border2-right; }
 .romo-table-border-none th, .romo-table-border-none td { @include border-style(none); }
-
-.romo-table-border-base    { @include border-base;    }
-.romo-table-border-alt     { @include border-alt;     }
-.romo-table-border-muted   { @include border-muted;   }
-.romo-table-border-warning { @include border-warning; }
-.romo-table-border-danger  { @include border-danger;  }
-.romo-table-border-info    { @include border-info;    }
-.romo-table-border-success { @include border-success; }
-.romo-table-border-inverse { @include border-inverse; }
-
-.romo-table-border-base    th, .romo-table-border-base    td { @include border-base;    }
-.romo-table-border-alt     th, .romo-table-border-alt     td { @include border-alt;     }
-.romo-table-border-muted   th, .romo-table-border-muted   td { @include border-muted;   }
-.romo-table-border-warning th, .romo-table-border-warning td { @include border-warning; }
-.romo-table-border-danger  th, .romo-table-border-danger  td { @include border-danger;  }
-.romo-table-border-info    th, .romo-table-border-info    td { @include border-info;    }
-.romo-table-border-success th, .romo-table-border-success td { @include border-success; }
-.romo-table-border-inverse th, .romo-table-border-inverse td { @include border-inverse; }
 
 .romo-table-pad    th, .romo-table-pad    td,
 .romo-table-pad1   th, .romo-table-pad1   td { @include pad1;   }
@@ -109,3 +73,139 @@
 .romo-table-pad0-left   th, .romo-table-pad0-left   td { @include pad0-left;   }
 .romo-table-pad2-left   th, .romo-table-pad2-left   td { @include pad2-left;   }
 .romo-table-rm-pad-left th, .romo-table-rm-pad-left td { @include rm-pad-left; }
+
+/* emphasis colored rows */
+
+.romo-table tr.romo-base    { @include bg-base(!important);    }
+.romo-table tr.romo-alt     { @include bg-alt(!important);     }
+.romo-table tr.romo-muted   { @include bg-muted(!important);   }
+.romo-table tr.romo-warning { @include bg-warning(!important); }
+.romo-table tr.romo-danger  { @include bg-danger(!important);  }
+.romo-table tr.romo-info    { @include bg-info(!important);    }
+.romo-table tr.romo-success { @include bg-success(!important); }
+.romo-table tr.romo-inverse { @include bg-inverse(!important); }
+
+.romo-table-hover tbody tr.romo-base:hover    { @include bg-base-hover(!important);    }
+.romo-table-hover tbody tr.romo-alt:hover     { @include bg-alt-hover(!important);     }
+.romo-table-hover tbody tr.romo-muted:hover   { @include bg-muted-hover(!important);   }
+.romo-table-hover tbody tr.romo-warning:hover { @include bg-warning-hover(!important); }
+.romo-table-hover tbody tr.romo-danger:hover  { @include bg-danger-hover(!important);  }
+.romo-table-hover tbody tr.romo-info:hover    { @include bg-info-hover(!important);    }
+.romo-table-hover tbody tr.romo-success:hover { @include bg-success-hover(!important); }
+.romo-table-hover tbody tr.romo-inverse:hover { @include bg-inverse-hover(!important); }
+
+/* explicit colored rows */
+
+.romo-table tr.romo-dark-red      { @include bg-dark-red(!important);      }
+.romo-table tr.romo-red           { @include bg-red(!important);           }
+.romo-table tr.romo-light-red     { @include bg-light-red(!important);     }
+.romo-table tr.romo-pastel-red    { @include bg-pastel-red(!important);    }
+.romo-table tr.romo-dark-orange   { @include bg-dark-orange(!important);   }
+.romo-table tr.romo-orange        { @include bg-orange(!important);        }
+.romo-table tr.romo-yellow        { @include bg-yellow(!important);        }
+.romo-table tr.romo-pastel-yellow { @include bg-pastel-yellow(!important); }
+.romo-table tr.romo-purple        { @include bg-purple(!important);        }
+.romo-table tr.romo-light-purple  { @include bg-light-purple(!important);  }
+.romo-table tr.romo-dark-pink     { @include bg-dark-pink(!important);     }
+.romo-table tr.romo-hot-pink      { @include bg-hot-pink(!important);      }
+.romo-table tr.romo-pink          { @include bg-pink(!important);          }
+.romo-table tr.romo-dark-green    { @include bg-dark-green(!important);    }
+.romo-table tr.romo-green         { @include bg-green(!important);         }
+.romo-table tr.romo-light-green   { @include bg-light-green(!important);   }
+.romo-table tr.romo-pastel-green  { @include bg-pastel-green(!important);  }
+.romo-table tr.romo-navy          { @include bg-navy(!important);          }
+.romo-table tr.romo-dark-blue     { @include bg-dark-blue(!important);     }
+.romo-table tr.romo-blue          { @include bg-blue(!important);          }
+.romo-table tr.romo-light-blue    { @include bg-light-blue(!important);    }
+.romo-table tr.romo-pastel-blue   { @include bg-pastel-blue(!important);   }
+
+.romo-table-hover tbody tr.romo-dark-red:hover      { @include bg-dark-red-hover(!important);      }
+.romo-table-hover tbody tr.romo-red:hover           { @include bg-red-hover(!important);           }
+.romo-table-hover tbody tr.romo-light-red:hover     { @include bg-light-red-hover(!important);     }
+.romo-table-hover tbody tr.romo-pastel-red:hover    { @include bg-pastel-red-hover(!important);    }
+.romo-table-hover tbody tr.romo-dark-orange:hover   { @include bg-dark-orange-hover(!important);   }
+.romo-table-hover tbody tr.romo-orange:hover        { @include bg-orange-hover(!important);        }
+.romo-table-hover tbody tr.romo-yellow:hover        { @include bg-yellow-hover(!important);        }
+.romo-table-hover tbody tr.romo-pastel-yellow:hover { @include bg-pastel-yellow-hover(!important); }
+.romo-table-hover tbody tr.romo-purple:hover        { @include bg-purple-hover(!important);        }
+.romo-table-hover tbody tr.romo-light-purple:hover  { @include bg-light-purple-hover(!important);  }
+.romo-table-hover tbody tr.romo-dark-pink:hover     { @include bg-dark-pink-hover(!important);     }
+.romo-table-hover tbody tr.romo-hot-pink:hover      { @include bg-hot-pink-hover(!important);      }
+.romo-table-hover tbody tr.romo-pink:hover          { @include bg-pink-hover(!important);          }
+.romo-table-hover tbody tr.romo-dark-green:hover    { @include bg-dark-green-hover(!important);    }
+.romo-table-hover tbody tr.romo-green:hover         { @include bg-green-hover(!important);         }
+.romo-table-hover tbody tr.romo-light-green:hover   { @include bg-light-green-hover(!important);   }
+.romo-table-hover tbody tr.romo-pastel-green:hover  { @include bg-pastel-green-hover(!important);  }
+.romo-table-hover tbody tr.romo-navy:hover          { @include bg-navy-hover(!important);          }
+.romo-table-hover tbody tr.romo-dark-blue:hover     { @include bg-dark-blue-hover(!important);     }
+.romo-table-hover tbody tr.romo-blue:hover          { @include bg-blue-hover(!important);          }
+.romo-table-hover tbody tr.romo-light-blue:hover    { @include bg-light-blue-hover(!important);    }
+.romo-table-hover tbody tr.romo-pastel-blue:hover   { @include bg-pastel-blue-hover(!important);   }
+
+/* emphasis colored borders */
+
+.romo-table-border-base    { @include border-base;    }
+.romo-table-border-alt     { @include border-alt;     }
+.romo-table-border-muted   { @include border-muted;   }
+.romo-table-border-warning { @include border-warning; }
+.romo-table-border-danger  { @include border-danger;  }
+.romo-table-border-info    { @include border-info;    }
+.romo-table-border-success { @include border-success; }
+.romo-table-border-inverse { @include border-inverse; }
+
+.romo-table-border-base    th, .romo-table-border-base    td { @include border-base;    }
+.romo-table-border-alt     th, .romo-table-border-alt     td { @include border-alt;     }
+.romo-table-border-muted   th, .romo-table-border-muted   td { @include border-muted;   }
+.romo-table-border-warning th, .romo-table-border-warning td { @include border-warning; }
+.romo-table-border-danger  th, .romo-table-border-danger  td { @include border-danger;  }
+.romo-table-border-info    th, .romo-table-border-info    td { @include border-info;    }
+.romo-table-border-success th, .romo-table-border-success td { @include border-success; }
+.romo-table-border-inverse th, .romo-table-border-inverse td { @include border-inverse; }
+
+/* explicit colored borders */
+
+.romo-table-border-dark-red      { @include border-dark-red;      }
+.romo-table-border-red           { @include border-red;           }
+.romo-table-border-light-red     { @include border-light-red;     }
+.romo-table-border-pastel-red    { @include border-pastel-red;    }
+.romo-table-border-dark-orange   { @include border-dark-orange;   }
+.romo-table-border-orange        { @include border-orange;        }
+.romo-table-border-yellow        { @include border-yellow;        }
+.romo-table-border-pastel-yellow { @include border-pastel-yellow; }
+.romo-table-border-purple        { @include border-purple;        }
+.romo-table-border-light-purple  { @include border-light-purple;  }
+.romo-table-border-dark-pink     { @include border-dark-pink;     }
+.romo-table-border-hot-pink      { @include border-hot-pink;      }
+.romo-table-border-pink          { @include border-pink;          }
+.romo-table-border-dark-green    { @include border-dark-green;    }
+.romo-table-border-green         { @include border-green;         }
+.romo-table-border-light-green   { @include border-light-green;   }
+.romo-table-border-pastel-green  { @include border-pastel-green;  }
+.romo-table-border-navy          { @include border-navy;          }
+.romo-table-border-dark-blue     { @include border-dark-blue;     }
+.romo-table-border-blue          { @include border-blue;          }
+.romo-table-border-light-blue    { @include border-light-blue;    }
+.romo-table-border-pastel-blue   { @include border-pastel-blue;   }
+
+.romo-table-border-dark-red      th, .romo-table-border-dark-red      td { @include border-dark-red;      }
+.romo-table-border-red           th, .romo-table-border-red           td { @include border-red;           }
+.romo-table-border-light-red     th, .romo-table-border-light-red     td { @include border-light-red;     }
+.romo-table-border-pastel-red    th, .romo-table-border-pastel-red    td { @include border-pastel-red;    }
+.romo-table-border-dark-orange   th, .romo-table-border-dark-orange   td { @include border-dark-orange;   }
+.romo-table-border-orange        th, .romo-table-border-orange        td { @include border-orange;        }
+.romo-table-border-yellow        th, .romo-table-border-yellow        td { @include border-yellow;        }
+.romo-table-border-pastel-yellow th, .romo-table-border-pastel-yellow td { @include border-pastel-yellow; }
+.romo-table-border-purple        th, .romo-table-border-purple        td { @include border-purple;        }
+.romo-table-border-light-purple  th, .romo-table-border-light-purple  td { @include border-light-purple;  }
+.romo-table-border-dark-pink     th, .romo-table-border-dark-pink     td { @include border-dark-pink;     }
+.romo-table-border-hot-pink      th, .romo-table-border-hot-pink      td { @include border-hot-pink;      }
+.romo-table-border-pink          th, .romo-table-border-pink          td { @include border-pink;          }
+.romo-table-border-dark-green    th, .romo-table-border-dark-green    td { @include border-dark-green;    }
+.romo-table-border-green         th, .romo-table-border-green         td { @include border-green;         }
+.romo-table-border-light-green   th, .romo-table-border-light-green   td { @include border-light-green;   }
+.romo-table-border-pastel-green  th, .romo-table-border-pastel-green  td { @include border-pastel-green;  }
+.romo-table-border-navy          th, .romo-table-border-navy          td { @include border-navy;          }
+.romo-table-border-dark-blue     th, .romo-table-border-dark-blue     td { @include border-dark-blue;     }
+.romo-table-border-blue          th, .romo-table-border-blue          td { @include border-blue;          }
+.romo-table-border-light-blue    th, .romo-table-border-light-blue    td { @include border-light-blue;    }
+.romo-table-border-pastel-blue   th, .romo-table-border-pastel-blue   td { @include border-pastel-blue;   }

--- a/gh-pages/view_handlers/css/buttons.md
+++ b/gh-pages/view_handlers/css/buttons.md
@@ -170,91 +170,6 @@ Use `.romo-btn-block` to add blocking full-width buttons.
 <button class="romo-btn romo-btn-block">Blocking full-width button</button>
 ```
 
-## Alternate buttons
-
-Use these as an alternative to the default styles and to add color emphasis to buttons.
-
-<div>
-  <table class="romo-table romo-table-border romo-table-striped romo-table-pad1">
-    <thead>
-      <tr>
-        <th>Disabled state</th>
-        <th>Active state</th>
-        <th>Large size</th>
-        <th>Default size</th>
-        <th>Small size</th>
-        <th>class=""</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><button href="#" class="romo-btn romo-btn-large disabled">Default</button></td>
-        <td><button href="#" class="romo-btn romo-btn-large active">Default</button></td>
-        <td><button href="#" class="romo-btn romo-btn-large">Default</button></td>
-        <td><button href="#" class="romo-btn">Default</button></td>
-        <td><button href="#" class="romo-btn romo-btn-small">Default</button></td>
-        <td><code>romo-btn</code></td>
-      </tr>
-      <tr>
-        <td><button href="#" class="romo-btn romo-btn-alt romo-btn-large disabled">Alt</button></td>
-        <td><button href="#" class="romo-btn romo-btn-alt romo-btn-large active">Alt</button></td>
-        <td><button href="#" class="romo-btn romo-btn-alt romo-btn-large">Alt</button></td>
-        <td><button href="#" class="romo-btn romo-btn-alt">Alt</button></td>
-        <td><button href="#" class="romo-btn romo-btn-alt romo-btn-small">Alt</button></td>
-        <td><code>romo-btn romo-btn-alt</code></td>
-      </tr>
-      <tr>
-        <td><button href="#" class="romo-btn romo-btn-inverse romo-btn-large disabled">Inverse</button></td>
-        <td><button href="#" class="romo-btn romo-btn-inverse romo-btn-large active">Inverse</button></td>
-        <td><button href="#" class="romo-btn romo-btn-inverse romo-btn-large">Inverse</button></td>
-        <td><button href="#" class="romo-btn romo-btn-inverse">Inverse</button></td>
-        <td><button href="#" class="romo-btn romo-btn-inverse romo-btn-small">Inverse</button></td>
-        <td><code>romo-btn romo-btn-inverse</code></td>
-      </tr>
-      <tr>
-        <td><button href="#" class="romo-btn romo-btn-warning romo-btn-large disabled">Warning</button></td>
-        <td><button href="#" class="romo-btn romo-btn-warning romo-btn-large active">Warning</button></td>
-        <td><button href="#" class="romo-btn romo-btn-warning romo-btn-large">Warning</button></td>
-        <td><button href="#" class="romo-btn romo-btn-warning">Warning</button></td>
-        <td><button href="#" class="romo-btn romo-btn-warning romo-btn-small">Warning</button></td>
-        <td><code>romo-btn romo-btn-warning</code></td>
-      </tr>
-      <tr>
-        <td><button href="#" class="romo-btn romo-btn-danger romo-btn-large disabled">Danger</button></td>
-        <td><button href="#" class="romo-btn romo-btn-danger romo-btn-large active">Danger</button></td>
-        <td><button href="#" class="romo-btn romo-btn-danger romo-btn-large">Danger</button></td>
-        <td><button href="#" class="romo-btn romo-btn-danger">Danger</button></td>
-        <td><button href="#" class="romo-btn romo-btn-danger romo-btn-small" >Danger</button></td>
-        <td><code>romo-btn romo-btn-danger</code></td>
-      </tr>
-      <tr>
-        <td><button href="#" class="romo-btn romo-btn-info romo-btn-large disabled">Info</button></td>
-        <td><button href="#" class="romo-btn romo-btn-info romo-btn-large active">Info</button></td>
-        <td><button href="#" class="romo-btn romo-btn-info romo-btn-large">Info</button></td>
-        <td><button href="#" class="romo-btn romo-btn-info">Info</button></td>
-        <td><button href="#" class="romo-btn romo-btn-info romo-btn-small">Info</button></td>
-        <td><code>romo-btn romo-btn-info</code></td>
-      </tr>
-      <tr>
-        <td><button href="#" class="romo-btn romo-btn-success romo-btn-large disabled">Success</button></td>
-        <td><button href="#" class="romo-btn romo-btn-success romo-btn-large active">Success</button></td>
-        <td><button href="#" class="romo-btn romo-btn-success romo-btn-large">Success</button></td>
-        <td><button href="#" class="romo-btn romo-btn-success">Success</button></td>
-        <td><button href="#" class="romo-btn romo-btn-success romo-btn-small">Success</button></td>
-        <td><code>romo-btn romo-btn-success</code></td>
-      </tr>
-      <tr>
-        <td><button href="#" class="romo-btn romo-btn-link romo-btn-large disabled">Link</button></td>
-        <td><button href="#" class="romo-btn romo-btn-link romo-btn-large active">Link</button></td>
-        <td><button href="#" class="romo-btn romo-btn-link romo-btn-large">Link</button></td>
-        <td><button href="#" class="romo-btn romo-btn-link">Link</button></td>
-        <td><button href="#" class="romo-btn romo-btn-link romo-btn-small">Link</button></td>
-        <td><code>romo-btn romo-btn-link</code></td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-
 ## Button groups
 
 Group buttons together by wrapping them in `.romo-btn-group`.
@@ -566,3 +481,304 @@ Optionally with border radius.
   </div>
 </div>
 ```
+
+## Colored buttons
+
+Use style classes to add color buttons based on an implicit emphasis OR an explicit name.
+
+## Basic
+
+<div class="romo-push2-bottom">
+  <table class="romo-table romo-table-border romo-table-pad1">
+    <thead>
+      <tr>
+        <th>Disabled state</th>
+        <th>Active state</th>
+        <th>Large size</th>
+        <th>Default size</th>
+        <th>Small size</th>
+        <th>class=""</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><button href="#" class="romo-btn romo-btn-large disabled">Default</button></td>
+        <td><button href="#" class="romo-btn romo-btn-large active">Default</button></td>
+        <td><button href="#" class="romo-btn romo-btn-large">Default</button></td>
+        <td><button href="#" class="romo-btn">Default</button></td>
+        <td><button href="#" class="romo-btn romo-btn-small">Default</button></td>
+        <td><code>romo-btn</code></td>
+      </tr>
+      <tr>
+        <td><button href="#" class="romo-btn romo-btn-alt romo-btn-large disabled">Alt</button></td>
+        <td><button href="#" class="romo-btn romo-btn-alt romo-btn-large active">Alt</button></td>
+        <td><button href="#" class="romo-btn romo-btn-alt romo-btn-large">Alt</button></td>
+        <td><button href="#" class="romo-btn romo-btn-alt">Alt</button></td>
+        <td><button href="#" class="romo-btn romo-btn-alt romo-btn-small">Alt</button></td>
+        <td><code>romo-btn romo-btn-alt</code></td>
+      </tr>
+      <tr>
+        <td><button href="#" class="romo-btn romo-btn-link romo-btn-large disabled">Link</button></td>
+        <td><button href="#" class="romo-btn romo-btn-link romo-btn-large active">Link</button></td>
+        <td><button href="#" class="romo-btn romo-btn-link romo-btn-large">Link</button></td>
+        <td><button href="#" class="romo-btn romo-btn-link">Link</button></td>
+        <td><button href="#" class="romo-btn romo-btn-link romo-btn-small">Link</button></td>
+        <td><code>romo-btn romo-btn-link</code></td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+### Explicit
+
+<div class="romo-push2-bottom">
+  <table class="romo-table romo-table-border romo-table-pad1">
+    <thead>
+      <tr>
+        <th>Disabled state</th>
+        <th>Active state</th>
+        <th>Large size</th>
+        <th>Default size</th>
+        <th>Small size</th>
+        <th>class=""</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><button href="#" class="romo-btn romo-btn-dark-red romo-btn-large disabled">Dark Red</button></td>
+        <td><button href="#" class="romo-btn romo-btn-dark-red romo-btn-large active">Dark Red</button></td>
+        <td><button href="#" class="romo-btn romo-btn-dark-red romo-btn-large">Dark Red</button></td>
+        <td><button href="#" class="romo-btn romo-btn-dark-red">Dark Red</button></td>
+        <td><button href="#" class="romo-btn romo-btn-dark-red romo-btn-small">Dark Red</button></td>
+        <td><code>romo-btn romo-btn-dark-red</code></td>
+      </tr>
+      <tr>
+        <td><button href="#" class="romo-btn romo-btn-red romo-btn-large disabled">Red</button></td>
+        <td><button href="#" class="romo-btn romo-btn-red romo-btn-large active">Red</button></td>
+        <td><button href="#" class="romo-btn romo-btn-red romo-btn-large">Red</button></td>
+        <td><button href="#" class="romo-btn romo-btn-red">Red</button></td>
+        <td><button href="#" class="romo-btn romo-btn-red romo-btn-small">Red</button></td>
+        <td><code>romo-btn romo-btn-red</code></td>
+      </tr>
+      <tr>
+        <td><button href="#" class="romo-btn romo-btn-light-red romo-btn-large disabled">Light Red</button></td>
+        <td><button href="#" class="romo-btn romo-btn-light-red romo-btn-large active">Light Red</button></td>
+        <td><button href="#" class="romo-btn romo-btn-light-red romo-btn-large">Light Red</button></td>
+        <td><button href="#" class="romo-btn romo-btn-light-red">Light Red</button></td>
+        <td><button href="#" class="romo-btn romo-btn-light-red romo-btn-small">Light Red</button></td>
+        <td><code>romo-btn romo-btn-light-red</code></td>
+      </tr>
+      <tr>
+        <td><button href="#" class="romo-btn romo-btn-pastel-red romo-btn-large disabled">Pastel Red</button></td>
+        <td><button href="#" class="romo-btn romo-btn-pastel-red romo-btn-large active">Pastel Red</button></td>
+        <td><button href="#" class="romo-btn romo-btn-pastel-red romo-btn-large">Pastel Red</button></td>
+        <td><button href="#" class="romo-btn romo-btn-pastel-red">Pastel Red</button></td>
+        <td><button href="#" class="romo-btn romo-btn-pastel-red romo-btn-small">Pastel Red</button></td>
+        <td><code>romo-btn romo-btn-pastel-red</code></td>
+      </tr>
+      <tr>
+        <td><button href="#" class="romo-btn romo-btn-dark-orange romo-btn-large disabled">Dark Orange</button></td>
+        <td><button href="#" class="romo-btn romo-btn-dark-orange romo-btn-large active">Dark Orange</button></td>
+        <td><button href="#" class="romo-btn romo-btn-dark-orange romo-btn-large">Dark Orange</button></td>
+        <td><button href="#" class="romo-btn romo-btn-dark-orange">Dark Orange</button></td>
+        <td><button href="#" class="romo-btn romo-btn-dark-orange romo-btn-small">Dark Orange</button></td>
+        <td><code>romo-btn romo-btn-dark-orange</code></td>
+      </tr>
+      <tr>
+        <td><button href="#" class="romo-btn romo-btn-orange romo-btn-large disabled">Orange</button></td>
+        <td><button href="#" class="romo-btn romo-btn-orange romo-btn-large active">Orange</button></td>
+        <td><button href="#" class="romo-btn romo-btn-orange romo-btn-large">Orange</button></td>
+        <td><button href="#" class="romo-btn romo-btn-orange">Orange</button></td>
+        <td><button href="#" class="romo-btn romo-btn-orange romo-btn-small">Orange</button></td>
+        <td><code>romo-btn romo-btn-orange</code></td>
+      </tr>
+      <tr>
+        <td><button href="#" class="romo-btn romo-btn-yellow romo-btn-large disabled">Yellow</button></td>
+        <td><button href="#" class="romo-btn romo-btn-yellow romo-btn-large active">Yellow</button></td>
+        <td><button href="#" class="romo-btn romo-btn-yellow romo-btn-large">Yellow</button></td>
+        <td><button href="#" class="romo-btn romo-btn-yellow">Yellow</button></td>
+        <td><button href="#" class="romo-btn romo-btn-yellow romo-btn-small">Yellow</button></td>
+        <td><code>romo-btn romo-btn-yellow</code></td>
+      </tr>
+      <tr>
+        <td><button href="#" class="romo-btn romo-btn-pastel-yellow romo-btn-large disabled">Pastel Yellow</button></td>
+        <td><button href="#" class="romo-btn romo-btn-pastel-yellow romo-btn-large active">Pastel Yellow</button></td>
+        <td><button href="#" class="romo-btn romo-btn-pastel-yellow romo-btn-large">Pastel Yellow</button></td>
+        <td><button href="#" class="romo-btn romo-btn-pastel-yellow">Pastel Yellow</button></td>
+        <td><button href="#" class="romo-btn romo-btn-pastel-yellow romo-btn-small">Pastel Yellow</button></td>
+        <td><code>romo-btn romo-btn-pastel-yellow</code></td>
+      </tr>
+      <tr>
+        <td><button href="#" class="romo-btn romo-btn-purple romo-btn-large disabled">Purple</button></td>
+        <td><button href="#" class="romo-btn romo-btn-purple romo-btn-large active">Purple</button></td>
+        <td><button href="#" class="romo-btn romo-btn-purple romo-btn-large">Purple</button></td>
+        <td><button href="#" class="romo-btn romo-btn-purple">Purple</button></td>
+        <td><button href="#" class="romo-btn romo-btn-purple romo-btn-small">Purple</button></td>
+        <td><code>romo-btn romo-btn-purple</code></td>
+      </tr>
+      <tr>
+        <td><button href="#" class="romo-btn romo-btn-light-purple romo-btn-large disabled">Light Purple</button></td>
+        <td><button href="#" class="romo-btn romo-btn-light-purple romo-btn-large active">Light Purple</button></td>
+        <td><button href="#" class="romo-btn romo-btn-light-purple romo-btn-large">Light Purple</button></td>
+        <td><button href="#" class="romo-btn romo-btn-light-purple">Light Purple</button></td>
+        <td><button href="#" class="romo-btn romo-btn-light-purple romo-btn-small">Light Purple</button></td>
+        <td><code>romo-btn romo-btn-light-purple</code></td>
+      </tr>
+      <tr>
+        <td><button href="#" class="romo-btn romo-btn-dark-pink romo-btn-large disabled">Dark Pink</button></td>
+        <td><button href="#" class="romo-btn romo-btn-dark-pink romo-btn-large active">Dark Pink</button></td>
+        <td><button href="#" class="romo-btn romo-btn-dark-pink romo-btn-large">Dark Pink</button></td>
+        <td><button href="#" class="romo-btn romo-btn-dark-pink">Dark Pink</button></td>
+        <td><button href="#" class="romo-btn romo-btn-dark-pink romo-btn-small">Dark Pink</button></td>
+        <td><code>romo-btn romo-btn-dark-pink</code></td>
+      </tr>
+      <tr>
+        <td><button href="#" class="romo-btn romo-btn-hot-pink romo-btn-large disabled">Hot Pink</button></td>
+        <td><button href="#" class="romo-btn romo-btn-hot-pink romo-btn-large active">Hot Pink</button></td>
+        <td><button href="#" class="romo-btn romo-btn-hot-pink romo-btn-large">Hot Pink</button></td>
+        <td><button href="#" class="romo-btn romo-btn-hot-pink">Hot Pink</button></td>
+        <td><button href="#" class="romo-btn romo-btn-hot-pink romo-btn-small">Hot Pink</button></td>
+        <td><code>romo-btn romo-btn-hot-pink</code></td>
+      </tr>
+      <tr>
+        <td><button href="#" class="romo-btn romo-btn-pink romo-btn-large disabled">Pink</button></td>
+        <td><button href="#" class="romo-btn romo-btn-pink romo-btn-large active">Pink</button></td>
+        <td><button href="#" class="romo-btn romo-btn-pink romo-btn-large">Pink</button></td>
+        <td><button href="#" class="romo-btn romo-btn-pink">Pink</button></td>
+        <td><button href="#" class="romo-btn romo-btn-pink romo-btn-small">Pink</button></td>
+        <td><code>romo-btn romo-btn-pink</code></td>
+      </tr>
+      <tr>
+        <td><button href="#" class="romo-btn romo-btn-dark-green romo-btn-large disabled">Dark Green</button></td>
+        <td><button href="#" class="romo-btn romo-btn-dark-green romo-btn-large active">Dark Green</button></td>
+        <td><button href="#" class="romo-btn romo-btn-dark-green romo-btn-large">Dark Green</button></td>
+        <td><button href="#" class="romo-btn romo-btn-dark-green">Dark Green</button></td>
+        <td><button href="#" class="romo-btn romo-btn-dark-green romo-btn-small">Dark Green</button></td>
+        <td><code>romo-btn romo-btn-dark-green</code></td>
+      </tr>
+      <tr>
+        <td><button href="#" class="romo-btn romo-btn-green romo-btn-large disabled">Green</button></td>
+        <td><button href="#" class="romo-btn romo-btn-green romo-btn-large active">Green</button></td>
+        <td><button href="#" class="romo-btn romo-btn-green romo-btn-large">Green</button></td>
+        <td><button href="#" class="romo-btn romo-btn-green">Green</button></td>
+        <td><button href="#" class="romo-btn romo-btn-green romo-btn-small">Green</button></td>
+        <td><code>romo-btn romo-btn-green</code></td>
+      </tr>
+      <tr>
+        <td><button href="#" class="romo-btn romo-btn-light-green romo-btn-large disabled">Light Green</button></td>
+        <td><button href="#" class="romo-btn romo-btn-light-green romo-btn-large active">Light Green</button></td>
+        <td><button href="#" class="romo-btn romo-btn-light-green romo-btn-large">Light Green</button></td>
+        <td><button href="#" class="romo-btn romo-btn-light-green">Light Green</button></td>
+        <td><button href="#" class="romo-btn romo-btn-light-green romo-btn-small">Light Green</button></td>
+        <td><code>romo-btn romo-btn-light-green</code></td>
+      </tr>
+      <tr>
+        <td><button href="#" class="romo-btn romo-btn-pastel-green romo-btn-large disabled">Pastel Green</button></td>
+        <td><button href="#" class="romo-btn romo-btn-pastel-green romo-btn-large active">Pastel Green</button></td>
+        <td><button href="#" class="romo-btn romo-btn-pastel-green romo-btn-large">Pastel Green</button></td>
+        <td><button href="#" class="romo-btn romo-btn-pastel-green">Pastel Green</button></td>
+        <td><button href="#" class="romo-btn romo-btn-pastel-green romo-btn-small">Pastel Green</button></td>
+        <td><code>romo-btn romo-btn-pastel-green</code></td>
+      </tr>
+      <tr>
+        <td><button href="#" class="romo-btn romo-btn-navy romo-btn-large disabled">Navy</button></td>
+        <td><button href="#" class="romo-btn romo-btn-navy romo-btn-large active">Navy</button></td>
+        <td><button href="#" class="romo-btn romo-btn-navy romo-btn-large">Navy</button></td>
+        <td><button href="#" class="romo-btn romo-btn-navy">Navy</button></td>
+        <td><button href="#" class="romo-btn romo-btn-navy romo-btn-small">Navy</button></td>
+        <td><code>romo-btn romo-btn-navy</code></td>
+      </tr>
+      <tr>
+        <td><button href="#" class="romo-btn romo-btn-dark-blue romo-btn-large disabled">Dark Blue</button></td>
+        <td><button href="#" class="romo-btn romo-btn-dark-blue romo-btn-large active">Dark Blue</button></td>
+        <td><button href="#" class="romo-btn romo-btn-dark-blue romo-btn-large">Dark Blue</button></td>
+        <td><button href="#" class="romo-btn romo-btn-dark-blue">Dark Blue</button></td>
+        <td><button href="#" class="romo-btn romo-btn-dark-blue romo-btn-small">Dark Blue</button></td>
+        <td><code>romo-btn romo-btn-dark-blue</code></td>
+      </tr>
+      <tr>
+        <td><button href="#" class="romo-btn romo-btn-blue romo-btn-large disabled">Blue</button></td>
+        <td><button href="#" class="romo-btn romo-btn-blue romo-btn-large active">Blue</button></td>
+        <td><button href="#" class="romo-btn romo-btn-blue romo-btn-large">Blue</button></td>
+        <td><button href="#" class="romo-btn romo-btn-blue">Blue</button></td>
+        <td><button href="#" class="romo-btn romo-btn-blue romo-btn-small">Blue</button></td>
+        <td><code>romo-btn romo-btn-blue</code></td>
+      </tr>
+      <tr>
+        <td><button href="#" class="romo-btn romo-btn-light-blue romo-btn-large disabled">Light Blue</button></td>
+        <td><button href="#" class="romo-btn romo-btn-light-blue romo-btn-large active">Light Blue</button></td>
+        <td><button href="#" class="romo-btn romo-btn-light-blue romo-btn-large">Light Blue</button></td>
+        <td><button href="#" class="romo-btn romo-btn-light-blue">Light Blue</button></td>
+        <td><button href="#" class="romo-btn romo-btn-light-blue romo-btn-small">Light Blue</button></td>
+        <td><code>romo-btn romo-btn-light-blue</code></td>
+      </tr>
+      <tr>
+        <td><button href="#" class="romo-btn romo-btn-pastel-blue romo-btn-large disabled">Pastel Blue</button></td>
+        <td><button href="#" class="romo-btn romo-btn-pastel-blue romo-btn-large active">Pastel Blue</button></td>
+        <td><button href="#" class="romo-btn romo-btn-pastel-blue romo-btn-large">Pastel Blue</button></td>
+        <td><button href="#" class="romo-btn romo-btn-pastel-blue">Pastel Blue</button></td>
+        <td><button href="#" class="romo-btn romo-btn-pastel-blue romo-btn-small">Pastel Blue</button></td>
+        <td><code>romo-btn romo-btn-pastel-blue</code></td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+### Emphasis
+
+<div class="romo-push2-bottom">
+  <table class="romo-table romo-table-border romo-table-pad1">
+    <thead>
+      <tr>
+        <th>Disabled state</th>
+        <th>Active state</th>
+        <th>Large size</th>
+        <th>Default size</th>
+        <th>Small size</th>
+        <th>class="" - Basis Color</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><button href="#" class="romo-btn romo-btn-warning romo-btn-large disabled">Warning</button></td>
+        <td><button href="#" class="romo-btn romo-btn-warning romo-btn-large active">Warning</button></td>
+        <td><button href="#" class="romo-btn romo-btn-warning romo-btn-large">Warning</button></td>
+        <td><button href="#" class="romo-btn romo-btn-warning">Warning</button></td>
+        <td><button href="#" class="romo-btn romo-btn-warning romo-btn-small">Warning</button></td>
+        <td><code>romo-btn romo-btn-warning</code> - <code>$orange</code></td>
+      </tr>
+      <tr>
+        <td><button href="#" class="romo-btn romo-btn-danger romo-btn-large disabled">Danger</button></td>
+        <td><button href="#" class="romo-btn romo-btn-danger romo-btn-large active">Danger</button></td>
+        <td><button href="#" class="romo-btn romo-btn-danger romo-btn-large">Danger</button></td>
+        <td><button href="#" class="romo-btn romo-btn-danger">Danger</button></td>
+        <td><button href="#" class="romo-btn romo-btn-danger romo-btn-small" >Danger</button></td>
+        <td><code>romo-btn romo-btn-danger - <code>$red</code></code></td>
+      </tr>
+      <tr>
+        <td><button href="#" class="romo-btn romo-btn-info romo-btn-large disabled">Info</button></td>
+        <td><button href="#" class="romo-btn romo-btn-info romo-btn-large active">Info</button></td>
+        <td><button href="#" class="romo-btn romo-btn-info romo-btn-large">Info</button></td>
+        <td><button href="#" class="romo-btn romo-btn-info">Info</button></td>
+        <td><button href="#" class="romo-btn romo-btn-info romo-btn-small">Info</button></td>
+        <td><code>romo-btn romo-btn-info</code> - <code>$blue</code></td>
+      </tr>
+      <tr>
+        <td><button href="#" class="romo-btn romo-btn-success romo-btn-large disabled">Success</button></td>
+        <td><button href="#" class="romo-btn romo-btn-success romo-btn-large active">Success</button></td>
+        <td><button href="#" class="romo-btn romo-btn-success romo-btn-large">Success</button></td>
+        <td><button href="#" class="romo-btn romo-btn-success">Success</button></td>
+        <td><button href="#" class="romo-btn romo-btn-success romo-btn-small">Success</button></td>
+        <td><code>romo-btn romo-btn-success</code> - <code>$green</code></td>
+      </tr>
+      <tr>
+        <td><button href="#" class="romo-btn romo-btn-inverse romo-btn-large disabled">Inverse</button></td>
+        <td><button href="#" class="romo-btn romo-btn-inverse romo-btn-large active">Inverse</button></td>
+        <td><button href="#" class="romo-btn romo-btn-inverse romo-btn-large">Inverse</button></td>
+        <td><button href="#" class="romo-btn romo-btn-inverse">Inverse</button></td>
+        <td><button href="#" class="romo-btn romo-btn-inverse romo-btn-small">Inverse</button></td>
+        <td><code>romo-btn romo-btn-inverse</code> - <code>$inverseColor</code></td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/gh-pages/view_handlers/css/grid_tables.md
+++ b/gh-pages/view_handlers/css/grid_tables.md
@@ -24,1307 +24,733 @@ For basic styling, wrap the grid markup and add the base classes `.romo-list-tab
 <div>
   <ul class="romo-grid-table">
     <li class="romo-row">
-      <span class="romo-span romo-1-12">1</span>
-      <span class="romo-span romo-5-12">Joe Test</span>
+      <span class="romo-span romo-6-12">Joe Test</span>
       <span class="romo-span romo-5-12">joe-test</span>
       <span class="romo-span romo-1-12">10</span>
     </li>
     <li class="romo-row">
-      <span class="romo-span romo-1-12">2</span>
-      <span class="romo-span romo-5-12">Jane Doe</span>
+      <span class="romo-span romo-6-12">Jane Doe</span>
       <span class="romo-span romo-5-12">jane-doe</span>
       <span class="romo-span romo-1-12">18</span>
     </li>
     <li class="romo-row">
-      <span class="romo-span romo-1-12">3</span>
-      <span class="romo-span romo-5-12">Good Corp.</span>
+      <span class="romo-span romo-6-12">Good Corp.</span>
       <span class="romo-span romo-5-12">good-corp</span>
       <span class="romo-span romo-1-12">5</span>
     </li>
   </ul>
 </div>
-
-```html
-<ul class="romo-grid-table">
-  <li class="romo-row">
-    ...
-  </li>
-  <li class="romo-row">
-    ...
-  </li>
-</ul>
-```
 
 ## Optional classes
 
-### `.romo-grid-table-header`
+`.romo-grid-table-header` assumes the first row is a header row and styles it.
 
-Assumes the first row is a header row and styles it.
-
-<div>
+<div class="romo-push2-bottom">
   <ul class="romo-grid-table romo-grid-table-header">
     <li class="romo-row">
-      <span class="romo-span romo-1-12">#</span>
-      <span class="romo-span romo-5-12">Name</span>
+      <span class="romo-span romo-6-12">Name</span>
       <span class="romo-span romo-5-12">Slug</span>
       <span class="romo-span romo-1-12">Count</span>
     </li>
     <li class="romo-row">
-      <span class="romo-span romo-1-12">1</span>
-      <span class="romo-span romo-5-12">Joe Test</span>
+      <span class="romo-span romo-6-12">Joe Test</span>
       <span class="romo-span romo-5-12">joe-test</span>
       <span class="romo-span romo-1-12">10</span>
     </li>
     <li class="romo-row">
-      <span class="romo-span romo-1-12">2</span>
-      <span class="romo-span romo-5-12">Jane Doe</span>
+      <span class="romo-span romo-6-12">Jane Doe</span>
       <span class="romo-span romo-5-12">jane-doe</span>
       <span class="romo-span romo-1-12">18</span>
     </li>
     <li class="romo-row">
-      <span class="romo-span romo-1-12">3</span>
-      <span class="romo-span romo-5-12">Good Corp.</span>
+      <span class="romo-span romo-6-12">Good Corp.</span>
       <span class="romo-span romo-5-12">good-corp</span>
       <span class="romo-span romo-1-12">5</span>
     </li>
   </ul>
 </div>
 
-```html
-<ul class="romo-grid-table romo-grid-table-header">
-  ...
-</ul>
-```
+`.romo-grid-table-striped{.romo-grid-table-striped-alt}` adds zebra-striping to grid table rows via the `:nth-child` CSS selector.
 
-### `.romo-grid-table-striped`
-
-Adds zebra-striping to grid table rows via the `:nth-child` CSS selector.
-
-<div class="romo-pad2-bottom">
-  <ul class="romo-grid-table romo-grid-table-striped">
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">1</span>
-      <span class="romo-span romo-5-12">Joe Test</span>
-      <span class="romo-span romo-5-12">joe-test</span>
-      <span class="romo-span romo-1-12">10</span>
-    </li>
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">2</span>
-      <span class="romo-span romo-5-12">Jane Doe</span>
-      <span class="romo-span romo-5-12">jane-doe</span>
-      <span class="romo-span romo-1-12">18</span>
-    </li>
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">3</span>
-      <span class="romo-span romo-5-12">Good Corp.</span>
-      <span class="romo-span romo-5-12">good-corp</span>
-      <span class="romo-span romo-1-12">5</span>
-    </li>
-  </ul>
-</div>
-
-<div class="romo-pad2-bottom">
+<div class="romo-push-bottom">
   <ul class="romo-grid-table romo-grid-table-header romo-grid-table-striped">
     <li class="romo-row">
-      <span class="romo-span romo-1-12">#</span>
-      <span class="romo-span romo-5-12">Name</span>
+      <span class="romo-span romo-6-12">Name</span>
       <span class="romo-span romo-5-12">Slug</span>
       <span class="romo-span romo-1-12">Count</span>
     </li>
     <li class="romo-row">
-      <span class="romo-span romo-1-12">1</span>
-      <span class="romo-span romo-5-12">Joe Test</span>
+      <span class="romo-span romo-6-12">Joe Test</span>
       <span class="romo-span romo-5-12">joe-test</span>
       <span class="romo-span romo-1-12">10</span>
     </li>
     <li class="romo-row">
-      <span class="romo-span romo-1-12">2</span>
-      <span class="romo-span romo-5-12">Jane Doe</span>
+      <span class="romo-span romo-6-12">Jane Doe</span>
       <span class="romo-span romo-5-12">jane-doe</span>
       <span class="romo-span romo-1-12">18</span>
     </li>
     <li class="romo-row">
-      <span class="romo-span romo-1-12">3</span>
-      <span class="romo-span romo-5-12">Good Corp.</span>
+      <span class="romo-span romo-6-12">Good Corp.</span>
       <span class="romo-span romo-5-12">good-corp</span>
       <span class="romo-span romo-1-12">5</span>
     </li>
   </ul>
 </div>
 
-<div>
+<div class="romo-push2-bottom">
   <ul class="romo-grid-table romo-grid-table-header romo-grid-table-striped romo-grid-table-striped-alt">
     <li class="romo-row">
-      <span class="romo-span romo-1-12">#</span>
-      <span class="romo-span romo-5-12">Name</span>
+      <span class="romo-span romo-6-12">Name</span>
       <span class="romo-span romo-5-12">Slug</span>
       <span class="romo-span romo-1-12">Count</span>
     </li>
     <li class="romo-row">
-      <span class="romo-span romo-1-12">1</span>
-      <span class="romo-span romo-5-12">Joe Test</span>
+      <span class="romo-span romo-6-12">Joe Test</span>
       <span class="romo-span romo-5-12">joe-test</span>
       <span class="romo-span romo-1-12">10</span>
     </li>
     <li class="romo-row">
-      <span class="romo-span romo-1-12">2</span>
-      <span class="romo-span romo-5-12">Jane Doe</span>
+      <span class="romo-span romo-6-12">Jane Doe</span>
       <span class="romo-span romo-5-12">jane-doe</span>
       <span class="romo-span romo-1-12">18</span>
     </li>
     <li class="romo-row">
-      <span class="romo-span romo-1-12">3</span>
-      <span class="romo-span romo-5-12">Good Corp.</span>
+      <span class="romo-span romo-6-12">Good Corp.</span>
       <span class="romo-span romo-5-12">good-corp</span>
       <span class="romo-span romo-1-12">5</span>
     </li>
   </ul>
 </div>
 
-```html
-<ul class="romo-grid-table romo-grid-table-striped">
-  ...
-</ul>
-<ul class="romo-grid-table romo-grid-table-header romo-grid-table-striped">
-  ...
-</ul>
-<ul class="romo-grid-table romo-grid-table-striped romo-grid-table-striped-alt">
-  ...
-</ul>
-```
+`.romo-grid-table-alt` uses the alternate bg color for the table background.
 
-### `.romo-grid-table-alt`
-
-Uses the alternate bg color for the table background.
-
-<div>
-  <ul class="romo-grid-table romo-grid-table-alt romo-grid-table-header">
+<div class="romo-push2-bottom">
+  <ul class="romo-grid-table romo-grid-table-header romo-grid-table-alt">
     <li class="romo-row">
-      <span class="romo-span romo-1-12">#</span>
-      <span class="romo-span romo-5-12">Name</span>
+      <span class="romo-span romo-6-12">Name</span>
       <span class="romo-span romo-5-12">Slug</span>
       <span class="romo-span romo-1-12">Count</span>
     </li>
     <li class="romo-row">
-      <span class="romo-span romo-1-12">1</span>
-      <span class="romo-span romo-5-12">Joe Test</span>
+      <span class="romo-span romo-6-12">Joe Test</span>
       <span class="romo-span romo-5-12">joe-test</span>
       <span class="romo-span romo-1-12">10</span>
     </li>
     <li class="romo-row">
-      <span class="romo-span romo-1-12">2</span>
-      <span class="romo-span romo-5-12">Jane Doe</span>
+      <span class="romo-span romo-6-12">Jane Doe</span>
       <span class="romo-span romo-5-12">jane-doe</span>
       <span class="romo-span romo-1-12">18</span>
     </li>
     <li class="romo-row">
-      <span class="romo-span romo-1-12">3</span>
-      <span class="romo-span romo-5-12">Good Corp.</span>
+      <span class="romo-span romo-6-12">Good Corp.</span>
       <span class="romo-span romo-5-12">good-corp</span>
       <span class="romo-span romo-1-12">5</span>
     </li>
   </ul>
 </div>
 
-```html
-<ul class="romo-grid-table romo-grid-table-alt">
-  ...
-</ul>
-```
+`.romo-grid-table-hover` add hover state to rows.
 
-### `.romo-row.romo-{muted|warning|danger|info|success|inverse}`
-
-Add color emphasis to grid table rows.
-
-<div>
-  <ul class="romo-grid-table romo-grid-table-header">
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">#</span>
-      <span class="romo-span romo-5-12">Name</span>
-      <span class="romo-span romo-5-12">Slug</span>
-      <span class="romo-span romo-1-12">Count</span>
-    </li>
-    <li class="romo-row romo-base">
-      <span class="romo-span romo-1-12">1</span>
-      <span class="romo-span romo-5-12">Joe Test</span>
-      <span class="romo-span romo-5-12">joe-test</span>
-      <span class="romo-span romo-1-12">10</span>
-    </li>
-    <li class="romo-row romo-alt">
-      <span class="romo-span romo-1-12">1</span>
-      <span class="romo-span romo-5-12">Joe Test</span>
-      <span class="romo-span romo-5-12">joe-test</span>
-      <span class="romo-span romo-1-12">10</span>
-    </li>
-    <li class="romo-row romo-muted">
-      <span class="romo-span romo-1-12">1</span>
-      <span class="romo-span romo-5-12">Joe Test</span>
-      <span class="romo-span romo-5-12">joe-test</span>
-      <span class="romo-span romo-1-12">10</span>
-    </li>
-    <li class="romo-row romo-warning">
-      <span class="romo-span romo-1-12">2</span>
-      <span class="romo-span romo-5-12">Jane Doe</span>
-      <span class="romo-span romo-5-12">jane-doe</span>
-      <span class="romo-span romo-1-12">18</span>
-    </li>
-    <li class="romo-row romo-danger">
-      <span class="romo-span romo-1-12">3</span>
-      <span class="romo-span romo-5-12">Good Corp.</span>
-      <span class="romo-span romo-5-12">good-corp</span>
-      <span class="romo-span romo-1-12">5</span>
-    </li>
-    <li class="romo-row romo-info">
-      <span class="romo-span romo-1-12">1</span>
-      <span class="romo-span romo-5-12">Joe Test</span>
-      <span class="romo-span romo-5-12">joe-test</span>
-      <span class="romo-span romo-1-12">10</span>
-    </li>
-    <li class="romo-row romo-success">
-      <span class="romo-span romo-1-12">2</span>
-      <span class="romo-span romo-5-12">Jane Doe</span>
-      <span class="romo-span romo-5-12">jane-doe</span>
-      <span class="romo-span romo-1-12">18</span>
-    </li>
-    <li class="romo-row romo-inverse romo-text-inverse">
-      <span class="romo-span romo-1-12">3</span>
-      <span class="romo-span romo-5-12">Good Corp.</span>
-      <span class="romo-span romo-5-12">good-corp</span>
-      <span class="romo-span romo-1-12">5</span>
-    </li>
-  </ul>
-</div>
-
-```html
-<ul class="romo-grid-table romo-grid-table-header">
-  <li class="romo-row">...</li>
-  <li class="romo-row romo-base">...</li>
-  <li class="romo-row romo-alt">...</li>
-  <li class="romo-row romo-muted">...</li>
-  <li class="romo-row romo-warning">...</li>
-  <li class="romo-row romo-danger">...</li>
-  <li class="romo-row romo-info">...</li>
-  <li class="romo-row romo-success">...</li>
-  <li class="romo-row romo-inverse romo-text-inverse">...</li>
-</ul>
-```
-
-### `.romo-grid-table-hover`
-
-Add hover state to rows
-
-<div class="romo-pad2-bottom">
-  <ul class="romo-grid-table romo-grid-table-hover">
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">1</span>
-      <span class="romo-span romo-5-12">Joe Test</span>
-      <span class="romo-span romo-5-12">joe-test</span>
-      <span class="romo-span romo-1-12">10</span>
-    </li>
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">2</span>
-      <span class="romo-span romo-5-12">Jane Doe</span>
-      <span class="romo-span romo-5-12">jane-doe</span>
-      <span class="romo-span romo-1-12">18</span>
-    </li>
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">3</span>
-      <span class="romo-span romo-5-12">Good Corp.</span>
-      <span class="romo-span romo-5-12">good-corp</span>
-      <span class="romo-span romo-1-12">5</span>
-    </li>
-  </ul>
-</div>
-
-<div>
+<div class="romo-push2-bottom">
   <ul class="romo-grid-table romo-grid-table-header romo-grid-table-hover">
     <li class="romo-row">
-      <span class="romo-span romo-1-12">#</span>
-      <span class="romo-span romo-5-12">Name</span>
+      <span class="romo-span romo-6-12">Name</span>
       <span class="romo-span romo-5-12">Slug</span>
       <span class="romo-span romo-1-12">Count</span>
     </li>
     <li class="romo-row">
-      <span class="romo-span romo-1-12">1</span>
-      <span class="romo-span romo-5-12">Joe Test</span>
+      <span class="romo-span romo-6-12">Joe Test</span>
       <span class="romo-span romo-5-12">joe-test</span>
       <span class="romo-span romo-1-12">10</span>
     </li>
     <li class="romo-row">
-      <span class="romo-span romo-1-12">2</span>
-      <span class="romo-span romo-5-12">Jane Doe</span>
+      <span class="romo-span romo-6-12">Jane Doe</span>
       <span class="romo-span romo-5-12">jane-doe</span>
       <span class="romo-span romo-1-12">18</span>
     </li>
     <li class="romo-row">
-      <span class="romo-span romo-1-12">3</span>
-      <span class="romo-span romo-5-12">Good Corp.</span>
+      <span class="romo-span romo-6-12">Good Corp.</span>
       <span class="romo-span romo-5-12">good-corp</span>
       <span class="romo-span romo-1-12">5</span>
     </li>
   </ul>
 </div>
 
-```html
-<ul class="romo-grid-table romo-grid-table-hover">
-  ...
-</ul>
-<ul class="romo-grid-table romo-grid-table-header romo-grid-table-hover">
-  ...
-</ul>
-```
-
-<div class="romo-pad2-bottom">
-  <ul class="romo-grid-table romo-grid-table-hover romo-grid-table-striped">
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">1</span>
-      <span class="romo-span romo-5-12">Joe Test</span>
-      <span class="romo-span romo-5-12">joe-test</span>
-      <span class="romo-span romo-1-12">10</span>
-    </li>
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">2</span>
-      <span class="romo-span romo-5-12">Jane Doe</span>
-      <span class="romo-span romo-5-12">jane-doe</span>
-      <span class="romo-span romo-1-12">18</span>
-    </li>
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">3</span>
-      <span class="romo-span romo-5-12">Good Corp.</span>
-      <span class="romo-span romo-5-12">good-corp</span>
-      <span class="romo-span romo-1-12">5</span>
-    </li>
-  </ul>
-</div>
-
-<div>
-  <ul class="romo-grid-table romo-grid-table-header romo-grid-table-hover romo-grid-table-striped">
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">#</span>
-      <span class="romo-span romo-5-12">Name</span>
-      <span class="romo-span romo-5-12">Slug</span>
-      <span class="romo-span romo-1-12">Count</span>
-    </li>
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">1</span>
-      <span class="romo-span romo-5-12">Joe Test</span>
-      <span class="romo-span romo-5-12">joe-test</span>
-      <span class="romo-span romo-1-12">10</span>
-    </li>
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">2</span>
-      <span class="romo-span romo-5-12">Jane Doe</span>
-      <span class="romo-span romo-5-12">jane-doe</span>
-      <span class="romo-span romo-1-12">18</span>
-    </li>
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">3</span>
-      <span class="romo-span romo-5-12">Good Corp.</span>
-      <span class="romo-span romo-5-12">good-corp</span>
-      <span class="romo-span romo-1-12">5</span>
-    </li>
-  </ul>
-</div>
-
-```html
-<ul class="romo-grid-table romo-grid-table-hover romo-grid-table-striped">
-  ...
-</ul>
-<ul class="romo-grid-table romo-grid-table-header romo-grid-table-hover romo-grid-table-striped">
-  ...
-</ul>
-```
-
-<div class="romo-pad2-bottom">
-  <ul class="romo-grid-table romo-grid-table-hover romo-grid-table-alt">
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">1</span>
-      <span class="romo-span romo-5-12">Joe Test</span>
-      <span class="romo-span romo-5-12">joe-test</span>
-      <span class="romo-span romo-1-12">10</span>
-    </li>
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">2</span>
-      <span class="romo-span romo-5-12">Jane Doe</span>
-      <span class="romo-span romo-5-12">jane-doe</span>
-      <span class="romo-span romo-1-12">18</span>
-    </li>
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">3</span>
-      <span class="romo-span romo-5-12">Good Corp.</span>
-      <span class="romo-span romo-5-12">good-corp</span>
-      <span class="romo-span romo-1-12">5</span>
-    </li>
-  </ul>
-</div>
-
-<div class="romo-pad2-bottom">
-  <ul class="romo-grid-table romo-grid-table-hover romo-grid-table-alt romo-grid-table-striped">
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">1</span>
-      <span class="romo-span romo-5-12">Joe Test</span>
-      <span class="romo-span romo-5-12">joe-test</span>
-      <span class="romo-span romo-1-12">10</span>
-    </li>
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">2</span>
-      <span class="romo-span romo-5-12">Jane Doe</span>
-      <span class="romo-span romo-5-12">jane-doe</span>
-      <span class="romo-span romo-1-12">18</span>
-    </li>
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">3</span>
-      <span class="romo-span romo-5-12">Good Corp.</span>
-      <span class="romo-span romo-5-12">good-corp</span>
-      <span class="romo-span romo-1-12">5</span>
-    </li>
-  </ul>
-</div>
-
-<div>
-  <ul class="romo-grid-table romo-grid-table-header romo-grid-table-hover romo-grid-table-alt romo-grid-table-striped">
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">#</span>
-      <span class="romo-span romo-5-12">Name</span>
-      <span class="romo-span romo-5-12">Slug</span>
-      <span class="romo-span romo-1-12">Count</span>
-    </li>
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">1</span>
-      <span class="romo-span romo-5-12">Joe Test</span>
-      <span class="romo-span romo-5-12">joe-test</span>
-      <span class="romo-span romo-1-12">10</span>
-    </li>
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">2</span>
-      <span class="romo-span romo-5-12">Jane Doe</span>
-      <span class="romo-span romo-5-12">jane-doe</span>
-      <span class="romo-span romo-1-12">18</span>
-    </li>
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">3</span>
-      <span class="romo-span romo-5-12">Good Corp.</span>
-      <span class="romo-span romo-5-12">good-corp</span>
-      <span class="romo-span romo-1-12">5</span>
-    </li>
-  </ul>
-</div>
-
-```html
-<ul class="romo-grid-table romo-grid-table-hover romo-grid-table-alt">
-  ...
-</ul>
-<ul class="romo-grid-table romo-grid-table-hover romo-grid-table-alt romo-grid-table-striped">
-  ...
-</ul>
-<ul class="romo-grid-table romo-grid-table-header romo-grid-table-hover romo-grid-table-alt romo-grid-table-striped">
-  ...
-</ul>
-```
-
-<div class="romo-pad2-bottom">
-  <ul class="romo-grid-table romo-grid-table-hover">
-    <li class="romo-row romo-base">
-      <span class="romo-span romo-1-12">1</span>
-      <span class="romo-span romo-5-12">Joe Test</span>
-      <span class="romo-span romo-5-12">joe-test</span>
-      <span class="romo-span romo-1-12">10</span>
-    </li>
-    <li class="romo-row romo-alt">
-      <span class="romo-span romo-1-12">1</span>
-      <span class="romo-span romo-5-12">Joe Test</span>
-      <span class="romo-span romo-5-12">joe-test</span>
-      <span class="romo-span romo-1-12">10</span>
-    </li>
-    <li class="romo-row romo-muted">
-      <span class="romo-span romo-1-12">1</span>
-      <span class="romo-span romo-5-12">Joe Test</span>
-      <span class="romo-span romo-5-12">joe-test</span>
-      <span class="romo-span romo-1-12">10</span>
-    </li>
-    <li class="romo-row romo-warning">
-      <span class="romo-span romo-1-12">2</span>
-      <span class="romo-span romo-5-12">Jane Doe</span>
-      <span class="romo-span romo-5-12">jane-doe</span>
-      <span class="romo-span romo-1-12">18</span>
-    </li>
-    <li class="romo-row romo-danger">
-      <span class="romo-span romo-1-12">3</span>
-      <span class="romo-span romo-5-12">Good Corp.</span>
-      <span class="romo-span romo-5-12">good-corp</span>
-      <span class="romo-span romo-1-12">5</span>
-    </li>
-    <li class="romo-row romo-info">
-      <span class="romo-span romo-1-12">1</span>
-      <span class="romo-span romo-5-12">Joe Test</span>
-      <span class="romo-span romo-5-12">joe-test</span>
-      <span class="romo-span romo-1-12">10</span>
-    </li>
-    <li class="romo-row romo-success">
-      <span class="romo-span romo-1-12">2</span>
-      <span class="romo-span romo-5-12">Jane Doe</span>
-      <span class="romo-span romo-5-12">jane-doe</span>
-      <span class="romo-span romo-1-12">18</span>
-    </li>
-    <li class="romo-row romo-inverse romo-text-inverse">
-      <span class="romo-span romo-1-12">3</span>
-      <span class="romo-span romo-5-12">Good Corp.</span>
-      <span class="romo-span romo-5-12">good-corp</span>
-      <span class="romo-span romo-1-12">5</span>
-    </li>
-  </ul>
-</div>
-
-```html
-<ul class="romo-grid-table romo-grid-table-hover">
-  <li class="romo-row romo-base">...</li>
-  <li class="romo-row romo-alt">...</li>
-  <li class="romo-row romo-muted">...</li>
-  <li class="romo-row romo-warning">...</li>
-  <li class="romo-row romo-danger">...</li>
-  <li class="romo-row romo-info">...</li>
-  <li class="romo-row romo-success">...</li>
-  <li class="romo-row romo-inverse romo-text-inverse">...</li>
-</ul>
-```
-
-<div>
-  <ul class="romo-grid-table romo-grid-table-header romo-grid-table-hover">
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">#</span>
-      <span class="romo-span romo-5-12">Name</span>
-      <span class="romo-span romo-5-12">Slug</span>
-      <span class="romo-span romo-1-12">Count</span>
-    </li>
-    <li class="romo-row romo-base">
-      <span class="romo-span romo-1-12">1</span>
-      <span class="romo-span romo-5-12">Joe Test</span>
-      <span class="romo-span romo-5-12">joe-test</span>
-      <span class="romo-span romo-1-12">10</span>
-    </li>
-    <li class="romo-row romo-alt">
-      <span class="romo-span romo-1-12">1</span>
-      <span class="romo-span romo-5-12">Joe Test</span>
-      <span class="romo-span romo-5-12">joe-test</span>
-      <span class="romo-span romo-1-12">10</span>
-    </li>
-    <li class="romo-row romo-muted">
-      <span class="romo-span romo-1-12">1</span>
-      <span class="romo-span romo-5-12">Joe Test</span>
-      <span class="romo-span romo-5-12">joe-test</span>
-      <span class="romo-span romo-1-12">10</span>
-    </li>
-    <li class="romo-row romo-warning">
-      <span class="romo-span romo-1-12">2</span>
-      <span class="romo-span romo-5-12">Jane Doe</span>
-      <span class="romo-span romo-5-12">jane-doe</span>
-      <span class="romo-span romo-1-12">18</span>
-    </li>
-    <li class="romo-row romo-danger">
-      <span class="romo-span romo-1-12">3</span>
-      <span class="romo-span romo-5-12">Good Corp.</span>
-      <span class="romo-span romo-5-12">good-corp</span>
-      <span class="romo-span romo-1-12">5</span>
-    </li>
-    <li class="romo-row romo-info">
-      <span class="romo-span romo-1-12">1</span>
-      <span class="romo-span romo-5-12">Joe Test</span>
-      <span class="romo-span romo-5-12">joe-test</span>
-      <span class="romo-span romo-1-12">10</span>
-    </li>
-    <li class="romo-row romo-success">
-      <span class="romo-span romo-1-12">2</span>
-      <span class="romo-span romo-5-12">Jane Doe</span>
-      <span class="romo-span romo-5-12">jane-doe</span>
-      <span class="romo-span romo-1-12">18</span>
-    </li>
-    <li class="romo-row romo-inverse romo-text-inverse">
-      <span class="romo-span romo-1-12">3</span>
-      <span class="romo-span romo-5-12">Good Corp.</span>
-      <span class="romo-span romo-5-12">good-corp</span>
-      <span class="romo-span romo-1-12">5</span>
-    </li>
-  </ul>
-</div>
-
-```html
-<ul class="romo-grid-table romo-grid-table-header romo-grid-table-hover">
-  <li class="romo-row">...</li>
-  <li class="romo-row romo-base">...</li>
-  <li class="romo-row romo-alt">...</li>
-  <li class="romo-row romo-muted">...</li>
-  <li class="romo-row romo-warning">...</li>
-  <li class="romo-row romo-danger">...</li>
-  <li class="romo-row romo-info">...</li>
-  <li class="romo-row romo-success">...</li>
-  <li class="romo-row romo-inverse romo-text-inverse">...</li>
-</ul>
-```
-
-### `.romo-grid-table-border{0-2}`
-
-Adds sized borders to the grid table.
+`.romo-grid-table-border{0-2}` adds sized borders to the grid table.
 
 **Note**: This makes all cells hide any overflow.  Since grid tables don't keep all cell heights the same (like normal tables do), uneven grid heights break the borders.  If you need cells to overflow with borders, use a standard romo table.
 
-<div class="romo-pad2-bottom">
+<div class="romo-push0-bottom">
   <ul class="romo-grid-table romo-grid-table-header romo-grid-table-border">
     <li class="romo-row">
-      <span class="romo-span romo-1-12">#</span>
-      <span class="romo-span romo-5-12">Name</span>
+      <span class="romo-span romo-6-12">Name</span>
       <span class="romo-span romo-5-12">Slug</span>
       <span class="romo-span romo-1-12">Count</span>
     </li>
     <li class="romo-row">
-      <span class="romo-span romo-1-12">1</span>
-      <span class="romo-span romo-5-12">Joe Test</span>
+      <span class="romo-span romo-6-12">Joe Test</span>
       <span class="romo-span romo-5-12">joe-test</span>
-      <span class="romo-span romo-1-12">10</span>
+      <span class="romo-span romo-1-12">overflow: 1234567890</span>
     </li>
+  </ul>
+</div>
+
+<div class="romo-push0-bottom">
+  <ul class="romo-grid-table romo-grid-table-border0">
     <li class="romo-row">
-      <span class="romo-span romo-1-12">2</span>
-      <span class="romo-span romo-5-12">Jane Doe</span>
+      <span class="romo-span romo-6-12">Jane Doe</span>
       <span class="romo-span romo-5-12">jane-doe</span>
-      <span class="romo-span romo-1-12">18</span>
+      <span class="romo-span romo-1-12">overflow: 1234567890</span>
     </li>
+  </ul>
+</div>
+
+<div class="romo-push0-bottom">
+  <ul class="romo-grid-table romo-grid-table-border1">
     <li class="romo-row">
-      <span class="romo-span romo-1-12">3</span>
-      <span class="romo-span romo-5-12">Good Corp.</span>
+      <span class="romo-span romo-6-12">Jane Doe</span>
+      <span class="romo-span romo-5-12">jane-doe</span>
+      <span class="romo-span romo-1-12">overflow: 1234567890</span>
+    </li>
+  </ul>
+</div>
+
+<div class="romo-push2-bottom">
+  <ul class="romo-grid-table romo-grid-table-border2">
+    <li class="romo-row">
+      <span class="romo-span romo-6-12">Good Corp.</span>
       <span class="romo-span romo-5-12">good-corp</span>
       <span class="romo-span romo-1-12">overflow: 1234567890</span>
     </li>
   </ul>
 </div>
 
-<div class="romo-pad2-bottom">
-  <ul class="romo-grid-table romo-grid-table-header romo-grid-table-border0">
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">#</span>
-      <span class="romo-span romo-5-12">Name</span>
-      <span class="romo-span romo-5-12">Slug</span>
-      <span class="romo-span romo-1-12">Count</span>
-    </li>
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">1</span>
-      <span class="romo-span romo-5-12">Joe Test</span>
-      <span class="romo-span romo-5-12">joe-test</span>
-      <span class="romo-span romo-1-12">10</span>
-    </li>
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">2</span>
-      <span class="romo-span romo-5-12">Jane Doe</span>
-      <span class="romo-span romo-5-12">jane-doe</span>
-      <span class="romo-span romo-1-12">18</span>
-    </li>
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">3</span>
-      <span class="romo-span romo-5-12">Good Corp.</span>
-      <span class="romo-span romo-5-12">good-corp</span>
-      <span class="romo-span romo-1-12">overflow: 1234567890</span>
-    </li>
-  </ul>
-</div>
+`.romo-grid-table-border-none` remove all borders from the grid table.
 
-<div class="romo-pad2-bottom">
-  <ul class="romo-grid-table romo-grid-table-header romo-grid-table-border1">
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">#</span>
-      <span class="romo-span romo-5-12">Name</span>
-      <span class="romo-span romo-5-12">Slug</span>
-      <span class="romo-span romo-1-12">Count</span>
-    </li>
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">1</span>
-      <span class="romo-span romo-5-12">Joe Test</span>
-      <span class="romo-span romo-5-12">joe-test</span>
-      <span class="romo-span romo-1-12">10</span>
-    </li>
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">2</span>
-      <span class="romo-span romo-5-12">Jane Doe</span>
-      <span class="romo-span romo-5-12">jane-doe</span>
-      <span class="romo-span romo-1-12">18</span>
-    </li>
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">3</span>
-      <span class="romo-span romo-5-12">Good Corp.</span>
-      <span class="romo-span romo-5-12">good-corp</span>
-      <span class="romo-span romo-1-12">overflow: 1234567890</span>
-    </li>
-  </ul>
-</div>
-
-<div>
-  <ul class="romo-grid-table romo-grid-table-header romo-grid-table-border2">
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">#</span>
-      <span class="romo-span romo-5-12">Name</span>
-      <span class="romo-span romo-5-12">Slug</span>
-      <span class="romo-span romo-1-12">Count</span>
-    </li>
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">1</span>
-      <span class="romo-span romo-5-12">Joe Test</span>
-      <span class="romo-span romo-5-12">joe-test</span>
-      <span class="romo-span romo-1-12">10</span>
-    </li>
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">2</span>
-      <span class="romo-span romo-5-12">Jane Doe</span>
-      <span class="romo-span romo-5-12">jane-doe</span>
-      <span class="romo-span romo-1-12">18</span>
-    </li>
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">3</span>
-      <span class="romo-span romo-5-12">Good Corp.</span>
-      <span class="romo-span romo-5-12">good-corp</span>
-      <span class="romo-span romo-1-12">overflow: 1234567890</span>
-    </li>
-  </ul>
-</div>
-
-```html
-<ul class="romo-grid-table romo-grid-table-border{0-2}">
-  ...
-</ul>
-```
-
-### `.romo-grid-table-border-none`
-
-Remove all borders from the grid table.
-
-**Note**: This makes all cells hide any overflow.  Since grid tables don't keep all cell heights the same (like normal tables do), uneven grid heights break the borders.  If you need cells to overflow with borders, use a standard romo table.
-
-<div class="romo-pad2-bottom">
+<div class="romo-push2-bottom">
   <ul class="romo-grid-table romo-grid-table-header romo-grid-table-border-none">
     <li class="romo-row">
-      <span class="romo-span romo-1-12">#</span>
-      <span class="romo-span romo-5-12">Name</span>
+      <span class="romo-span romo-6-12">Name</span>
       <span class="romo-span romo-5-12">Slug</span>
       <span class="romo-span romo-1-12">Count</span>
     </li>
     <li class="romo-row">
-      <span class="romo-span romo-1-12">1</span>
-      <span class="romo-span romo-5-12">Joe Test</span>
+      <span class="romo-span romo-6-12">Joe Test</span>
       <span class="romo-span romo-5-12">joe-test</span>
-      <span class="romo-span romo-1-12">10</span>
-    </li>
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">2</span>
-      <span class="romo-span romo-5-12">Jane Doe</span>
-      <span class="romo-span romo-5-12">jane-doe</span>
-      <span class="romo-span romo-1-12">18</span>
-    </li>
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">3</span>
-      <span class="romo-span romo-5-12">Good Corp.</span>
-      <span class="romo-span romo-5-12">good-corp</span>
       <span class="romo-span romo-1-12">overflow: 1234567890</span>
     </li>
   </ul>
 </div>
 
-```html
-<ul class="romo-grid-table romo-grid-table-border-none">
-  ...
-</ul>
-```
+`.romo-grid-table-padN{-top|-right|-bottom|-left|}` add cell padding to every cell in the grid table.
 
-### `.romo-grid-table-border-{muted|warning|danger|info|success|inverse}`
+**Note**: Use large padding sizes with caution as they can cause the grid table rows to "break" if there is not enough width for the padding.
 
-Adds border color emphasis to the entire grid table.
-
-<div class="romo-pad2-bottom">
-  <ul class="romo-grid-table romo-grid-table-header romo-grid-table-border2 romo-grid-table-border-base">
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">#</span>
-      <span class="romo-span romo-5-12">Name</span>
-      <span class="romo-span romo-5-12">Slug</span>
-      <span class="romo-span romo-1-12">Count</span>
-    </li>
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">1</span>
-      <span class="romo-span romo-5-12">Joe Test</span>
-      <span class="romo-span romo-5-12">joe-test</span>
-      <span class="romo-span romo-1-12">10</span>
-    </li>
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">2</span>
-      <span class="romo-span romo-5-12">Jane Doe</span>
-      <span class="romo-span romo-5-12">jane-doe</span>
-      <span class="romo-span romo-1-12">18</span>
-    </li>
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">3</span>
-      <span class="romo-span romo-5-12">Good Corp.</span>
-      <span class="romo-span romo-5-12">good-corp</span>
-      <span class="romo-span romo-1-12">5</span>
-    </li>
-  </ul>
-</div>
-
-<div class="romo-pad2-bottom">
-  <ul class="romo-grid-table romo-grid-table-header romo-grid-table-border2 romo-grid-table-border-alt">
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">#</span>
-      <span class="romo-span romo-5-12">Name</span>
-      <span class="romo-span romo-5-12">Slug</span>
-      <span class="romo-span romo-1-12">Count</span>
-    </li>
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">1</span>
-      <span class="romo-span romo-5-12">Joe Test</span>
-      <span class="romo-span romo-5-12">joe-test</span>
-      <span class="romo-span romo-1-12">10</span>
-    </li>
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">2</span>
-      <span class="romo-span romo-5-12">Jane Doe</span>
-      <span class="romo-span romo-5-12">jane-doe</span>
-      <span class="romo-span romo-1-12">18</span>
-    </li>
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">3</span>
-      <span class="romo-span romo-5-12">Good Corp.</span>
-      <span class="romo-span romo-5-12">good-corp</span>
-      <span class="romo-span romo-1-12">5</span>
-    </li>
-  </ul>
-</div>
-
-<div class="romo-pad2-bottom">
-  <ul class="romo-grid-table romo-grid-table-header romo-grid-table-border2 romo-grid-table-border-muted">
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">#</span>
-      <span class="romo-span romo-5-12">Name</span>
-      <span class="romo-span romo-5-12">Slug</span>
-      <span class="romo-span romo-1-12">Count</span>
-    </li>
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">1</span>
-      <span class="romo-span romo-5-12">Joe Test</span>
-      <span class="romo-span romo-5-12">joe-test</span>
-      <span class="romo-span romo-1-12">10</span>
-    </li>
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">2</span>
-      <span class="romo-span romo-5-12">Jane Doe</span>
-      <span class="romo-span romo-5-12">jane-doe</span>
-      <span class="romo-span romo-1-12">18</span>
-    </li>
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">3</span>
-      <span class="romo-span romo-5-12">Good Corp.</span>
-      <span class="romo-span romo-5-12">good-corp</span>
-      <span class="romo-span romo-1-12">5</span>
-    </li>
-  </ul>
-</div>
-
-<div class="romo-pad2-bottom">
-  <ul class="romo-grid-table romo-grid-table-header romo-grid-table-border2 romo-grid-table-border-warning">
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">#</span>
-      <span class="romo-span romo-5-12">Name</span>
-      <span class="romo-span romo-5-12">Slug</span>
-      <span class="romo-span romo-1-12">Count</span>
-    </li>
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">1</span>
-      <span class="romo-span romo-5-12">Joe Test</span>
-      <span class="romo-span romo-5-12">joe-test</span>
-      <span class="romo-span romo-1-12">10</span>
-    </li>
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">2</span>
-      <span class="romo-span romo-5-12">Jane Doe</span>
-      <span class="romo-span romo-5-12">jane-doe</span>
-      <span class="romo-span romo-1-12">18</span>
-    </li>
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">3</span>
-      <span class="romo-span romo-5-12">Good Corp.</span>
-      <span class="romo-span romo-5-12">good-corp</span>
-      <span class="romo-span romo-1-12">5</span>
-    </li>
-  </ul>
-</div>
-
-<div class="romo-pad2-bottom">
-  <ul class="romo-grid-table romo-grid-table-header romo-grid-table-border2 romo-grid-table-border-danger">
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">#</span>
-      <span class="romo-span romo-5-12">Name</span>
-      <span class="romo-span romo-5-12">Slug</span>
-      <span class="romo-span romo-1-12">Count</span>
-    </li>
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">1</span>
-      <span class="romo-span romo-5-12">Joe Test</span>
-      <span class="romo-span romo-5-12">joe-test</span>
-      <span class="romo-span romo-1-12">10</span>
-    </li>
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">2</span>
-      <span class="romo-span romo-5-12">Jane Doe</span>
-      <span class="romo-span romo-5-12">jane-doe</span>
-      <span class="romo-span romo-1-12">18</span>
-    </li>
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">3</span>
-      <span class="romo-span romo-5-12">Good Corp.</span>
-      <span class="romo-span romo-5-12">good-corp</span>
-      <span class="romo-span romo-1-12">5</span>
-    </li>
-  </ul>
-</div>
-
-<div class="romo-pad2-bottom">
-  <ul class="romo-grid-table romo-grid-table-header romo-grid-table-border2 romo-grid-table-border-info">
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">#</span>
-      <span class="romo-span romo-5-12">Name</span>
-      <span class="romo-span romo-5-12">Slug</span>
-      <span class="romo-span romo-1-12">Count</span>
-    </li>
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">1</span>
-      <span class="romo-span romo-5-12">Joe Test</span>
-      <span class="romo-span romo-5-12">joe-test</span>
-      <span class="romo-span romo-1-12">10</span>
-    </li>
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">2</span>
-      <span class="romo-span romo-5-12">Jane Doe</span>
-      <span class="romo-span romo-5-12">jane-doe</span>
-      <span class="romo-span romo-1-12">18</span>
-    </li>
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">3</span>
-      <span class="romo-span romo-5-12">Good Corp.</span>
-      <span class="romo-span romo-5-12">good-corp</span>
-      <span class="romo-span romo-1-12">5</span>
-    </li>
-  </ul>
-</div>
-
-<div class="romo-pad2-bottom">
-  <ul class="romo-grid-table romo-grid-table-header romo-grid-table-border2 romo-grid-table-border-success">
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">#</span>
-      <span class="romo-span romo-5-12">Name</span>
-      <span class="romo-span romo-5-12">Slug</span>
-      <span class="romo-span romo-1-12">Count</span>
-    </li>
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">1</span>
-      <span class="romo-span romo-5-12">Joe Test</span>
-      <span class="romo-span romo-5-12">joe-test</span>
-      <span class="romo-span romo-1-12">10</span>
-    </li>
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">2</span>
-      <span class="romo-span romo-5-12">Jane Doe</span>
-      <span class="romo-span romo-5-12">jane-doe</span>
-      <span class="romo-span romo-1-12">18</span>
-    </li>
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">3</span>
-      <span class="romo-span romo-5-12">Good Corp.</span>
-      <span class="romo-span romo-5-12">good-corp</span>
-      <span class="romo-span romo-1-12">5</span>
-    </li>
-  </ul>
-</div>
-
-<div>
-  <ul class="romo-grid-table romo-grid-table-header romo-grid-table-border2 romo-grid-table-border-inverse">
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">#</span>
-      <span class="romo-span romo-5-12">Name</span>
-      <span class="romo-span romo-5-12">Slug</span>
-      <span class="romo-span romo-1-12">Count</span>
-    </li>
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">1</span>
-      <span class="romo-span romo-5-12">Joe Test</span>
-      <span class="romo-span romo-5-12">joe-test</span>
-      <span class="romo-span romo-1-12">10</span>
-    </li>
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">2</span>
-      <span class="romo-span romo-5-12">Jane Doe</span>
-      <span class="romo-span romo-5-12">jane-doe</span>
-      <span class="romo-span romo-1-12">18</span>
-    </li>
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">3</span>
-      <span class="romo-span romo-5-12">Good Corp.</span>
-      <span class="romo-span romo-5-12">good-corp</span>
-      <span class="romo-span romo-1-12">5</span>
-    </li>
-  </ul>
-</div>
-
-```html
-<ul class="romo-grid-table romo-grid-table-border-{base|alt|muted|warning|danger|info|success|inverse}">
-  ...
-</ul>
-```
-
-### `.romo-grid-table-border-alt`
-
-Uses the alternate border color for the grid table borders.
-
-<div>
-  <ul class="romo-grid-table romo-grid-table-header romo-grid-table-border2 romo-grid-table-alt romo-grid-table-border-alt">
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">#</span>
-      <span class="romo-span romo-5-12">Name</span>
-      <span class="romo-span romo-5-12">Slug</span>
-      <span class="romo-span romo-1-12">Count</span>
-    </li>
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">1</span>
-      <span class="romo-span romo-5-12">Joe Test</span>
-      <span class="romo-span romo-5-12">joe-test</span>
-      <span class="romo-span romo-1-12">10</span>
-    </li>
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">2</span>
-      <span class="romo-span romo-5-12">Jane Doe</span>
-      <span class="romo-span romo-5-12">jane-doe</span>
-      <span class="romo-span romo-1-12">18</span>
-    </li>
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">3</span>
-      <span class="romo-span romo-5-12">Good Corp.</span>
-      <span class="romo-span romo-5-12">good-corp</span>
-      <span class="romo-span romo-1-12">5</span>
-    </li>
-  </ul>
-</div>
-
-```html
-<ul class="romo-grid-table romo-grid-table-alt romo-grid-table-border-alt">
-  ...
-</ul>
-```
-
-### `.romo-grid-table-padN{-top|-right|-bottom|-left|}`
-
-Adds cell padding to every cell in the table.  Use large padding sizes with caution as they can cause the grid table rows to "break" if there is not enough width for the padding.
-
-<div>
+<div class="romo-push0-bottom">
   <ul class="romo-grid-table romo-grid-table-header romo-grid-table-border romo-grid-table-pad0">
     <li class="romo-row">
-      <span class="romo-span romo-1-12">#</span>
-      <span class="romo-span romo-5-12">Name</span>
+      <span class="romo-span romo-6-12">Name</span>
       <span class="romo-span romo-5-12">Slug</span>
       <span class="romo-span romo-1-12">Count</span>
     </li>
     <li class="romo-row">
-      <span class="romo-span romo-1-12">1</span>
-      <span class="romo-span romo-5-12">Joe Test</span>
+      <span class="romo-span romo-6-12">Joe Test</span>
       <span class="romo-span romo-5-12">joe-test</span>
       <span class="romo-span romo-1-12">10</span>
     </li>
+  </ul>
+</div>
+
+<div class="romo-push0-bottom">
+  <ul class="romo-grid-table romo-grid-table-border romo-grid-table-pad">
     <li class="romo-row">
-      <span class="romo-span romo-1-12">2</span>
-      <span class="romo-span romo-5-12">Jane Doe</span>
+      <span class="romo-span romo-6-12">Jane Doe</span>
       <span class="romo-span romo-5-12">jane-doe</span>
       <span class="romo-span romo-1-12">18</span>
     </li>
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">3</span>
-      <span class="romo-span romo-5-12">Good Corp.</span>
-      <span class="romo-span romo-5-12">good-corp</span>
-      <span class="romo-span romo-1-12">5</span>
-    </li>
   </ul>
 </div>
 
-```html
-<ul class="romo-grid-table romo-grid-table-pad0">
-  ...
-</ul>
-```
-
-<div>
-  <ul class="romo-grid-table romo-grid-table-header romo-grid-table-border romo-grid-table-pad">
+<div class="romo-push0-bottom">
+  <ul class="romo-grid-table romo-grid-table-border romo-grid-table-pad1">
     <li class="romo-row">
-      <span class="romo-span romo-1-12">#</span>
-      <span class="romo-span romo-5-12">Name</span>
-      <span class="romo-span romo-5-12">Slug</span>
-      <span class="romo-span romo-1-12">Count</span>
-    </li>
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">1</span>
-      <span class="romo-span romo-5-12">Joe Test</span>
-      <span class="romo-span romo-5-12">joe-test</span>
-      <span class="romo-span romo-1-12">10</span>
-    </li>
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">2</span>
-      <span class="romo-span romo-5-12">Jane Doe</span>
+      <span class="romo-span romo-6-12">Jane Doe</span>
       <span class="romo-span romo-5-12">jane-doe</span>
       <span class="romo-span romo-1-12">18</span>
     </li>
+  </ul>
+</div>
+
+<div class="romo-push2-bottom">
+  <ul class="romo-grid-table romo-grid-table-border romo-grid-table-pad2">
     <li class="romo-row">
-      <span class="romo-span romo-1-12">3</span>
-      <span class="romo-span romo-5-12">Good Corp.</span>
+      <span class="romo-span romo-6-12">Good Corp.</span>
       <span class="romo-span romo-5-12">good-corp</span>
       <span class="romo-span romo-1-12">5</span>
     </li>
   </ul>
 </div>
 
-```html
-<ul class="romo-grid-table romo-grid-table-pad">
-  ...
-</ul>
-```
+## Colored Rows
 
-<div>
-  <ul class="romo-grid-table romo-grid-table-header romo-grid-table-border romo-grid-table-pad1">
+`.romo-row.romo-{...}` add grid table row style classes to color row backgrounds based on an implicit emphasis OR an explicit name.
+
+### Basic
+
+<div class="romo-push2-bottom">
+  <ul class="romo-grid-table romo-grid-table-header romo-grid-table-pad0 romo-grid-table-hover">
     <li class="romo-row">
-      <span class="romo-span romo-1-12">#</span>
-      <span class="romo-span romo-5-12">Name</span>
-      <span class="romo-span romo-5-12">Slug</span>
-      <span class="romo-span romo-1-12">Count</span>
+      <span class="romo-span romo-1-2">Name</span>
+      <span class="romo-span romo-1-2">class=""</span>
     </li>
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">1</span>
-      <span class="romo-span romo-5-12">Joe Test</span>
-      <span class="romo-span romo-5-12">joe-test</span>
-      <span class="romo-span romo-1-12">10</span>
+    <li class="romo-row romo-base">
+      <span class="romo-span romo-1-2">Base</span>
+      <span class="romo-span romo-1-2"><code>.romo-base</code></span>
     </li>
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">2</span>
-      <span class="romo-span romo-5-12">Jane Doe</span>
-      <span class="romo-span romo-5-12">jane-doe</span>
-      <span class="romo-span romo-1-12">18</span>
+    <li class="romo-row romo-alt">
+      <span class="romo-span romo-1-2">Alt</span>
+      <span class="romo-span romo-1-2"><code>.romo-alt</code></span>
     </li>
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">3</span>
-      <span class="romo-span romo-5-12">Good Corp.</span>
-      <span class="romo-span romo-5-12">good-corp</span>
-      <span class="romo-span romo-1-12">5</span>
+    <li class="romo-row romo-muted romo-text-muted">
+      <span class="romo-span romo-1-2">Muted</span>
+      <span class="romo-span romo-1-2"><code>.romo-muted.romo-text-muted</code></span>
     </li>
   </ul>
 </div>
 
-```html
-<ul class="romo-grid-table romo-grid-table-pad1">
-  ...
-</ul>
-```
+### Explicit
 
-<div>
-  <ul class="romo-grid-table romo-grid-table-header romo-grid-table-border romo-grid-table-pad2">
+<div class="romo-push2-bottom">
+  <ul class="romo-grid-table romo-grid-table-header romo-grid-table-pad0 romo-grid-table-hover">
     <li class="romo-row">
-      <span class="romo-span romo-1-12">#</span>
-      <span class="romo-span romo-5-12">Name</span>
-      <span class="romo-span romo-5-12">Slug</span>
-      <span class="romo-span romo-1-12">Count</span>
+      <span class="romo-span romo-1-3">Name</span>
+      <span class="romo-span romo-1-3">class=""</span>
+      <span class="romo-span romo-1-3">Basis Color</span>
     </li>
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">1</span>
-      <span class="romo-span romo-5-12">Joe Test</span>
-      <span class="romo-span romo-5-12">joe-test</span>
-      <span class="romo-span romo-1-12">10</span>
+    <li class="romo-row romo-dark-red romo-text-inverse">
+      <span class="romo-span romo-1-3">Dark Red</span>
+      <span class="romo-span romo-1-3"><code>.romo-dark-red</code></span>
+      <span class="romo-span romo-1-3"><code>$darkRed</code></span>
     </li>
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">2</span>
-      <span class="romo-span romo-5-12">Jane Doe</span>
-      <span class="romo-span romo-5-12">jane-doe</span>
-      <span class="romo-span romo-1-12">18</span>
+    <li class="romo-row romo-red romo-text-inverse">
+      <span class="romo-span romo-1-3">Red</span>
+      <span class="romo-span romo-1-3"><code>.romo-red</code></span>
+      <span class="romo-span romo-1-3"><code>$red</code></span>
     </li>
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">3</span>
-      <span class="romo-span romo-5-12">Good Corp.</span>
-      <span class="romo-span romo-5-12">good-corp</span>
-      <span class="romo-span romo-1-12">5</span>
+    <li class="romo-row romo-light-red romo-text-inverse">
+      <span class="romo-span romo-1-3">Light Red</span>
+      <span class="romo-span romo-1-3"><code>.romo-light-red</code></span>
+      <span class="romo-span romo-1-3"><code>$lightRed</code></span>
+    </li>
+    <li class="romo-row romo-pastel-red romo-text-base">
+      <span class="romo-span romo-1-3">Pastel Red</span>
+      <span class="romo-span romo-1-3"><code>.romo-pastel-red</code></span>
+      <span class="romo-span romo-1-3"><code>$pastelRed</code></span>
+    </li>
+    <li class="romo-row romo-dark-orange romo-text-inverse">
+      <span class="romo-span romo-1-3">Dark Orange</span>
+      <span class="romo-span romo-1-3"><code>.romo-dark-orange</code></span>
+      <span class="romo-span romo-1-3"><code>$darkOrange</code></span>
+    </li>
+    <li class="romo-row romo-orange romo-text-inverse">
+      <span class="romo-span romo-1-3">Orange</span>
+      <span class="romo-span romo-1-3"><code>.romo-orange</code></span>
+      <span class="romo-span romo-1-3"><code>$orange</code></span>
+    </li>
+    <li class="romo-row romo-yellow romo-text-base">
+      <span class="romo-span romo-1-3">Yellow</span>
+      <span class="romo-span romo-1-3"><code>.romo-yellow</code></span>
+      <span class="romo-span romo-1-3"><code>$yellow</code></span>
+    </li>
+    <li class="romo-row romo-pastel-yellow romo-text-base">
+      <span class="romo-span romo-1-3">Pastel Yellow</span>
+      <span class="romo-span romo-1-3"><code>.romo-pastel-yellow</code></span>
+      <span class="romo-span romo-1-3"><code>$pastelYellow</code></span>
+    </li>
+    <li class="romo-row romo-purple romo-text-inverse">
+      <span class="romo-span romo-1-3">Purple</span>
+      <span class="romo-span romo-1-3"><code>.romo-purple</code></span>
+      <span class="romo-span romo-1-3"><code>$purple</code></span>
+    </li>
+    <li class="romo-row romo-light-purple romo-text-inverse">
+      <span class="romo-span romo-1-3">Light Purple</span>
+      <span class="romo-span romo-1-3"><code>.romo-light-purple</code></span>
+      <span class="romo-span romo-1-3"><code>$lightPurple</code></span>
+    </li>
+    <li class="romo-row romo-dark-pink romo-text-inverse">
+      <span class="romo-span romo-1-3">Dark Pink</span>
+      <span class="romo-span romo-1-3"><code>.romo-dark-pink</code></span>
+      <span class="romo-span romo-1-3"><code>$darkPink</code></span>
+    </li>
+    <li class="romo-row romo-hot-pink romo-text-inverse">
+      <span class="romo-span romo-1-3">Hot Pink</span>
+      <span class="romo-span romo-1-3"><code>.romo-hot-blue</code></span>
+      <span class="romo-span romo-1-3"><code>$hotPink</code></span>
+    </li>
+    <li class="romo-row romo-pink romo-text-inverse">
+      <span class="romo-span romo-1-3">Pink</span>
+      <span class="romo-span romo-1-3"><code>.romo-pink</code></span>
+      <span class="romo-span romo-1-3"><code>$pink</code></span>
+    </li>
+    <li class="romo-row romo-dark-green romo-text-inverse">
+      <span class="romo-span romo-1-3">Dark Green</span>
+      <span class="romo-span romo-1-3"><code>.romo-dark-green</code></span>
+      <span class="romo-span romo-1-3"><code>$darkGreen</code></span>
+    </li>
+    <li class="romo-row romo-green romo-text-inverse">
+      <span class="romo-span romo-1-3">Green</span>
+      <span class="romo-span romo-1-3"><code>.romo-green</code></span>
+      <span class="romo-span romo-1-3"><code>$green</code></span>
+    </li>
+    <li class="romo-row romo-light-green romo-text-base">
+      <span class="romo-span romo-1-3">Light Green</span>
+      <span class="romo-span romo-1-3"><code>.romo-light-green</code></span>
+      <span class="romo-span romo-1-3"><code>$lightGreen</code></span>
+    </li>
+    <li class="romo-row romo-pastel-green romo-text-base">
+      <span class="romo-span romo-1-3">Pastel Green</span>
+      <span class="romo-span romo-1-3"><code>.romo-pastel-green</code></span>
+      <span class="romo-span romo-1-3"><code>$pastelGreen</code></span>
+    </li>
+    <li class="romo-row romo-navy romo-text-inverse">
+      <span class="romo-span romo-1-3">Navy</span>
+      <span class="romo-span romo-1-3"><code>.romo-navy</code></span>
+      <span class="romo-span romo-1-3"><code>$navy</code></span>
+    </li>
+    <li class="romo-row romo-dark-blue romo-text-inverse">
+      <span class="romo-span romo-1-3">Dark Blue</span>
+      <span class="romo-span romo-1-3"><code>.romo-dark-blue</code></span>
+      <span class="romo-span romo-1-3"><code>$darkBlue</code></span>
+    </li>
+    <li class="romo-row romo-blue romo-text-inverse">
+      <span class="romo-span romo-1-3">Blue</span>
+      <span class="romo-span romo-1-3"><code>.romo-blue</code></span>
+      <span class="romo-span romo-1-3"><code>$blue</code></span>
+    </li>
+    <li class="romo-row romo-light-blue romo-text-inverse">
+      <span class="romo-span romo-1-3">Light Blue</span>
+      <span class="romo-span romo-1-3"><code>.romo-light-blue</code></span>
+      <span class="romo-span romo-1-3"><code>$lightBlue</code></span>
+    </li>
+    <li class="romo-row romo-pastel-blue romo-text-base">
+      <span class="romo-span romo-1-3">Pastel Blue</span>
+      <span class="romo-span romo-1-3"><code>.romo-pastel-blue</code></span>
+      <span class="romo-span romo-1-3"><code>$pastelBlue</code></span>
     </li>
   </ul>
 </div>
 
-```html
-<ul class="romo-grid-table romo-grid-table-pad2">
-  ...
-</ul>
-```
+### Emphasis
 
-## Custom Styles
-
-Use any helper style classes in any combination on rows/cells.
-
-<div>
-  <ul class="romo-grid-table romo-grid-table-header romo-grid-table-pad">
-    <tr>
-      <th class="romo-pad2">#</th>
-      <th>Name</th>
-      <th class="romo-text2 romo-pad2-left">Slug</th>
-      <th class="romo-span romo-1-12 romo-align-center romo-align-top">Count</th>
-    </tr>
+<div class="romo-push2-bottom">
+  <ul class="romo-grid-table romo-grid-table-header romo-grid-table-pad0 romo-grid-table-hover">
     <li class="romo-row">
-      <span class="romo-span romo-1-12 romo-pad2">#</span>
-      <span class="romo-span romo-5-12">Name</span>
-      <span class="romo-span romo-5-12 romo-text2 romo-pad2-left">Slug</span>
-      <span class="romo-span romo-1-12 romo-align-center romo-align-top">Count</span>
+      <span class="romo-span romo-1-3">Name</span>
+      <span class="romo-span romo-1-3">class=""</span>
+      <span class="romo-span romo-1-3">Basis Color</span>
     </li>
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">1</span>
-      <span class="romo-span romo-5-12 romo-bg-info">Joe Test</span>
-      <span class="romo-span romo-5-12">joe-test</span>
-      <span class="romo-span romo-1-12 romo-span romo-1-12 romo-text2 romo-border-danger romo-border4">10</span>
+    <li class="romo-row romo-warning">
+      <span class="romo-span romo-1-3">Warning</span>
+      <span class="romo-span romo-1-3"><code>.romo-warning</code></span>
+      <span class="romo-span romo-1-3"><code>$pastelYellow</code></span>
     </li>
-    <li class="romo-row">
-      <span class="romo-span romo-1-12">2</span>
-      <span class="romo-span romo-5-12">Jane Doe</span>
-      <span class="romo-span romo-5-12 romo-pad0">jane-doe</span>
-      <span class="romo-span romo-1-12 romo-align-center romo-text-success">18</span>
+    <li class="romo-row romo-danger">
+      <span class="romo-span romo-1-3">Danger</span>
+      <span class="romo-span romo-1-3"><code>.romo-danger</code></span>
+      <span class="romo-span romo-1-3"><code>$pastelRed</code></span>
     </li>
-    <li class="romo-row romo-bg-success">
-      <span class="romo-span romo-1-12">3</span>
-      <span class="romo-span romo-5-12">Good Corp.</span>
-      <span class="romo-span romo-5-12">good-corp</span>
-      <span class="romo-span romo-1-12">5</span>
+    <li class="romo-row romo-info">
+      <span class="romo-span romo-1-3">Info</span>
+      <span class="romo-span romo-1-3"><code>.romo-info</code></span>
+      <span class="romo-span romo-1-3"><code>$pastelBlue</code></span>
+    </li>
+    <li class="romo-row romo-success">
+      <span class="romo-span romo-1-3">Success</span>
+      <span class="romo-span romo-1-3"><code>.romo-success</code></span>
+      <span class="romo-span romo-1-3"><code>$pastelGreen</code></span>
+    </li>
+    <li class="romo-row romo-inverse romo-text-inverse">
+      <span class="romo-span romo-1-3">Inverse</span>
+      <span class="romo-span romo-1-3"><code>.romo-inverse.romo-text-inverse</code></span>
+      <span class="romo-span romo-1-3"><code>$inverseColor</code></span>
     </li>
   </ul>
 </div>
 
-```html
-<ul class="romo-grid-table romo-grid-table-header romo-grid-table-pad">
-  <tr>
-    <th class="romo-pad2">#</th>
-    <th>Name</th>
-    <th class="romo-text2 romo-pad2-left">Slug</th>
-    <th class="romo-span romo-1-12 romo-align-center romo-align-top">Count</th>
-  </tr>
-  <li class="romo-row">
-    <span class="romo-span romo-1-12 romo-pad2">#</span>
-    <span class="romo-span romo-5-12">Name</span>
-    <span class="romo-span romo-5-12 romo-text2 romo-pad2-left">Slug</span>
-    <span class="romo-span romo-1-12 romo-align-center romo-align-top">Count</span>
-  </li>
-  <li class="romo-row">
-    <span class="romo-span romo-1-12">1</span>
-    <span class="romo-span romo-5-12 romo-bg-info">Joe Test</span>
-    <span class="romo-span romo-5-12">joe-test</span>
-    <span class="romo-span romo-1-12 romo-span romo-1-12 romo-text2 romo-border-danger romo-border4">10</span>
-  </li>
-  <li class="romo-row">
-    <span class="romo-span romo-1-12">2</span>
-    <span class="romo-span romo-5-12">Jane Doe</span>
-    <span class="romo-span romo-5-12 romo-pad0">jane-doe</span>
-    <span class="romo-span romo-1-12 romo-align-center romo-text-success">18</span>
-  </li>
-  <li class="romo-row romo-bg-success">
-    <span class="romo-span romo-1-12">3</span>
-    <span class="romo-span romo-5-12">Good Corp.</span>
-    <span class="romo-span romo-5-12">good-corp</span>
-    <span class="romo-span romo-1-12">5</span>
-  </li>
-</ul>
-```
+## Colored Borders
+
+`.romo-grid-table-border-{...}` add grid table style classes to color all table borders based on an implicit emphasis OR an explicit name.
+
+<div class="romo-push0-bottom">
+  <ul class="romo-grid-table romo-grid-table-pad0 romo-grid-table-border2 romo-grid-table-border-base">
+    <li class="romo-row">
+      <span class="romo-span romo-1-2">Base</span>
+      <span class="romo-span romo-1-2"><code>.romo-grid-table-border-base</code></span>
+    </li>
+  </ul>
+</div>
+<div class="romo-push0-bottom">
+  <ul class="romo-grid-table romo-grid-table-pad0 romo-grid-table-border2 romo-grid-table-alt romo-grid-table-border-alt">
+    <li class="romo-row">
+      <span class="romo-span romo-1-2">Alt</span>
+      <span class="romo-span romo-1-2"><code>.romo-grid-table-alt.romo-grid-table-border-alt</code></span>
+    </li>
+  </ul>
+</div>
+<div class="romo-push2-bottom">
+  <ul class="romo-grid-table romo-grid-table-pad0 romo-grid-table-border2 romo-grid-table-border-muted">
+    <li class="romo-row">
+      <span class="romo-span romo-1-2">Muted</span>
+      <span class="romo-span romo-1-2"><code>.romo-grid-table-border-muted</code></span>
+    </li>
+  </ul>
+</div>
+
+### Explicit
+
+<div class="romo-push0-bottom">
+  <ul class="romo-grid-table romo-grid-table-pad0 romo-grid-table-border2 romo-grid-table-border-dark-red">
+    <li class="romo-row">
+      <span class="romo-span romo-1-3">Dark Red</span>
+      <span class="romo-span romo-1-3"><code>.romo-grid-table-border-dark-red</code></span>
+      <span class="romo-span romo-1-3"><code>$darkRed</code></span>
+    </li>
+  </ul>
+</div>
+<div class="romo-push0-bottom">
+  <ul class="romo-grid-table romo-grid-table-pad0 romo-grid-table-border2 romo-grid-table-border-red">
+    <li class="romo-row">
+      <span class="romo-span romo-1-3">Red</span>
+      <span class="romo-span romo-1-3"><code>.romo-grid-table-border-red</code></span>
+      <span class="romo-span romo-1-3"><code>$red</code></span>
+    </li>
+  </ul>
+</div>
+<div class="romo-push0-bottom">
+  <ul class="romo-grid-table romo-grid-table-pad0 romo-grid-table-border2 romo-grid-table-border-light-red">
+    <li class="romo-row">
+      <span class="romo-span romo-1-3">Light Red</span>
+      <span class="romo-span romo-1-3"><code>.romo-grid-table-border-light-red</code></span>
+      <span class="romo-span romo-1-3"><code>$lightRed</code></span>
+    </li>
+  </ul>
+</div>
+<div class="romo-push0-bottom">
+  <ul class="romo-grid-table romo-grid-table-pad0 romo-grid-table-border2 romo-grid-table-border-pastel-red">
+    <li class="romo-row">
+      <span class="romo-span romo-1-3">Pastel Red</span>
+      <span class="romo-span romo-1-3"><code>.romo-grid-table-border-pastel-red</code></span>
+      <span class="romo-span romo-1-3"><code>$pastelRed</code></span>
+    </li>
+  </ul>
+</div>
+<div class="romo-push0-bottom">
+  <ul class="romo-grid-table romo-grid-table-pad0 romo-grid-table-border2 romo-grid-table-border-dark-orange">
+    <li class="romo-row">
+      <span class="romo-span romo-1-3">Dark Orange</span>
+      <span class="romo-span romo-1-3"><code>.romo-grid-table-border-dark-orange</code></span>
+      <span class="romo-span romo-1-3"><code>$darkOrange</code></span>
+    </li>
+  </ul>
+</div>
+<div class="romo-push0-bottom">
+  <ul class="romo-grid-table romo-grid-table-pad0 romo-grid-table-border2 romo-grid-table-border-orange">
+    <li class="romo-row">
+      <span class="romo-span romo-1-3">Orange</span>
+      <span class="romo-span romo-1-3"><code>.romo-grid-table-border-orange</code></span>
+      <span class="romo-span romo-1-3"><code>$orange</code></span>
+    </li>
+  </ul>
+</div>
+<div class="romo-push0-bottom">
+  <ul class="romo-grid-table romo-grid-table-pad0 romo-grid-table-border2 romo-grid-table-border-yellow">
+    <li class="romo-row">
+      <span class="romo-span romo-1-3">Yellow</span>
+      <span class="romo-span romo-1-3"><code>.romo-grid-table-border-yellow</code></span>
+      <span class="romo-span romo-1-3"><code>$yellow</code></span>
+    </li>
+  </ul>
+</div>
+<div class="romo-push0-bottom">
+  <ul class="romo-grid-table romo-grid-table-pad0 romo-grid-table-border2 romo-grid-table-border-pastel-yellow">
+    <li class="romo-row">
+      <span class="romo-span romo-1-3">Pastel Yellow</span>
+      <span class="romo-span romo-1-3"><code>.romo-grid-table-border-pastel-yellow</code></span>
+      <span class="romo-span romo-1-3"><code>$pastelYellow</code></span>
+    </li>
+  </ul>
+</div>
+<div class="romo-push0-bottom">
+  <ul class="romo-grid-table romo-grid-table-pad0 romo-grid-table-border2 romo-grid-table-border-purple">
+    <li class="romo-row">
+      <span class="romo-span romo-1-3">Purple</span>
+      <span class="romo-span romo-1-3"><code>.romo-grid-table-border-purple</code></span>
+      <span class="romo-span romo-1-3"><code>$purple</code></span>
+    </li>
+  </ul>
+</div>
+<div class="romo-push0-bottom">
+  <ul class="romo-grid-table romo-grid-table-pad0 romo-grid-table-border2 romo-grid-table-border-light-purple">
+    <li class="romo-row">
+      <span class="romo-span romo-1-3">Light Purple</span>
+      <span class="romo-span romo-1-3"><code>.romo-grid-table-border-light-purple</code></span>
+      <span class="romo-span romo-1-3"><code>$lightPurple</code></span>
+    </li>
+  </ul>
+</div>
+<div class="romo-push0-bottom">
+  <ul class="romo-grid-table romo-grid-table-pad0 romo-grid-table-border2 romo-grid-table-border-dark-pink">
+    <li class="romo-row">
+      <span class="romo-span romo-1-3">Dark Pink</span>
+      <span class="romo-span romo-1-3"><code>.romo-grid-table-border-dark-pink</code></span>
+      <span class="romo-span romo-1-3"><code>$darkPink</code></span>
+    </li>
+  </ul>
+</div>
+<div class="romo-push0-bottom">
+  <ul class="romo-grid-table romo-grid-table-pad0 romo-grid-table-border2 romo-grid-table-border-hot-pink">
+    <li class="romo-row">
+      <span class="romo-span romo-1-3">Hot Pink</span>
+      <span class="romo-span romo-1-3"><code>.romo-grid-table-border-hot-pink</code></span>
+      <span class="romo-span romo-1-3"><code>$hotPink</code></span>
+    </li>
+  </ul>
+</div>
+<div class="romo-push0-bottom">
+  <ul class="romo-grid-table romo-grid-table-pad0 romo-grid-table-border2 romo-grid-table-border-pink">
+    <li class="romo-row">
+      <span class="romo-span romo-1-3">Pink</span>
+      <span class="romo-span romo-1-3"><code>.romo-grid-table-border-pink</code></span>
+      <span class="romo-span romo-1-3"><code>$pink</code></span>
+    </li>
+  </ul>
+</div>
+<div class="romo-push0-bottom">
+  <ul class="romo-grid-table romo-grid-table-pad0 romo-grid-table-border2 romo-grid-table-border-dark-green">
+    <li class="romo-row">
+      <span class="romo-span romo-1-3">Dark Green</span>
+      <span class="romo-span romo-1-3"><code>.romo-grid-table-border-dark-green</code></span>
+      <span class="romo-span romo-1-3"><code>$darkGreen</code></span>
+    </li>
+  </ul>
+</div>
+<div class="romo-push0-bottom">
+  <ul class="romo-grid-table romo-grid-table-pad0 romo-grid-table-border2 romo-grid-table-border-green">
+    <li class="romo-row">
+      <span class="romo-span romo-1-3">Green</span>
+      <span class="romo-span romo-1-3"><code>.romo-grid-table-border-green</code></span>
+      <span class="romo-span romo-1-3"><code>$green</code></span>
+    </li>
+  </ul>
+</div>
+<div class="romo-push0-bottom">
+  <ul class="romo-grid-table romo-grid-table-pad0 romo-grid-table-border2 romo-grid-table-border-light-green">
+    <li class="romo-row">
+      <span class="romo-span romo-1-3">Light Green</span>
+      <span class="romo-span romo-1-3"><code>.romo-grid-table-border-light-green</code></span>
+      <span class="romo-span romo-1-3"><code>$lightGreen</code></span>
+    </li>
+  </ul>
+</div>
+<div class="romo-push0-bottom">
+  <ul class="romo-grid-table romo-grid-table-pad0 romo-grid-table-border2 romo-grid-table-border-pastel-green">
+    <li class="romo-row">
+      <span class="romo-span romo-1-3">Pastel Green</span>
+      <span class="romo-span romo-1-3"><code>.romo-grid-table-border-pastel-green</code></span>
+      <span class="romo-span romo-1-3"><code>$pastelGreen</code></span>
+    </li>
+  </ul>
+</div>
+<div class="romo-push0-bottom">
+  <ul class="romo-grid-table romo-grid-table-pad0 romo-grid-table-border2 romo-grid-table-border-navy">
+    <li class="romo-row">
+      <span class="romo-span romo-1-3">Navy</span>
+      <span class="romo-span romo-1-3"><code>.romo-grid-table-border-navy</code></span>
+      <span class="romo-span romo-1-3"><code>$navy</code></span>
+    </li>
+  </ul>
+</div>
+<div class="romo-push0-bottom">
+  <ul class="romo-grid-table romo-grid-table-pad0 romo-grid-table-border2 romo-grid-table-border-dark-blue">
+    <li class="romo-row">
+      <span class="romo-span romo-1-3">Dark Blue</span>
+      <span class="romo-span romo-1-3"><code>.romo-grid-table-border-dark-blue</code></span>
+      <span class="romo-span romo-1-3"><code>$darkBlue</code></span>
+    </li>
+  </ul>
+</div>
+<div class="romo-push0-bottom">
+  <ul class="romo-grid-table romo-grid-table-pad0 romo-grid-table-border2 romo-grid-table-border-blue">
+    <li class="romo-row">
+      <span class="romo-span romo-1-3">Blue</span>
+      <span class="romo-span romo-1-3"><code>.romo-grid-table-border-blue</code></span>
+      <span class="romo-span romo-1-3"><code>$blue</code></span>
+    </li>
+  </ul>
+</div>
+<div class="romo-push0-bottom">
+  <ul class="romo-grid-table romo-grid-table-pad0 romo-grid-table-border2 romo-grid-table-border-light-blue">
+    <li class="romo-row">
+      <span class="romo-span romo-1-3">Light Blue</span>
+      <span class="romo-span romo-1-3"><code>.romo-grid-table-border-light-blue</code></span>
+      <span class="romo-span romo-1-3"><code>$lightBlue</code></span>
+    </li>
+  </ul>
+</div>
+<div class="romo-push2-bottom">
+  <ul class="romo-grid-table romo-grid-table-pad0 romo-grid-table-border2 romo-grid-table-border-pastel-blue">
+    <li class="romo-row">
+      <span class="romo-span romo-1-3">Pastel Blue</span>
+      <span class="romo-span romo-1-3"><code>.romo-grid-table-border-pastel-blue</code></span>
+      <span class="romo-span romo-1-3"><code>$pastelBlue</code></span>
+    </li>
+  </ul>
+</div>
+
+### Emphasis
+
+<div class="romo-push0-bottom">
+  <ul class="romo-grid-table romo-grid-table-pad0 romo-grid-table-border2 romo-grid-table-border-warning">
+    <li class="romo-row">
+      <span class="romo-span romo-1-3">Warning</span>
+      <span class="romo-span romo-1-3"><code>.romo-grid-table-border-warning</code></span>
+      <span class="romo-span romo-1-3"><code>$pastelYellow</code></span>
+    </li>
+  </ul>
+</div>
+<div class="romo-push0-bottom">
+  <ul class="romo-grid-table romo-grid-table-pad0 romo-grid-table-border2 romo-grid-table-border-danger">
+    <li class="romo-row">
+      <span class="romo-span romo-1-3">Danger</span>
+      <span class="romo-span romo-1-3"><code>.romo-grid-table-border-danger</code></span>
+      <span class="romo-span romo-1-3"><code>$pastelRed</code></span>
+    </li>
+  </ul>
+</div>
+<div class="romo-push0-bottom">
+  <ul class="romo-grid-table romo-grid-table-pad0 romo-grid-table-border2 romo-grid-table-border-info">
+    <li class="romo-row">
+      <span class="romo-span romo-1-3">Info</span>
+      <span class="romo-span romo-1-3"><code>.romo-grid-table-border-info</code></span>
+      <span class="romo-span romo-1-3"><code>$pastelBlue</code></span>
+    </li>
+  </ul>
+</div>
+<div class="romo-push0-bottom">
+  <ul class="romo-grid-table romo-grid-table-pad0 romo-grid-table-border2 romo-grid-table-border-success">
+    <li class="romo-row">
+      <span class="romo-span romo-1-3">Success</span>
+      <span class="romo-span romo-1-3"><code>.romo-grid-table-border-success</code></span>
+      <span class="romo-span romo-1-3"><code>$pastelGreen</code></span>
+    </li>
+  </ul>
+</div>
+<div class="romo-push2-bottom">
+  <ul class="romo-grid-table romo-grid-table-pad0 romo-grid-table-border2 romo-grid-table-border-inverse">
+    <li class="romo-row">
+      <span class="romo-span romo-1-3">Inverse</span>
+      <span class="romo-span romo-1-3"><code>.romo-grid-table-border-inverse</code></span>
+      <span class="romo-span romo-1-3"><code>$inverseColor</code></span>
+    </li>
+  </ul>
+</div>

--- a/gh-pages/view_handlers/css/labels.md
+++ b/gh-pages/view_handlers/css/labels.md
@@ -142,12 +142,14 @@ Use `.romo-label-block` to add blocking full-width labels.
 <span class="romo-label romo-label-block">...</span>
 ```
 
-## Alternate labels
+## Colored labels
 
-Use these as an alternative to the default styles and to add color emphasis to labels.
+Use style classes to add color buttons based on an implicit emphasis OR an explicit name.
 
-<div>
-  <table class="romo-table romo-table-border romo-table-striped romo-table-pad1">
+## Basic
+
+<div class="romo-push2-bottom">
+  <table class="romo-table romo-table-border romo-table-pad1">
     <thead>
       <tr>
         <th>Large size</th>
@@ -164,40 +166,206 @@ Use these as an alternative to the default styles and to add color emphasis to l
         <td><code>romo-label</code></td>
       </tr>
       <tr>
-        <td class="romo-bg-alt"><span class="romo-label romo-label-alt romo-label-large">Alt</span></td>
-        <td class="romo-bg-alt"><span class="romo-label romo-label-alt">Alt</span></td>
-        <td class="romo-bg-alt"><span class="romo-label romo-label-alt romo-label-small">Alt</span></td>
+        <td><span class="romo-label romo-label-alt romo-label-large">Alt</span></td>
+        <td><span class="romo-label romo-label-alt">Alt</span></td>
+        <td><span class="romo-label romo-label-alt romo-label-small">Alt</span></td>
         <td><code>romo-label romo-label-alt</code></td>
       </tr>
+    </tbody>
+  </table>
+</div>
+
+### Explicit
+
+<div class="romo-push2-bottom">
+  <table class="romo-table romo-table-border romo-table-pad1">
+    <thead>
       <tr>
-        <td><span class="romo-label romo-label-inverse romo-label-large">Inverse</span></td>
-        <td><span class="romo-label romo-label-inverse ">Inverse</span></td>
-        <td><span class="romo-label romo-label-inverse romo-label-small">Inverse</span></td>
-        <td><code>romo-label romo-label-inverse</code></td>
+        <th>Large size</th>
+        <th>Default size</th>
+        <th>Small size</th>
+        <th>class=""</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="romo-label romo-label-dark-red romo-label-large">Dark Red</span></td>
+        <td><span class="romo-label romo-label-dark-red">Dark Red</span></td>
+        <td><span class="romo-label romo-label-dark-red romo-label-small">Dark Red</span></td>
+        <td><code>romo-label romo-label-dark-red</code></td>
       </tr>
       <tr>
+        <td><span class="romo-label romo-label-red romo-label-large">Red</span></td>
+        <td><span class="romo-label romo-label-red">Red</span></td>
+        <td><span class="romo-label romo-label-red romo-label-small">Red</span></td>
+        <td><code>romo-label romo-label-red</code></td>
+      </tr>
+      <tr>
+        <td><span class="romo-label romo-label-light-red romo-label-large">Light Red</span></td>
+        <td><span class="romo-label romo-label-light-red">Light Red</span></td>
+        <td><span class="romo-label romo-label-light-red romo-label-small">Light Red</span></td>
+        <td><code>romo-label romo-label-light-red</code></td>
+      </tr>
+      <tr>
+        <td><span class="romo-label romo-label-pastel-red romo-label-large">Pastel Red</span></td>
+        <td><span class="romo-label romo-label-pastel-red">Pastel Red</span></td>
+        <td><span class="romo-label romo-label-pastel-red romo-label-small">Pastel Red</span></td>
+        <td><code>romo-label romo-label-pastel-red</code></td>
+      </tr>
+      <tr>
+        <td><span class="romo-label romo-label-dark-orange romo-label-large">Dark Orange</span></td>
+        <td><span class="romo-label romo-label-dark-orange">Dark Orange</span></td>
+        <td><span class="romo-label romo-label-dark-orange romo-label-small">Dark Orange</span></td>
+        <td><code>romo-label romo-label-dark-orange</code></td>
+      </tr>
+      <tr>
+        <td><span class="romo-label romo-label-orange romo-label-large">Orange</span></td>
+        <td><span class="romo-label romo-label-orange">Orange</span></td>
+        <td><span class="romo-label romo-label-orange romo-label-small">Orange</span></td>
+        <td><code>romo-label romo-label-orange</code></td>
+      </tr>
+      <tr>
+        <td><span class="romo-label romo-label-yellow romo-label-large">Yellow</span></td>
+        <td><span class="romo-label romo-label-yellow">Yellow</span></td>
+        <td><span class="romo-label romo-label-yellow romo-label-small">Yellow</span></td>
+        <td><code>romo-label romo-label-yellow</code></td>
+      </tr>
+      <tr>
+        <td><span class="romo-label romo-label-pastel-yellow romo-label-large">Pastel Yellow</span></td>
+        <td><span class="romo-label romo-label-pastel-yellow">Pastel Yellow</span></td>
+        <td><span class="romo-label romo-label-pastel-yellow romo-label-small">Pastel Yellow</span></td>
+        <td><code>romo-label romo-label-pastel-yellow</code></td>
+      </tr>
+      <tr>
+        <td><span class="romo-label romo-label-purple romo-label-large">Purple</span></td>
+        <td><span class="romo-label romo-label-purple">Purple</span></td>
+        <td><span class="romo-label romo-label-purple romo-label-small">Purple</span></td>
+        <td><code>romo-label romo-label-purple</code></td>
+      </tr>
+      <tr>
+        <td><span class="romo-label romo-label-light-purple romo-label-large">Light Purple</span></td>
+        <td><span class="romo-label romo-label-light-purple">Light Purple</span></td>
+        <td><span class="romo-label romo-label-light-purple romo-label-small">Light Purple</span></td>
+        <td><code>romo-label romo-label-light-purple</code></td>
+      </tr>
+      <tr>
+        <td><span class="romo-label romo-label-dark-pink romo-label-large">Dark Pink</span></td>
+        <td><span class="romo-label romo-label-dark-pink">Dark Pink</span></td>
+        <td><span class="romo-label romo-label-dark-pink romo-label-small">Dark Pink</span></td>
+        <td><code>romo-label romo-label-dark-pink</code></td>
+      </tr>
+      <tr>
+        <td><span class="romo-label romo-label-hot-pink romo-label-large">Hot Pink</span></td>
+        <td><span class="romo-label romo-label-hot-pink">Hot Pink</span></td>
+        <td><span class="romo-label romo-label-hot-pink romo-label-small">Hot Pink</span></td>
+        <td><code>romo-label romo-label-hot-pink</code></td>
+      </tr>
+      <tr>
+        <td><span class="romo-label romo-label-pink romo-label-large">Pink</span></td>
+        <td><span class="romo-label romo-label-pink">Pink</span></td>
+        <td><span class="romo-label romo-label-pink romo-label-small">Pink</span></td>
+        <td><code>romo-label romo-label-pink</code></td>
+      </tr>
+      <tr>
+        <td><span class="romo-label romo-label-dark-green romo-label-large">Dark Green</span></td>
+        <td><span class="romo-label romo-label-dark-green">Dark Green</span></td>
+        <td><span class="romo-label romo-label-dark-green romo-label-small">Dark Green</span></td>
+        <td><code>romo-label romo-label-dark-green</code></td>
+      </tr>
+      <tr>
+        <td><span class="romo-label romo-label-green romo-label-large">Green</span></td>
+        <td><span class="romo-label romo-label-green">Green</span></td>
+        <td><span class="romo-label romo-label-green romo-label-small">Green</span></td>
+        <td><code>romo-label romo-label-green</code></td>
+      </tr>
+      <tr>
+        <td><span class="romo-label romo-label-light-green romo-label-large">Light Green</span></td>
+        <td><span class="romo-label romo-label-light-green">Light Green</span></td>
+        <td><span class="romo-label romo-label-light-green romo-label-small">Light Green</span></td>
+        <td><code>romo-label romo-label-light-green</code></td>
+      </tr>
+      <tr>
+        <td><span class="romo-label romo-label-pastel-green romo-label-large">Pastel Green</span></td>
+        <td><span class="romo-label romo-label-pastel-green">Pastel Green</span></td>
+        <td><span class="romo-label romo-label-pastel-green romo-label-small">Pastel Green</span></td>
+        <td><code>romo-label romo-label-pastel-green</code></td>
+      </tr>
+      <tr>
+        <td><span class="romo-label romo-label-navy romo-label-large">Navy</span></td>
+        <td><span class="romo-label romo-label-navy">Navy</span></td>
+        <td><span class="romo-label romo-label-navy romo-label-small">Navy</span></td>
+        <td><code>romo-label romo-label-navy</code></td>
+      </tr>
+      <tr>
+        <td><span class="romo-label romo-label-dark-blue romo-label-large">Dark Blue</span></td>
+        <td><span class="romo-label romo-label-dark-blue">Dark Blue</span></td>
+        <td><span class="romo-label romo-label-dark-blue romo-label-small">Dark Blue</span></td>
+        <td><code>romo-label romo-label-dark-blue</code></td>
+      </tr>
+      <tr>
+        <td><span class="romo-label romo-label-blue romo-label-large">Blue</span></td>
+        <td><span class="romo-label romo-label-blue">Blue</span></td>
+        <td><span class="romo-label romo-label-blue romo-label-small">Blue</span></td>
+        <td><code>romo-label romo-label-blue</code></td>
+      </tr>
+      <tr>
+        <td><span class="romo-label romo-label-light-blue romo-label-large">Light Blue</span></td>
+        <td><span class="romo-label romo-label-light-blue">Light Blue</span></td>
+        <td><span class="romo-label romo-label-light-blue romo-label-small">Light Blue</span></td>
+        <td><code>romo-label romo-label-light-blue</code></td>
+      </tr>
+      <tr>
+        <td><span class="romo-label romo-label-pastel-blue romo-label-large">Pastel Blue</span></td>
+        <td><span class="romo-label romo-label-pastel-blue">Pastel Blue</span></td>
+        <td><span class="romo-label romo-label-pastel-blue romo-label-small">Pastel Blue</span></td>
+        <td><code>romo-label romo-label-pastel-blue</code></td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+### Emphasis
+
+<div class="romo-push2-bottom">
+  <table class="romo-table romo-table-border romo-table-pad1">
+    <thead>
+      <tr>
+        <th>Large size</th>
+        <th>Default size</th>
+        <th>Small size</th>
+        <th>class="" - Basis Color</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
         <td><span class="romo-label romo-label-warning romo-label-large">Warning</span></td>
-        <td><span class="romo-label romo-label-warning ">Warning</span></td>
+        <td><span class="romo-label romo-label-warning">Warning</span></td>
         <td><span class="romo-label romo-label-warning romo-label-small">Warning</span></td>
-        <td><code>romo-label romo-label-warning</code></td>
+        <td><code>romo-label romo-label-warning</code> - <code>$orange</code></td>
       </tr>
       <tr>
         <td><span class="romo-label romo-label-danger romo-label-large">Danger</span></td>
         <td><span class="romo-label romo-label-danger">Danger</span></td>
-        <td><span class="romo-label romo-label-danger romo-label-small">Danger</span></td>
-        <td><code>romo-label romo-label-danger</code></td>
+        <td><span class="romo-label romo-label-danger romo-label-small" >Danger</span></td>
+        <td><code>romo-label romo-label-danger - <code>$red</code></code></td>
       </tr>
       <tr>
         <td><span class="romo-label romo-label-info romo-label-large">Info</span></td>
-        <td><span class="romo-label romo-label-info ">Info</span></td>
+        <td><span class="romo-label romo-label-info">Info</span></td>
         <td><span class="romo-label romo-label-info romo-label-small">Info</span></td>
-        <td><code>romo-label romo-label-info</code></td>
+        <td><code>romo-label romo-label-info</code> - <code>$blue</code></td>
       </tr>
       <tr>
         <td><span class="romo-label romo-label-success romo-label-large">Success</span></td>
-        <td><span class="romo-label romo-label-success ">Success</span></td>
+        <td><span class="romo-label romo-label-success">Success</span></td>
         <td><span class="romo-label romo-label-success romo-label-small">Success</span></td>
-        <td><code>romo-label romo-label-success</code></td>
+        <td><code>romo-label romo-label-success</code> - <code>$green</code></td>
+      </tr>
+      <tr>
+        <td><span class="romo-label romo-label-inverse romo-label-large">Inverse</span></td>
+        <td><span class="romo-label romo-label-inverse">Inverse</span></td>
+        <td><span class="romo-label romo-label-inverse romo-label-small">Inverse</span></td>
+        <td><code>romo-label romo-label-inverse</code> - <code>$inverseColor</code></td>
       </tr>
     </tbody>
   </table>

--- a/gh-pages/view_handlers/css/tables.md
+++ b/gh-pages/view_handlers/css/tables.md
@@ -4,13 +4,12 @@
 
 ## Default styles
 
-For basic styling with horizontal dividers, add the base class `.romo-table`.
+`.romo-table` For basic styling with horizontal dividers.
 
-<div>
+<div class="romo-push2-bottom">
   <table class="romo-table">
     <thead>
       <tr>
-        <th>#</th>
         <th>Name</th>
         <th>Slug</th>
         <th>Count</th>
@@ -18,19 +17,16 @@ For basic styling with horizontal dividers, add the base class `.romo-table`.
     </thead>
     <tbody>
       <tr>
-        <td>1</td>
         <td>Joe Test</td>
         <td>joe-test</td>
         <td>10</td>
       </tr>
       <tr>
-        <td>2</td>
         <td>Jane Doe</td>
         <td>jane-doe</td>
         <td>18</td>
       </tr>
       <tr>
-        <td>3</td>
         <td>Good Corp.</td>
         <td>good-corp</td>
         <td>5</td>
@@ -39,23 +35,14 @@ For basic styling with horizontal dividers, add the base class `.romo-table`.
   </table>
 </div>
 
-```html
-<table class="romo-table">
-  ...
-</table>
-```
-
 ## Optional classes
 
-### `.romo-table-fixed`
+`.romo-table-fixed` use the "fixed" table layout algorithm.
 
-Use the "fixed" table layout algorithm.
-
-<div>
+<div class="romo-push2-bottom">
   <table class="romo-table romo-table-fixed">
     <thead>
       <tr>
-        <th>#</th>
         <th>Name</th>
         <th>Slug</th>
         <th>Count</th>
@@ -63,19 +50,16 @@ Use the "fixed" table layout algorithm.
     </thead>
     <tbody>
       <tr>
-        <td>1</td>
         <td>Joe Test</td>
         <td>joe-test</td>
         <td>10</td>
       </tr>
       <tr>
-        <td>2</td>
         <td>Jane Doe</td>
         <td>jane-doe</td>
         <td>18</td>
       </tr>
       <tr>
-        <td>3</td>
         <td>Good Corp. with really really long content that would normally cause the layout to adjust to fit it.</td>
         <td>good-corp</td>
         <td>5</td>
@@ -84,42 +68,30 @@ Use the "fixed" table layout algorithm.
   </table>
 </div>
 
-```html
-<table class="romo-table">
-  ...
-</table>
-```
+`{th|td}.romo-N-N` add grid column size classes to set table cell widths.
 
-### `{th|td}.romo-N-N`
-
-Add grid column size classes to set table cell widths.
-
-<div>
+<div class="romo-push2-bottom">
   <table class="romo-table">
     <thead>
       <tr>
-        <th class="romo-1-12">#</th>
-        <th class="romo-7-12">Name</th>
+        <th class="romo-8-12">Name</th>
         <th class="romo-2-12">Slug</th>
         <th class="romo-2-12">Count</th>
       </tr>
     </thead>
     <tbody>
       <tr>
-        <td class="romo-1-12">1</td>
-        <td class="romo-7-12">Joe Test</td>
+        <td class="romo-8-12">Joe Test</td>
         <td class="romo-2-12">joe-test</td>
         <td class="romo-2-12">10</td>
       </tr>
       <tr>
-        <td class="romo-1-12">2</td>
-        <td class="romo-7-12">Jane Doe</td>
+        <td class="romo-8-12">Jane Doe</td>
         <td class="romo-2-12">jane-doe</td>
         <td class="romo-2-12">18</td>
       </tr>
       <tr>
-        <td class="romo-1-12">3</td>
-        <td class="romo-7-12">Good Corp.</td>
+        <td class="romo-8-12">Good Corp.</td>
         <td class="romo-2-12">good-corp</td>
         <td class="romo-2-12">5</td>
       </tr>
@@ -127,48 +99,12 @@ Add grid column size classes to set table cell widths.
   </table>
 </div>
 
-```html
-<table class="romo-table">
-  <thead>
-    <tr>
-      <th class="romo-1-12">#</th>
-      <th class="romo-7-12">Name</th>
-      <th class="romo-2-12">Slug</th>
-      <th class="romo-2-12">Count</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td class="romo-1-12">1</td>
-      <td class="romo-7-12">Joe Test</td>
-      <td class="romo-2-12">joe-test</td>
-      <td class="romo-2-12">10</td>
-    </tr>
-    <tr>
-      <td class="romo-1-12">2</td>
-      <td class="romo-7-12">Jane Doe</td>
-      <td class="romo-2-12">jane-doe</td>
-      <td class="romo-2-12">18</td>
-    </tr>
-    <tr>
-      <td class="romoromo-1-12">3</td>
-      <td class="romoromo-7-12">Good Corp.</td>
-      <td class="romoromo-2-12">good-corp</td>
-      <td class="romoromo-2-12">5</td>
-    </tr>
-  </tbody>
-</table>
-```
+`.romo-table-striped{.romo-table-striped-alt}` adds zebra-striping to any table row within the `<tbody>` via the `:nth-child` CSS selector.
 
-### `.romo-table-striped`
-
-Adds zebra-striping to any table row within the `<tbody>` via the `:nth-child` CSS selector.
-
-<div class="romo-push2-bottom">
+<div class="romo-push-bottom">
   <table class="romo-table romo-table-striped">
     <thead>
       <tr>
-        <th>#</th>
         <th>Name</th>
         <th>Slug</th>
         <th>Count</th>
@@ -176,19 +112,16 @@ Adds zebra-striping to any table row within the `<tbody>` via the `:nth-child` C
     </thead>
     <tbody>
       <tr>
-        <td>1</td>
         <td>Joe Test</td>
         <td>joe-test</td>
         <td>10</td>
       </tr>
       <tr>
-        <td>2</td>
         <td>Jane Doe</td>
         <td>jane-doe</td>
         <td>18</td>
       </tr>
       <tr>
-        <td>3</td>
         <td>Good Corp.</td>
         <td>good-corp</td>
         <td>5</td>
@@ -197,11 +130,10 @@ Adds zebra-striping to any table row within the `<tbody>` via the `:nth-child` C
   </table>
 </div>
 
-<div>
+<div class="romo-push2-bottom">
   <table class="romo-table romo-table-striped romo-table-striped-alt">
     <thead>
       <tr>
-        <th>#</th>
         <th>Name</th>
         <th>Slug</th>
         <th>Count</th>
@@ -209,19 +141,16 @@ Adds zebra-striping to any table row within the `<tbody>` via the `:nth-child` C
     </thead>
     <tbody>
       <tr>
-        <td>1</td>
         <td>Joe Test</td>
         <td>joe-test</td>
         <td>10</td>
       </tr>
       <tr>
-        <td>2</td>
         <td>Jane Doe</td>
         <td>jane-doe</td>
         <td>18</td>
       </tr>
       <tr>
-        <td>3</td>
         <td>Good Corp.</td>
         <td>good-corp</td>
         <td>5</td>
@@ -230,25 +159,12 @@ Adds zebra-striping to any table row within the `<tbody>` via the `:nth-child` C
   </table>
 </div>
 
-```html
-<table class="romo-table romo-table-striped">
-  ...
-</table>
+`.romo-table-alt` uses the alternate bg color for the table background.
 
-<table class="romo-table romo-table-striped romo-table-striped-alt">
-  ...
-</table>
-```
-
-### `.romo-table-alt`
-
-Uses the alternate bg color for the table background.
-
-<div>
+<div class="romo-push2-bottom">
   <table class="romo-table romo-table-alt">
     <thead>
       <tr>
-        <th>#</th>
         <th>Name</th>
         <th>Slug</th>
         <th>Count</th>
@@ -256,19 +172,16 @@ Uses the alternate bg color for the table background.
     </thead>
     <tbody>
       <tr>
-        <td>1</td>
         <td>Joe Test</td>
         <td>joe-test</td>
         <td>10</td>
       </tr>
       <tr>
-        <td>2</td>
         <td>Jane Doe</td>
         <td>jane-doe</td>
         <td>18</td>
       </tr>
       <tr>
-        <td>3</td>
         <td>Good Corp.</td>
         <td>good-corp</td>
         <td>5</td>
@@ -277,1027 +190,704 @@ Uses the alternate bg color for the table background.
   </table>
 </div>
 
-```html
-<table class="romo-table romo-table-alt">
-  ...
-</table>
-```
+`.romo-table-hover` add hover state to rows within a `<tbody>`.
 
-### `tr.romo-{muted|warning|danger|info|success|inverse}`
-
-Add color emphasis to rows.
-
-<div>
-  <table class="romo-table">
+<div class="romo-push2-bottom">
+  <table class="romo-table romo-table-hover">
     <thead>
       <tr>
-        <th>#</th>
         <th>Name</th>
         <th>Slug</th>
         <th>Count</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Joe Test</td>
+        <td>joe-test</td>
+        <td>10</td>
+      </tr>
+      <tr>
+        <td>Jane Doe</td>
+        <td>jane-doe</td>
+        <td>18</td>
+      </tr>
+      <tr>
+        <td>Good Corp.</td>
+        <td>good-corp</td>
+        <td>5</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+`.romo-table-border{0-2}` adds sized borders to the table.
+
+<div class="romo-push-bottom">
+  <table class="romo-table romo-table-fixed romo-table-border">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Slug</th>
+        <th>Count</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td rowspan="2">Joe Test</td>
+        <td rowspan="2">joe-test</td>
+        <td>10</td>
+      </tr>
+      <tr>
+        <td>0</td>
+      </tr>
+      <tr>
+        <td>Jane Doe</td>
+        <td>jane-doe</td>
+        <td rowspan="2">18</td>
+      </tr>
+      <tr>
+        <td colspan="2">Good Corp.</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+<div class="romo-push-bottom">
+  <table class="romo-table romo-table-fixed romo-table-border0">
+    <tbody>
+      <tr>
+        <td rowspan="2">Joe Test</td>
+        <td rowspan="2">joe-test</td>
+        <td>10</td>
+      </tr>
+      <tr>
+        <td>0</td>
+      </tr>
+      <tr>
+        <td>Jane Doe</td>
+        <td>jane-doe</td>
+        <td rowspan="2">18</td>
+      </tr>
+      <tr>
+        <td colspan="2">Good Corp.</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+<div class="romo-push-bottom">
+  <table class="romo-table romo-table-fixed romo-table-border1">
+    <tbody>
+      <tr>
+        <td rowspan="2">Joe Test</td>
+        <td rowspan="2">joe-test</td>
+        <td>10</td>
+      </tr>
+      <tr>
+        <td>0</td>
+      </tr>
+      <tr>
+        <td>Jane Doe</td>
+        <td>jane-doe</td>
+        <td rowspan="2">18</td>
+      </tr>
+      <tr>
+        <td colspan="2">Good Corp.</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+<div class="romo-push2-bottom">
+  <table class="romo-table romo-table-fixed romo-table-border2">
+    <tbody>
+      <tr>
+        <td rowspan="2">Joe Test</td>
+        <td rowspan="2">joe-test</td>
+        <td>10</td>
+      </tr>
+      <tr>
+        <td>0</td>
+      </tr>
+      <tr>
+        <td>Jane Doe</td>
+        <td>jane-doe</td>
+        <td rowspan="2">18</td>
+      </tr>
+      <tr>
+        <td colspan="2">Good Corp.</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+`.romo-table-border-none` remove all borders from the table.
+
+<div class="romo-push2-bottom">
+  <table class="romo-table romo-table-fixed romo-table-border-none">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Slug</th>
+        <th>Count</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td rowspan="2">Joe Test</td>
+        <td rowspan="2">joe-test</td>
+        <td>10</td>
+      </tr>
+      <tr>
+        <td>0</td>
+      </tr>
+      <tr>
+        <td>Jane Doe</td>
+        <td>jane-doe</td>
+        <td rowspan="2">18</td>
+      </tr>
+      <tr>
+        <td colspan="2">Good Corp.</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+`.romo-table-padN{-top|-right|-bottom|-left|}` adds cell padding to every cell in the table
+
+<div class="romo-push0-bottom">
+  <table class="romo-table romo-table-fixed romo-table-border romo-table-pad0">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Slug</th>
+        <th>Count</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Joe Test</td>
+        <td>joe-test</td>
+        <td>10</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+<div class="romo-push0-bottom">
+  <table class="romo-table romo-table-fixed romo-table-border romo-table-pad">
+    <tbody>
+      <tr>
+        <td>Jane Doe</td>
+        <td>jane-doe</td>
+        <td>18</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+<div class="romo-push0-bottom">
+  <table class="romo-table romo-table-fixed romo-table-border romo-table-pad1">
+    <tbody>
+      <tr>
+        <td>Jane Doe</td>
+        <td>jane-doe</td>
+        <td>18</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+<div class="romo-push2-bottom">
+  <table class="romo-table romo-table-fixed romo-table-border romo-table-pad2">
+    <tbody>
+      <tr>
+        <td>Good Corp.</td>
+        <td>good-corp</td>
+        <td>5</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+## Colored Rows
+
+`tr.romo-{...}` add table row style classes to color row backgrounds based on an implicit emphasis OR an explicit name.
+
+### Basic
+
+<div class="romo-push2-bottom">
+  <table class="romo-table romo-table-fixed romo-table-pad0 romo-table-hover romo-table-pad0">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>class=""</th>
       </tr>
     </thead>
     <tbody>
       <tr class="romo-base">
-        <td>2</td>
-        <td>Jane Doe</td>
-        <td>jane-doe</td>
-        <td>18</td>
+        <td>Base</td>
+        <td><code>.romo-base</code></td>
       </tr>
       <tr class="romo-alt">
-        <td>2</td>
-        <td>Jane Doe</td>
-        <td>jane-doe</td>
-        <td>18</td>
+        <td>Alt</td>
+        <td><code>.romo-alt</code></td>
       </tr>
       <tr class="romo-muted romo-text-muted">
-        <td>1</td>
-        <td>Joe Test</td>
-        <td>joe-test</td>
-        <td>10</td>
+        <td>Muted</td>
+        <td><code>.romo-muted.romo-text-muted</code></td>
       </tr>
+    </tbody>
+  </table>
+</div>
+
+### Explicit
+
+<div class="romo-push2-bottom">
+  <table class="romo-table romo-table-fixed romo-table-pad0 romo-table-hover romo-table-pad0">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>class=""</th>
+        <th>Color</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr class="romo-dark-red romo-text-inverse">
+        <td>Dark Red</td>
+        <td><code>.romo-dark-red</code></td>
+        <td><code>$darkRed</code></td>
+      </tr>
+      <tr class="romo-red romo-text-inverse">
+        <td>Red</td>
+        <td><code>.romo-red</code></td>
+        <td><code>$red</code></td>
+      </tr>
+      <tr class="romo-light-red romo-text-inverse">
+        <td>Light Red</td>
+        <td><code>.romo-light-red</code></td>
+        <td><code>$lightRed</code></td>
+      </tr>
+      <tr class="romo-pastel-red romo-text-base">
+        <td>Pastel Red</td>
+        <td><code>.romo-pastel-red</code></td>
+        <td><code>$pastelRed</code></td>
+      </tr>
+      <tr class="romo-dark-orange romo-text-inverse">
+        <td>Dark Orange</td>
+        <td><code>.romo-dark-orange</code></td>
+        <td><code>$darkOrange</code></td>
+      </tr>
+      <tr class="romo-orange romo-text-inverse">
+        <td>Orange</td>
+        <td><code>.romo-orange</code></td>
+        <td><code>$orange</code></td>
+      </tr>
+      <tr class="romo-yellow romo-text-base">
+        <td>Yellow</td>
+        <td><code>.romo-yellow</code></td>
+        <td><code>$yellow</code></td>
+      </tr>
+      <tr class="romo-pastel-yellow romo-text-base">
+        <td>Pastel Yellow</td>
+        <td><code>.romo-pastel-yellow</code></td>
+        <td><code>$pastelYellow</code></td>
+      </tr>
+      <tr class="romo-purple romo-text-inverse">
+        <td>Purple</td>
+        <td><code>.romo-purple</code></td>
+        <td><code>$purple</code></td>
+      </tr>
+      <tr class="romo-light-purple romo-text-inverse">
+        <td>Light Purple</td>
+        <td><code>.romo-light-purple</code></td>
+        <td><code>$lightPurple</code></td>
+      </tr>
+      <tr class="romo-dark-pink romo-text-inverse">
+        <td>Dark Pink</td>
+        <td><code>.romo-dark-pink</code></td>
+        <td><code>$darkPink</code></td>
+      </tr>
+      <tr class="romo-hot-pink romo-text-inverse">
+        <td>Hot Pink</td>
+        <td><code>.romo-hot-pink</code></td>
+        <td><code>$hotPink</code></td>
+      </tr>
+      <tr class="romo-pink romo-text-inverse">
+        <td>Pink</td>
+        <td><code>.romo-pink</code></td>
+        <td><code>$pink</code></td>
+      </tr>
+      <tr class="romo-dark-green romo-text-inverse">
+        <td>Dark Green</td>
+        <td><code>.romo-dark-green</code></td>
+        <td><code>$darkGreen</code></td>
+      </tr>
+      <tr class="romo-green romo-text-inverse">
+        <td>Green</td>
+        <td><code>.romo-green</code></td>
+        <td><code>$green</code></td>
+      </tr>
+      <tr class="romo-light-green romo-text-base">
+        <td>Light Green</td>
+        <td><code>.romo-light-green</code></td>
+        <td><code>$lightGreen</code></td>
+      </tr>
+      <tr class="romo-pastel-green romo-text-base">
+        <td>Pastel Green</td>
+        <td><code>.romo-pastel-green</code></td>
+        <td><code>$pastelGreen</code></td>
+      </tr>
+      <tr class="romo-navy romo-text-inverse">
+        <td>Navy</td>
+        <td><code>.romo-navy</code></td>
+        <td><code>$navy</code></td>
+      </tr>
+      <tr class="romo-dark-blue romo-text-inverse">
+        <td>Dark Blue</td>
+        <td><code>.romo-dark-blue</code></td>
+        <td><code>$darkBlue</code></td>
+      </tr>
+      <tr class="romo-blue romo-text-inverse">
+        <td>Blue</td>
+        <td><code>.romo-blue</code></td>
+        <td><code>$blue</code></td>
+      </tr>
+      <tr class="romo-light-blue romo-text-inverse">
+        <td>Light Blue</td>
+        <td><code>.romo-light-blue</code></td>
+        <td><code>$lightBlue</code></td>
+      </tr>
+      <tr class="romo-pastel-blue romo-text-base">
+        <td>Pastel Blue</td>
+        <td><code>.romo-pastel-blue</code></td>
+        <td><code>$pastelBlue</code></td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+### Emphasis
+
+<div class="romo-push2-bottom">
+  <table class="romo-table romo-table-fixed romo-table-pad0 romo-table-hover romo-table-pad0">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>class=""</th>
+        <th>Basis Color</th>
+      </tr>
+    </thead>
+    <tbody>
       <tr class="romo-warning">
-        <td>2</td>
-        <td>Jane Doe</td>
-        <td>jane-doe</td>
-        <td>18</td>
+        <td>Warning</td>
+        <td><code>.romo-warning</code></td>
+        <td><code>$pastelYellow</code></td>
       </tr>
       <tr class="romo-danger">
-        <td>3</td>
-        <td>Good Corp.</td>
-        <td>good-corp</td>
-        <td>5</td>
+        <td>Danger</td>
+        <td><code>.romo-danger</code></td>
+        <td><code>$pastelRed</code></td>
       </tr>
       <tr class="romo-info">
-        <td>1</td>
-        <td>Joe Test</td>
-        <td>joe-test</td>
-        <td>10</td>
+        <td>Info</td>
+        <td><code>.romo-info</code></td>
+        <td><code>$pastelBlue</code></td>
       </tr>
       <tr class="romo-success">
-        <td>2</td>
-        <td>Jane Doe</td>
-        <td>jane-doe</td>
-        <td>18</td>
+        <td>Success</td>
+        <td><code>.romo-success</code></td>
+        <td><code>$pastelGreen</code></td>
       </tr>
       <tr class="romo-inverse romo-text-inverse">
-        <td>3</td>
-        <td>Good Corp.</td>
-        <td>good-corp</td>
-        <td>5</td>
+        <td>Inverse</td>
+        <td><code>.romo-inverse.romo-text-inverse</code></td>
+        <td><code>$inverseColor</code></td>
       </tr>
     </tbody>
   </table>
 </div>
 
-```html
-<table class="romo-table romo-table-hover">
-  ...
-  <tr class="romo-base">...</tr>
-  <tr class="romo-alt">...</tr>
-  <tr class="romo-muted romo-text-muted">...</tr>
-  <tr class="romo-warning">...</tr>
-  <tr class="romo-danger">...</tr>
-  <tr class="romo-info">...</tr>
-  <tr class="romo-success">...</tr>
-  <tr class="romo-inverse romo-text-inverse">...</tr>
-</table>
-```
+## Colored Borders
 
-### `.romo-table-hover`
+`.romo-table-border-{...}` add table style classes to color all table borders based on an implicit emphasis OR an explicit name.
 
-Add hover state to rows within a `<tbody>`.
+### Basic
 
-<div>
-  <table class="romo-table romo-table-hover">
-    <thead>
-      <tr>
-        <th>#</th>
-        <th>Name</th>
-        <th>Slug</th>
-        <th>Count</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>1</td>
-        <td>Joe Test</td>
-        <td>joe-test</td>
-        <td>10</td>
-      </tr>
-      <tr>
-        <td>2</td>
-        <td>Jane Doe</td>
-        <td>jane-doe</td>
-        <td>18</td>
-      </tr>
-      <tr>
-        <td>3</td>
-        <td>Good Corp.</td>
-        <td>good-corp</td>
-        <td>5</td>
-      </tr>
-    </tbody>
+<div class="romo-push0-bottom">
+  <table class="romo-table romo-table-fixed romo-table-pad0 romo-table-border2 romo-table-border-base">
+    <tbody><tr>
+      <td>Base</td>
+      <td><code>.romo-table-border-base</code></td>
+    </tr></tbody>
   </table>
 </div>
-
-```html
-<table class="romo-table romo-table-hover">
-  ...
-</table>
-```
-
-<div>
-  <table class="romo-table romo-table-hover romo-table-striped">
-    <thead>
-      <tr>
-        <th>#</th>
-        <th>Name</th>
-        <th>Slug</th>
-        <th>Count</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>1</td>
-        <td>Joe Test</td>
-        <td>joe-test</td>
-        <td>10</td>
-      </tr>
-      <tr>
-        <td>2</td>
-        <td>Jane Doe</td>
-        <td>jane-doe</td>
-        <td>18</td>
-      </tr>
-      <tr>
-        <td>3</td>
-        <td>Good Corp.</td>
-        <td>good-corp</td>
-        <td>5</td>
-      </tr>
-    </tbody>
+<div class="romo-push0-bottom">
+  <table class="romo-table romo-table-fixed romo-table-pad0 romo-table-border2 romo-table-alt romo-table-border-alt">
+    <tbody><tr>
+      <td>Alt</td>
+      <td><code>.romo-table-alt.romo-table-border-alt</code></td>
+    </tr></tbody>
   </table>
 </div>
-
-```html
-<table class="romo-table romo-table-hover romo-table-striped">
-  ...
-</table>
-```
-
 <div class="romo-push2-bottom">
-  <table class="romo-table romo-table-hover romo-table-alt">
-    <thead>
-      <tr>
-        <th>#</th>
-        <th>Name</th>
-        <th>Slug</th>
-        <th>Count</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>1</td>
-        <td>Joe Test</td>
-        <td>joe-test</td>
-        <td>10</td>
-      </tr>
-      <tr>
-        <td>2</td>
-        <td>Jane Doe</td>
-        <td>jane-doe</td>
-        <td>18</td>
-      </tr>
-      <tr>
-        <td>3</td>
-        <td>Good Corp.</td>
-        <td>good-corp</td>
-        <td>5</td>
-      </tr>
-    </tbody>
+  <table class="romo-table romo-table-fixed romo-table-pad0 romo-table-border2 romo-table-border-muted">
+    <tbody><tr>
+      <td>Muted</td>
+      <td><code>.romo-table-border-muted</code></td>
+    </tr></tbody>
   </table>
 </div>
 
-<div>
-  <table class="romo-table romo-table-hover romo-table-alt romo-table-striped">
-    <thead>
-      <tr>
-        <th>#</th>
-        <th>Name</th>
-        <th>Slug</th>
-        <th>Count</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>1</td>
-        <td>Joe Test</td>
-        <td>joe-test</td>
-        <td>10</td>
-      </tr>
-      <tr>
-        <td>2</td>
-        <td>Jane Doe</td>
-        <td>jane-doe</td>
-        <td>18</td>
-      </tr>
-      <tr>
-        <td>3</td>
-        <td>Good Corp.</td>
-        <td>good-corp</td>
-        <td>5</td>
-      </tr>
-    </tbody>
+### Explicit
+
+<div class="romo-push0-bottom">
+  <table class="romo-table romo-table-fixed romo-table-pad0 romo-table-border2 romo-table-border-dark-red">
+    <tbody><tr>
+      <td>Dark Red</td>
+      <td><code>.romo-table-border-dark-red</code></td>
+      <td><code>$darkRed</code></td>
+    </tr></tbody>
   </table>
 </div>
-
-```html
-<table class="romo-table romo-table-hover romo-table-alt">
-  ...
-</table>
-```
-
-<div>
-  <table class="romo-table romo-table-hover">
-    <thead>
-      <tr>
-        <th>#</th>
-        <th>Name</th>
-        <th>Slug</th>
-        <th>Count</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr class="romo-base">
-        <td>2</td>
-        <td>Jane Doe</td>
-        <td>jane-doe</td>
-        <td>18</td>
-      </tr>
-      <tr class="romo-alt">
-        <td>2</td>
-        <td>Jane Doe</td>
-        <td>jane-doe</td>
-        <td>18</td>
-      </tr>
-      <tr class="romo-muted romo-text-muted">
-        <td>1</td>
-        <td>Joe Test</td>
-        <td>joe-test</td>
-        <td>10</td>
-      </tr>
-      <tr class="romo-warning">
-        <td>2</td>
-        <td>Jane Doe</td>
-        <td>jane-doe</td>
-        <td>18</td>
-      </tr>
-      <tr class="romo-danger">
-        <td>3</td>
-        <td>Good Corp.</td>
-        <td>good-corp</td>
-        <td>5</td>
-      </tr>
-      <tr class="romo-info">
-        <td>1</td>
-        <td>Joe Test</td>
-        <td>joe-test</td>
-        <td>10</td>
-      </tr>
-      <tr class="romo-success">
-        <td>2</td>
-        <td>Jane Doe</td>
-        <td>jane-doe</td>
-        <td>18</td>
-      </tr>
-      <tr class="romo-inverse romo-text-inverse">
-        <td>3</td>
-        <td>Good Corp.</td>
-        <td>good-corp</td>
-        <td>5</td>
-      </tr>
-    </tbody>
+<div class="romo-push0-bottom">
+  <table class="romo-table romo-table-fixed romo-table-pad0 romo-table-border2 romo-table-border-red">
+    <tbody><tr>
+      <td>Red</td>
+      <td><code>.romo-table-border-red</code></td>
+      <td><code>$red</code></td>
+    </tr></tbody>
   </table>
 </div>
-
-```html
-<table class="romo-table romo-table-hover">
-  ...
-  <tr class="romo-base">...</tr>
-  <tr class="romo-alt">...</tr>
-  <tr class="romo-muted romo-text-muted">...</tr>
-  <tr class="romo-warning">...</tr>
-  <tr class="romo-danger">...</tr>
-  <tr class="romo-info">...</tr>
-  <tr class="romo-success">...</tr>
-  <tr class="romo-inverse romo-text-inverse">...</tr>
-</table>
-```
-
-### `.romo-table-border{0-2}`
-
-Adds sized borders to the table.
-
+<div class="romo-push0-bottom">
+  <table class="romo-table romo-table-fixed romo-table-pad0 romo-table-border2 romo-table-border-light-red">
+    <tbody><tr>
+      <td>Light Red</td>
+      <td><code>.romo-table-border-light-red</code></td>
+      <td><code>$lightRed</code></td>
+    </tr></tbody>
+  </table>
+</div>
+<div class="romo-push0-bottom">
+  <table class="romo-table romo-table-fixed romo-table-pad0 romo-table-border2 romo-table-border-pastel-red">
+    <tbody><tr>
+      <td>Pastel Red</td>
+      <td><code>.romo-table-border-pastel-red</code></td>
+      <td><code>$pastelRed</code></td>
+    </tr></tbody>
+  </table>
+</div>
+<div class="romo-push0-bottom">
+  <table class="romo-table romo-table-fixed romo-table-pad0 romo-table-border2 romo-table-border-dark-orange">
+    <tbody><tr>
+      <td>Dark Orange</td>
+      <td><code>.romo-table-border-dark-orange</code></td>
+      <td><code>$darkOrange</code></td>
+    </tr></tbody>
+  </table>
+</div>
+<div class="romo-push0-bottom">
+  <table class="romo-table romo-table-fixed romo-table-pad0 romo-table-border2 romo-table-border-orange">
+    <tbody><tr>
+      <td>Orange</td>
+      <td><code>.romo-table-border-orange</code></td>
+      <td><code>$orange</code></td>
+    </tr></tbody>
+  </table>
+</div>
+<div class="romo-push0-bottom">
+  <table class="romo-table romo-table-fixed romo-table-pad0 romo-table-border2 romo-table-border-yellow">
+    <tbody><tr>
+      <td>Yellow</td>
+      <td><code>.romo-table-border-yellow</code></td>
+      <td><code>$yellow</code></td>
+    </tr></tbody>
+  </table>
+</div>
+<div class="romo-push0-bottom">
+  <table class="romo-table romo-table-fixed romo-table-pad0 romo-table-border2 romo-table-border-pastel-yellow">
+    <tbody><tr>
+      <td>Pastel Yellow</td>
+      <td><code>.romo-table-border-pastel-yellow</code></td>
+      <td><code>$pastelYellow</code></td>
+    </tr></tbody>
+  </table>
+</div>
+<div class="romo-push0-bottom">
+  <table class="romo-table romo-table-fixed romo-table-pad0 romo-table-border2 romo-table-border-purple">
+    <tbody><tr>
+      <td>Purple</td>
+      <td><code>.romo-table-border-purple</code></td>
+      <td><code>$purple</code></td>
+    </tr></tbody>
+  </table>
+</div>
+<div class="romo-push0-bottom">
+  <table class="romo-table romo-table-fixed romo-table-pad0 romo-table-border2 romo-table-border-light-purple">
+    <tbody><tr>
+      <td>Light Purple</td>
+      <td><code>.romo-table-border-light-purple</code></td>
+      <td><code>$lightPurple</code></td>
+    </tr></tbody>
+  </table>
+</div>
+<div class="romo-push0-bottom">
+  <table class="romo-table romo-table-fixed romo-table-pad0 romo-table-border2 romo-table-border-dark-pink">
+    <tbody><tr>
+      <td>Dark Pink</td>
+      <td><code>.romo-table-border-dark-pink</code></td>
+      <td><code>$darkPink</code></td>
+    </tr></tbody>
+  </table>
+</div>
+<div class="romo-push0-bottom">
+  <table class="romo-table romo-table-fixed romo-table-pad0 romo-table-border2 romo-table-border-hot-pink">
+    <tbody><tr>
+      <td>Hot Pink</td>
+      <td><code>.romo-table-border-hot-pink</code></td>
+      <td><code>$hotPink</code></td>
+    </tr></tbody>
+  </table>
+</div>
+<div class="romo-push0-bottom">
+  <table class="romo-table romo-table-fixed romo-table-pad0 romo-table-border2 romo-table-border-pink">
+    <tbody><tr>
+      <td>Pink</td>
+      <td><code>.romo-table-border-pink</code></td>
+      <td><code>$pink</code></td>
+    </tr></tbody>
+  </table>
+</div>
+<div class="romo-push0-bottom">
+  <table class="romo-table romo-table-fixed romo-table-pad0 romo-table-border2 romo-table-border-dark-green">
+    <tbody><tr>
+      <td>Dark Green</td>
+      <td><code>.romo-table-border-dark-green</code></td>
+      <td><code>$darkGreen</code></td>
+    </tr></tbody>
+  </table>
+</div>
+<div class="romo-push0-bottom">
+  <table class="romo-table romo-table-fixed romo-table-pad0 romo-table-border2 romo-table-border-green">
+    <tbody><tr>
+      <td>Green</td>
+      <td><code>.romo-table-border-green</code></td>
+      <td><code>$green</code></td>
+    </tr></tbody>
+  </table>
+</div>
+<div class="romo-push0-bottom">
+  <table class="romo-table romo-table-fixed romo-table-pad0 romo-table-border2 romo-table-border-light-green">
+    <tbody><tr>
+      <td>Light Green</td>
+      <td><code>.romo-table-border-light-green</code></td>
+      <td><code>$lightGreen</code></td>
+    </tr></tbody>
+  </table>
+</div>
+<div class="romo-push0-bottom">
+  <table class="romo-table romo-table-fixed romo-table-pad0 romo-table-border2 romo-table-border-pastel-green">
+    <tbody><tr>
+      <td>Pastel Green</td>
+      <td><code>.romo-table-border-pastel-green</code></td>
+      <td><code>$pastelGreen</code></td>
+    </tr></tbody>
+  </table>
+</div>
+<div class="romo-push0-bottom">
+  <table class="romo-table romo-table-fixed romo-table-pad0 romo-table-border2 romo-table-border-navy">
+    <tbody><tr>
+      <td>Navy</td>
+      <td><code>.romo-table-border-navy</code></td>
+      <td><code>$navy</code></td>
+    </tr></tbody>
+  </table>
+</div>
+<div class="romo-push0-bottom">
+  <table class="romo-table romo-table-fixed romo-table-pad0 romo-table-border2 romo-table-border-dark-blue">
+    <tbody><tr>
+      <td>Dark Blue</td>
+      <td><code>.romo-table-border-dark-blue</code></td>
+      <td><code>$darkBlue</code></td>
+    </tr></tbody>
+  </table>
+</div>
+<div class="romo-push0-bottom">
+  <table class="romo-table romo-table-fixed romo-table-pad0 romo-table-border2 romo-table-border-blue">
+    <tbody><tr>
+      <td>Blue</td>
+      <td><code>.romo-table-border-blue</code></td>
+      <td><code>$blue</code></td>
+    </tr></tbody>
+  </table>
+</div>
+<div class="romo-push0-bottom">
+  <table class="romo-table romo-table-fixed romo-table-pad0 romo-table-border2 romo-table-border-light-blue">
+    <tbody><tr>
+      <td>Light Blue</td>
+      <td><code>.romo-table-border-light-blue</code></td>
+      <td><code>$lightBlue</code></td>
+    </tr></tbody>
+  </table>
+</div>
 <div class="romo-push2-bottom">
-  <table class="romo-table romo-table-border">
-    <thead>
-      <tr>
-        <th>#</th>
-        <th>Name</th>
-        <th>Slug</th>
-        <th>Count</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td rowspan="2">1</td>
-        <td>Joe Test</td>
-        <td>joe-test</td>
-        <td>10</td>
-      </tr>
-      <tr>
-        <td>Joe Test</td>
-        <td>joe-test</td>
-        <td>0</td>
-      </tr>
-      <tr>
-        <td>2</td>
-        <td>Jane Doe</td>
-        <td>jane-doe</td>
-        <td rowspan="2">18</td>
-      </tr>
-      <tr>
-        <td>3</td>
-        <td colspan="2">Good Corp.</td>
-      </tr>
-    </tbody>
+  <table class="romo-table romo-table-fixed romo-table-pad0 romo-table-border2 romo-table-border-pastel-blue">
+    <tbody><tr>
+      <td>Pastel Blue</td>
+      <td><code>.romo-table-border-pastel-blue</code></td>
+      <td><code>$pastelBlue</code></td>
+    </tr></tbody>
   </table>
 </div>
 
+### Emphasis
+
+<div class="romo-push0-bottom">
+  <table class="romo-table romo-table-fixed romo-table-pad0 romo-table-border2 romo-table-border-warning">
+    <tbody><tr>
+      <td>Warning</td>
+      <td><code>.romo-table-border-warning</code></td>
+      <td><code>$pastelYellow</code></td>
+    </tr></tbody>
+  </table>
+</div>
+<div class="romo-push0-bottom">
+  <table class="romo-table romo-table-fixed romo-table-pad0 romo-table-border2 romo-table-border-danger">
+    <tbody><tr>
+      <td>Danger</td>
+      <td><code>.romo-table-border-danger</code></td>
+      <td><code>$pastelRed</code></td>
+    </tr></tbody>
+  </table>
+</div>
+<div class="romo-push0-bottom">
+  <table class="romo-table romo-table-fixed romo-table-pad0 romo-table-border2 romo-table-border-info">
+    <tbody><tr>
+      <td>Info</td>
+      <td><code>.romo-table-border-info</code></td>
+      <td><code>$pastelBlue</code></td>
+    </tr></tbody>
+  </table>
+</div>
+<div class="romo-push0-bottom">
+  <table class="romo-table romo-table-fixed romo-table-pad0 romo-table-border2 romo-table-border-success">
+    <tbody><tr>
+      <td>Success</td>
+      <td><code>.romo-table-border-success</code></td>
+      <td><code>$pastelGreen</code></td>
+    </tr></tbody>
+  </table>
+</div>
 <div class="romo-push2-bottom">
-  <table class="romo-table romo-table-border0">
-    <thead>
-      <tr>
-        <th>#</th>
-        <th>Name</th>
-        <th>Slug</th>
-        <th>Count</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td rowspan="2">1</td>
-        <td>Joe Test</td>
-        <td>joe-test</td>
-        <td>10</td>
-      </tr>
-      <tr>
-        <td>Joe Test</td>
-        <td>joe-test</td>
-        <td>0</td>
-      </tr>
-      <tr>
-        <td>2</td>
-        <td>Jane Doe</td>
-        <td>jane-doe</td>
-        <td rowspan="2">18</td>
-      </tr>
-      <tr>
-        <td>3</td>
-        <td colspan="2">Good Corp.</td>
-      </tr>
-    </tbody>
+  <table class="romo-table romo-table-fixed romo-table-pad0 romo-table-border2 romo-table-border-inverse">
+    <tbody><tr>
+      <td>Inverse</td>
+      <td><code>.romo-table-border-inverse</code></td>
+      <td><code>$inverseColor</code></td>
+    </tr></tbody>
   </table>
 </div>
-
-<div class="romo-push2-bottom">
-  <table class="romo-table romo-table-border1">
-    <thead>
-      <tr>
-        <th>#</th>
-        <th>Name</th>
-        <th>Slug</th>
-        <th>Count</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td rowspan="2">1</td>
-        <td>Joe Test</td>
-        <td>joe-test</td>
-        <td>10</td>
-      </tr>
-      <tr>
-        <td>Joe Test</td>
-        <td>joe-test</td>
-        <td>0</td>
-      </tr>
-      <tr>
-        <td>2</td>
-        <td>Jane Doe</td>
-        <td>jane-doe</td>
-        <td rowspan="2">18</td>
-      </tr>
-      <tr>
-        <td>3</td>
-        <td colspan="2">Good Corp.</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-
-<div>
-  <table class="romo-table romo-table-border2">
-    <thead>
-      <tr>
-        <th>#</th>
-        <th>Name</th>
-        <th>Slug</th>
-        <th>Count</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td rowspan="2">1</td>
-        <td>Joe Test</td>
-        <td>joe-test</td>
-        <td>10</td>
-      </tr>
-      <tr>
-        <td>Joe Test</td>
-        <td>joe-test</td>
-        <td>0</td>
-      </tr>
-      <tr>
-        <td>2</td>
-        <td>Jane Doe</td>
-        <td>jane-doe</td>
-        <td rowspan="2">18</td>
-      </tr>
-      <tr>
-        <td>3</td>
-        <td colspan="2">Good Corp.</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-
-```html
-<table class="romo-table romo-table-border{0-2}">
-  ...
-</table>
-```
-
-### `.romo-table-border-none`
-
-Remove all borders from the table.
-
-<div class="romo-push2-bottom">
-  <table class="romo-table romo-table-border-none">
-    <thead>
-      <tr>
-        <th>#</th>
-        <th>Name</th>
-        <th>Slug</th>
-        <th>Count</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td rowspan="2">1</td>
-        <td>Joe Test</td>
-        <td>joe-test</td>
-        <td>10</td>
-      </tr>
-      <tr>
-        <td>Joe Test</td>
-        <td>joe-test</td>
-        <td>0</td>
-      </tr>
-      <tr>
-        <td>2</td>
-        <td>Jane Doe</td>
-        <td>jane-doe</td>
-        <td rowspan="2">18</td>
-      </tr>
-      <tr>
-        <td>3</td>
-        <td colspan="2">Good Corp.</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-
-```html
-<table class="romo-table romo-table-border-none">
-  ...
-</table>
-```
-
-### `.romo-table-border-{muted|warning|danger|info|success|inverse}`
-
-Adds border color empasis to the entire table.
-
-<div class="romo-push2-bottom">
-  <table class="romo-table romo-table-border2 romo-table-border-base">
-    <thead>
-      <tr>
-        <th>#</th>
-        <th>Name</th>
-        <th>Slug</th>
-        <th>Count</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>1</td>
-        <td>Joe Test</td>
-        <td>joe-test</td>
-        <td>10</td>
-      </tr>
-      <tr>
-        <td>2</td>
-        <td>Jane Doe</td>
-        <td>jane-doe</td>
-        <td>18</td>
-      </tr>
-      <tr>
-        <td>3</td>
-        <td>Good Corp.</td>
-        <td>good-corp</td>
-        <td>5</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-
-<div class="romo-push2-bottom">
-  <table class="romo-table romo-table-border2 romo-table-border-alt">
-    <thead>
-      <tr>
-        <th>#</th>
-        <th>Name</th>
-        <th>Slug</th>
-        <th>Count</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>1</td>
-        <td>Joe Test</td>
-        <td>joe-test</td>
-        <td>10</td>
-      </tr>
-      <tr>
-        <td>2</td>
-        <td>Jane Doe</td>
-        <td>jane-doe</td>
-        <td>18</td>
-      </tr>
-      <tr>
-        <td>3</td>
-        <td>Good Corp.</td>
-        <td>good-corp</td>
-        <td>5</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-
-<div class="romo-push2-bottom">
-  <table class="romo-table romo-table-border2 romo-table-border-muted">
-    <thead>
-      <tr>
-        <th>#</th>
-        <th>Name</th>
-        <th>Slug</th>
-        <th>Count</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>1</td>
-        <td>Joe Test</td>
-        <td>joe-test</td>
-        <td>10</td>
-      </tr>
-      <tr>
-        <td>2</td>
-        <td>Jane Doe</td>
-        <td>jane-doe</td>
-        <td>18</td>
-      </tr>
-      <tr>
-        <td>3</td>
-        <td>Good Corp.</td>
-        <td>good-corp</td>
-        <td>5</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-
-<div class="romo-push2-bottom">
-  <table class="romo-table romo-table-border2 romo-table-border-warning">
-    <thead>
-      <tr>
-        <th>#</th>
-        <th>Name</th>
-        <th>Slug</th>
-        <th>Count</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>1</td>
-        <td>Joe Test</td>
-        <td>joe-test</td>
-        <td>10</td>
-      </tr>
-      <tr>
-        <td>2</td>
-        <td>Jane Doe</td>
-        <td>jane-doe</td>
-        <td>18</td>
-      </tr>
-      <tr>
-        <td>3</td>
-        <td>Good Corp.</td>
-        <td>good-corp</td>
-        <td>5</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-
-<div class="romo-push2-bottom">
-  <table class="romo-table romo-table-border2 romo-table-border-danger">
-    <thead>
-      <tr>
-        <th>#</th>
-        <th>Name</th>
-        <th>Slug</th>
-        <th>Count</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>1</td>
-        <td>Joe Test</td>
-        <td>joe-test</td>
-        <td>10</td>
-      </tr>
-      <tr>
-        <td>2</td>
-        <td>Jane Doe</td>
-        <td>jane-doe</td>
-        <td>18</td>
-      </tr>
-      <tr>
-        <td>3</td>
-        <td>Good Corp.</td>
-        <td>good-corp</td>
-        <td>5</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-
-<div class="romo-push2-bottom">
-  <table class="romo-table romo-table-border2 romo-table-border-info">
-    <thead>
-      <tr>
-        <th>#</th>
-        <th>Name</th>
-        <th>Slug</th>
-        <th>Count</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>1</td>
-        <td>Joe Test</td>
-        <td>joe-test</td>
-        <td>10</td>
-      </tr>
-      <tr>
-        <td>2</td>
-        <td>Jane Doe</td>
-        <td>jane-doe</td>
-        <td>18</td>
-      </tr>
-      <tr>
-        <td>3</td>
-        <td>Good Corp.</td>
-        <td>good-corp</td>
-        <td>5</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-
-<div class="romo-push2-bottom">
-  <table class="romo-table romo-table-border2 romo-table-border-success">
-    <thead>
-      <tr>
-        <th>#</th>
-        <th>Name</th>
-        <th>Slug</th>
-        <th>Count</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>1</td>
-        <td>Joe Test</td>
-        <td>joe-test</td>
-        <td>10</td>
-      </tr>
-      <tr>
-        <td>2</td>
-        <td>Jane Doe</td>
-        <td>jane-doe</td>
-        <td>18</td>
-      </tr>
-      <tr>
-        <td>3</td>
-        <td>Good Corp.</td>
-        <td>good-corp</td>
-        <td>5</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-
-<div>
-  <table class="romo-table romo-table-border2 romo-table-border-inverse">
-    <thead>
-      <tr>
-        <th>#</th>
-        <th>Name</th>
-        <th>Slug</th>
-        <th>Count</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>1</td>
-        <td>Joe Test</td>
-        <td>joe-test</td>
-        <td>10</td>
-      </tr>
-      <tr>
-        <td>2</td>
-        <td>Jane Doe</td>
-        <td>jane-doe</td>
-        <td>18</td>
-      </tr>
-      <tr>
-        <td>3</td>
-        <td>Good Corp.</td>
-        <td>good-corp</td>
-        <td>5</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-
-```html
-<table class="romo-table romo-table-border2 romo-table-border-{base|alt|muted|warning|danger|info|success|inverse}">
-  ...
-</table>
-```
-
-### `.romo-table-padN{-top|-right|-bottom|-left|}`
-
-Adds cell padding to every cell in the table
-
-<div>
-  <table class="romo-table romo-table-border romo-table-pad0">
-    <thead>
-      <tr>
-        <th>#</th>
-        <th>Name</th>
-        <th>Slug</th>
-        <th>Count</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>1</td>
-        <td>Joe Test</td>
-        <td>joe-test</td>
-        <td>10</td>
-      </tr>
-      <tr>
-        <td>2</td>
-        <td>Jane Doe</td>
-        <td>jane-doe</td>
-        <td>18</td>
-      </tr>
-      <tr>
-        <td>3</td>
-        <td>Good Corp.</td>
-        <td>good-corp</td>
-        <td>5</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-
-```html
-<table class="romo-table romo-table-pad0">
-  ...
-</table>
-```
-
-<div>
-  <table class="romo-table romo-table-border romo-table-pad">
-    <thead>
-      <tr>
-        <th>#</th>
-        <th>Name</th>
-        <th>Slug</th>
-        <th>Count</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>1</td>
-        <td>Joe Test</td>
-        <td>joe-test</td>
-        <td>10</td>
-      </tr>
-      <tr>
-        <td>2</td>
-        <td>Jane Doe</td>
-        <td>jane-doe</td>
-        <td>18</td>
-      </tr>
-      <tr>
-        <td>3</td>
-        <td>Good Corp.</td>
-        <td>good-corp</td>
-        <td>5</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-
-```html
-<table class="romo-table romo-table-pad">
-  ...
-</table>
-```
-
-<div>
-  <table class="romo-table romo-table-border romo-table-pad1">
-    <thead>
-      <tr>
-        <th>#</th>
-        <th>Name</th>
-        <th>Slug</th>
-        <th>Count</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>1</td>
-        <td>Joe Test</td>
-        <td>joe-test</td>
-        <td>10</td>
-      </tr>
-      <tr>
-        <td>2</td>
-        <td>Jane Doe</td>
-        <td>jane-doe</td>
-        <td>18</td>
-      </tr>
-      <tr>
-        <td>3</td>
-        <td>Good Corp.</td>
-        <td>good-corp</td>
-        <td>5</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-
-```html
-<table class="romo-table romo-table-pad1">
-  ...
-</table>
-```
-
-<div>
-  <table class="romo-table romo-table-border romo-table-pad2">
-    <thead>
-      <tr>
-        <th>#</th>
-        <th>Name</th>
-        <th>Slug</th>
-        <th>Count</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>1</td>
-        <td>Joe Test</td>
-        <td>joe-test</td>
-        <td>10</td>
-      </tr>
-      <tr>
-        <td>2</td>
-        <td>Jane Doe</td>
-        <td>jane-doe</td>
-        <td>18</td>
-      </tr>
-      <tr>
-        <td>3</td>
-        <td>Good Corp.</td>
-        <td>good-corp</td>
-        <td>5</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-
-```html
-<table class="romo-table romo-table-pad2">
-  ...
-</table>
-```
-
-## Custom Styles
-
-Use any helper style classes in any combination on rows/cells.
-
-<div>
-  <table class="romo-table romo-table-pad2">
-    <thead>
-      <tr>
-        <th class="romo-pad2">#</th>
-        <th>Name</th>
-        <th class="romo-text2 romo-pad2-left">Slug</th>
-        <th class="romo-1-12 romo-align-center romo-align-top">Count</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>1</td>
-        <td class="romo-bg-info">Joe Test</td>
-        <td>joe-test</td>
-        <td class="romo-1-12 romo-text2 romo-border-danger romo-border4">10</td>
-      </tr>
-      <tr>
-        <td>2</td>
-        <td>Jane Doe</td>
-        <td class="romo-pad0">jane-doe</td>
-        <td class="romo-1-12 romo-align-center romo-text-success">18</td>
-      </tr>
-      <tr class="romo-bg-success">
-        <td>3</td>
-        <td>Good Corp.</td>
-        <td>good-corp</td>
-        <td class="romo-1-12">5</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-
-```html
-<table class="romo-table romo-table-pad2">
-  <thead>
-    <tr>
-      <th class="romo-pad2">#</th>
-      <th>Name</th>
-      <th class="romo-text2 romo-pad2-left">Slug</th>
-      <th class="romo-1-12 romo-align-center romo-align-top">Count</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>1</td>
-      <td class="romo-bg-info">Joe Test</td>
-      <td>joe-test</td>
-      <td class="romo-1-12 romo-text2 romo-border-danger romo-border4">10</td>
-    </tr>
-    <tr>
-      <td>2</td>
-      <td>Jane Doe</td>
-      <td class="romo-pad0">jane-doe</td>
-      <td class="romo-1-12 romo-align-center romo-text-success">18</td>
-    </tr>
-    <tr class="romo-bg-success">
-      <td>3</td>
-      <td>Good Corp.</td>
-      <td>good-corp</td>
-      <td class="romo-1-12">5</td>
-    </tr>
-  </tbody>
-</table>
-```
 
 ## Supported table markup
 
@@ -1343,26 +933,3 @@ List of supported table HTML elements and how they should be used.
   </tbody>
 </table>
 </div>
-
-```html
-<table>
-  <thead>
-    <tr>
-      <th>...</th>
-      <th>...</th>
-    </tr>
-  </thead>
-  <tfoot>
-    <tr>
-      <td>...</td>
-      <td>...</td>
-    </tr>
-  </tfoot>
-  <tbody>
-    <tr>
-      <td>...</td>
-      <td>...</td>
-    </tr>
-  </tbody>
-</table>
-```

--- a/gh-pages/view_handlers/css/typography.md
+++ b/gh-pages/view_handlers/css/typography.md
@@ -242,7 +242,7 @@ Or only set a font weight on hover.
 
 ## Colors
 
-Use style classes to add color (with optional hover color to text and backgrounds based on an implicit emphasis OR an explicit name.  These also work for links and hover-only use cases.
+Use style classes to add color (with optional hover color) to text and backgrounds based on an implicit emphasis OR an explicit name.  These also work for links and hover-only use cases.
 
 ### Basic
 
@@ -655,7 +655,7 @@ Use style classes to add color (with optional hover color to text and background
         <th class="romo-align-center">Text</th>
         <th class="romo-align-center">Anchor</th>
         <th class="romo-align-center">class=""</th>
-        <th class="romo-align-center">Default Basis Color</th>
+        <th class="romo-align-center">Basis Color</th>
       </tr>
     </thead>
     <tbody>


### PR DESCRIPTION
This takes all of the work to add in color style classes and
adds corresponding style classes to apply colors to the CSS
components.  This is the final step in adding standard color style
class support to Romo.

The goal here is to limit the colors available to a consistent set
and to have that set applied as you would expect throughout Romo.
This means that buttons, labels, and table backgrounds will all
match if given the same color style class.

To accomplish all this, I had to do a few extra things:

* add in button vars for the explicit colors.  These needed to be
  defined to support the button style classes in the same way the
  emphasis style classes were implemented.  I also chose to switch
  to `inverseColor` instead of hard coding `#fff` for the text/btn
  color vars.  This is all to keep colors consistent.
* I basically rewrote the docs for each CSS component.  I tried
  to remove as much cruft and superfulous markup as possible, esp
  since I was adding a significant amount of additional markup for
  documenting the color classes.

Buttons:
![buttons](https://cloud.githubusercontent.com/assets/82110/21569345/a8db0e30-ce81-11e6-8ca4-190bbeb35248.jpg)

Labels:
![labels](https://cloud.githubusercontent.com/assets/82110/21569357/c141b096-ce81-11e6-9c01-d8dfbf3e8cda.jpg)

Tables:
![tables](https://cloud.githubusercontent.com/assets/82110/21569382/e5dc4074-ce81-11e6-85b9-267015d38e60.jpg)

Grid Tables:
![grid-tables](https://cloud.githubusercontent.com/assets/82110/21569389/0499f470-ce82-11e6-9c3d-f543cba98ed5.jpg)

@jcredding sorry for the bloat on this PR.  The docs kinda spiraled out of control.  This docs rewrite is a preview of some optimizations I want to do for the docs in the future.  This should be the last of the Romo color stuff (for now).  Ready for review.
