### PR TITLE
add RomoDate util functions; use in datepicker

### DIFF
--- a/assets/js/romo/date.js
+++ b/assets/js/romo/date.js
@@ -1,0 +1,310 @@
+var RomoDate = {
+
+  date: function(date) {
+    if (date === undefined || date === null) {
+      return undefined;
+    } else {
+      var d = new Date(date);
+      d.setHours(0,0,0,0); // RomoDate Dates are always local with zero time
+      return d;
+    }
+  },
+
+  for: function(yearNum, zeroBasedMonthNum, dayNum) {
+    return RomoDate.date(new Date(yearNum, zeroBasedMonthNum, dayNum));
+  },
+
+  parse: function(dateString) {
+    return (new RomoDate.Parser(String(dateString).trim())).date();
+  },
+
+  format: function(date, formatString) {
+    return (new RomoDate.Formatter(String(formatString).trim())).dateString(date);
+  },
+
+  today: function() {
+    return RomoDate.date(new Date());
+  },
+
+  currentYear: function() {
+    return RomoDate.today().getFullYear();
+  },
+
+  vector: function(date, numDays) {
+    var d = RomoDate.date(date)
+    return RomoDate.for(d.getFullYear(), d.getMonth(), d.getDate()+(numDays || 0));
+  },
+
+  next: function(date, numDays) {
+    return RomoDate.vector(date, numDays || 1);
+  },
+
+  prev: function(date, numDays) {
+    return RomoDate.vector(date, -(numDays || 1));
+  },
+
+  firstDateOfMonth: function(monthDate, vectorNumMonths) {
+    var d = RomoDate.date(monthDate)
+    return RomoDate.for(d.getFullYear(), d.getMonth()+(vectorNumMonths || 0), 1);
+  },
+
+  lastDateOfMonth: function(monthDate, vectorNumMonths) {
+    var d = RomoDate.date(monthDate)
+    return RomoDate.for(d.getFullYear(), d.getMonth()+(vectorNumMonths || 0)+1, 0);
+  },
+
+  firstDateOfNextMonth: function(monthDate, numMonths) {
+    return RomoDate.firstDateOfMonth(monthDate, numMonths || 1);
+  },
+
+  firstDateOfPrevMonth: function(monthDate, numMonths) {
+    return RomoDate.firstDateOfMonth(monthDate, -(numMonths || 1));
+  },
+
+  lastDateOfNextMonth: function(monthDate, numMonths) {
+    return RomoDate.lastDateOfMonth(monthDate, numMonths || 1);
+  },
+
+  lastDateOfPrevMonth: function(monthDate, numMonths) {
+    return RomoDate.lastDateOfMonth(monthDate, -(numMonths || 1));
+  },
+
+  daysInMonth: function(monthDate, vectorNumMonths) {
+    return RomoDate.lastDateOfMonth(monthDate, vectorNumMonths).getDate();
+  },
+
+  daysRemainingInMonth: function(monthDate) {
+    var d = RomoDate.date(monthDate)
+    return RomoDate.daysInMonth(d) - d.getDate() + 1;
+  },
+
+  isoWeekNum: function(weekDate) {
+    var d = RomoDate.date(weekDate)
+
+    // calc full weeks to nearest Thursday (basis for ISO week numbers)
+    // set to nearest Thursday: current date + 4 - current day number
+    d.setDate(d.getDate() + 4 - (d.getDay()||7));
+    var yearStartDate           = RomoDate.for(d.getFullYear(), 0, 1);
+    var milliSecsSinceYearStart = d - yearStartDate;
+    var milliSecsInADay         = 24*60*60*1000;
+    var daysSinceYearStart      = milliSecsSinceYearStart / milliSecsInADay;
+    var weekNumber              = Math.ceil((daysSinceYearStart + 1) / 7);
+
+    return weekNumber;
+  },
+
+  isEqual: function(date1, date2, formatString) {
+    var d1 = RomoDate.date(date1);
+    var d2 = RomoDate.date(date2);
+    var  f = formatString || 'yyyy-mm-dd'
+
+    if (d1 === undefined || d2 === undefined) {
+      return d1 === d2;
+    } else {
+      return RomoDate.format(d1, f) === RomoDate.format(d2, f)
+    }
+  },
+
+  isSameDate: function(date1, date2) {
+    return RomoDate.isEqual(date1, date2);
+  },
+
+  isSameMonth: function(date1, date2) {
+    return RomoDate.isEqual(date1, date2, 'yyyy-mm')
+  },
+
+  isSameYear: function(date1, date2) {
+    return RomoDate.isEqual(date1, date2, 'yyyy')
+  },
+
+  isDay: function(date, day) {
+    if (date === undefined || date === null) {
+      return false;
+    }
+    var d_day = RomoDate.date(date).getDay();
+    return (day === d_day ||
+            day === RomoDate.Utils.dayNames[d_day] ||
+            day === RomoDate.Utils.dayAbbrevs[d_day]);
+  },
+
+  isWeekend: function(date) {
+    if (date === undefined || date === null) {
+      return false;
+    }
+    var dow = RomoDate.date(date).getDay();
+    return (dow === 0 || dow === 6);
+  },
+
+  // child classes
+
+  Parser: function(trimmedDateString) {
+    this.dateString = trimmedDateString;
+  },
+
+  Formatter: function(trimmedFormatString) {
+    this.formatString = trimmedFormatString;
+  },
+
+  Utils: undefined,
+
+}
+
+// Parser - child utility class to encapsulate parsing a Date obj from a trimmed
+//          date String ('12/25', '12/25/16', '12/25/2016', '2016/12/25')
+
+RomoDate.Parser.prototype.date = function() {
+  if (this.dateString === undefined || this.dateString === '') {
+    return undefined;
+  }
+
+  var dateValues = this._parseValues(this.dateString);
+  if (dateValues.length === 0) {
+    return undefined;
+  }
+  var year = parseInt(dateValues[0]);
+  if (year < 0) {
+    return undefined;
+  }
+  if (dateValues[0].length > 2 && year < 100) {
+    return undefined;
+  }
+  if (dateValues[0].length === 2 && year < 100) {
+    var cy = RomoDate.currentYear();
+    year = cy - (cy % 100) + year; // 2-digit years are subjective. prefer assuming
+    if ((year - cy) > 10) {        // they are past years except assuming all years
+      year = year - 100;           // in the next decade are future years.
+    }
+  }
+
+  var month = parseInt(dateValues[1]) - 1;
+  if (month < 0 || month > 11) {
+    return undefined;
+  }
+
+  var day = parseInt(dateValues[2]);
+  var date = RomoDate.for(year, month, day);
+  if (date.getMonth() !== month) {
+    return undefined;
+  }
+
+  return date;
+}
+
+RomoDate.Parser.prototype._parseValues = function(dateString) {
+  var regex, matches;
+
+  regex = /^([0-9]{1,2})[^0-9]+([0-9]{1,2})[^0-9]+([0-9]{2,4})$/; // "mm dd yyyy" or "mm dd yy"
+  matches = RomoDate.Utils.regexMatches(dateString, regex);
+  if (matches.length === 3) {
+    return [matches[2], matches[0], matches[1]];
+  }
+
+  regex = /^([0-9]{3,4})[^0-9]+([0-9]{1,2})[^0-9]+([0-9]{1,2})$/; // "yyyy mm dd"
+  matches = RomoDate.Utils.regexMatches(dateString, regex);
+  if (matches.length === 3) {
+    return matches;
+  }
+
+  regex = /^([0-9]{1,2})[^0-9]+([0-9]{1,2})$/; // "mm dd"
+  matches = RomoDate.Utils.regexMatches(dateString, regex);
+  if (matches.length === 2) {
+    return [RomoDate.currentYear(), matches[0], matches[1]];
+  }
+
+  return [];
+}
+
+// Parser
+
+// Formatter - child utility class to encapsulate formatting a Date obj into a
+//             date String ('12/25', '12/25/16', '12/25/2016', '2016/12/25')
+
+RomoDate.Formatter.prototype.dateString = function(forDate) {
+  var d     = RomoDate.date(forDate)
+  var year  = d.getFullYear();
+  var month = d.getMonth() + 1; // months are zero-based
+  var day   = d.getDate();
+
+  var formatter = this;
+
+  return this.formatString.replace(/([ymMdD]+)/g, function(match) {
+    switch (match) {
+      case "yyyy":
+      case  "yyy":
+        return year.toString();
+      case   "yy":
+      case    "y":
+        return year.toString().slice(-2);
+      case   "mm":
+        return ("00"+ month.toString()).slice(-2); // pad 2 with "0"s
+      case    "m":
+        return month.toString();
+      case   "MM":
+        return RomoDate.Utils.monthNames[d.getMonth()]
+      case    "M":
+        return RomoDate.Utils.monthAbbrevs[d.getMonth()]
+      case  "ddd":
+        var ds = day.toString();
+        switch (ds.slice(-1)) {
+          case '1':
+            ds += 'st';
+            break;
+          case '2':
+            ds += 'nd'
+            break;
+          case '3':
+            ds += 'rd';
+            break;
+          default:
+            ds += 'th';
+            break;
+        }
+        return ds;
+      case   "dd":
+        return ("00"+ day.toString()).slice(-2); // pad 2 with "0"s
+      case    "d":
+        return day.toString();
+      case   "DD":
+        return RomoDate.Utils.dayNames[d.getDay()]
+      case    "D":
+        return RomoDate.Utils.dayAbbrevs[d.getDay()]
+      default:
+        return match; // delimeter, pass-thru
+    }
+  });
+}
+
+// Formatter
+
+// Utils - sub utility functions shared by the utility classes
+
+RomoDate.Utils = {
+
+  regexMatches: function(value, regex) {
+    if (regex.test(value) === true) {
+      return regex.exec(value).slice(1);
+    }
+    return [];
+  },
+
+  monthNames: [
+    "January", "Febuary", "March",     "April",    "May",      "June",
+    "July",    "August",  "September", "October", "November", "December"
+  ],
+
+  monthAbbrevs: [
+    "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+    "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
+  ],
+
+  dayNames: [
+    "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"
+  ],
+
+  dayAbbrevs: [
+    "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"
+  ],
+
+}
+
+// Utils

--- a/assets/js/romo/datepicker.js
+++ b/assets/js/romo/datepicker.js
@@ -6,10 +6,6 @@ $.fn.romoDatepicker = function() {
 
 var RomoDatepicker = function(element) {
   this.elem = $(element);
-  this.monthNames = [
-    "January", "February", "March", "April", "May", "June",
-    "July", "August", "September", "October", "November", "December"
-  ]
 
   this.defaultFormat    = 'yyyy-mm-dd'
   this.defaultPrevClass = undefined;
@@ -17,7 +13,7 @@ var RomoDatepicker = function(element) {
   this.itemSelector     = 'TD.romo-datepicker-day:not(.disabled)';
   this.calTable         = $();
   this.date             = undefined;
-  this.today            = this._getTodaysDate();
+  this.today            = RomoDate.today();
   this.prevValue        = undefined;
 
   this.doInit();
@@ -84,14 +80,13 @@ RomoDatepicker.prototype.doBindElem = function() {
 }
 
 RomoDatepicker.prototype.doSetFormat = function() {
-  var format = this.elem.data('romo-datepicker-format') || this.defaultFormat;
-  this.formatValues = this._parseFormatValues(format);
+  this.formatString = this.elem.data('romo-datepicker-format') || this.defaultFormat;
 }
 
 RomoDatepicker.prototype.doSetDate = function(value) {
-  this.date = this._parseDate(value);
+  this.date = RomoDate.parse(value);
   if (this.date !== undefined) {
-    this.elem.val(this._formatDate(this.date));
+    this.elem.val(RomoDate.format(this.date, this.formatString));
   } else {
     this.elem.val(value);
   }
@@ -151,7 +146,7 @@ RomoDatepicker.prototype.doBuildUI = function() {
 }
 
 RomoDatepicker.prototype.doRefreshUI = function(date) {
-  var rDate = date || this.date || (new Date);
+  var rDate = date || this.date || this.today;
   this._refreshCalendar(rDate);
   this.elem.trigger('datepicker:refresh', [rDate, this]);
 
@@ -163,29 +158,15 @@ RomoDatepicker.prototype.doRefreshUI = function(date) {
 }
 
 RomoDatepicker.prototype.doRefreshToPrevMonth = function() {
-  var date = this.refreshDate || this.date || (new Date);
-  var year = date.getUTCFullYear();
-  var month = date.getUTCMonth() - 1;
-  if (month < 0) {
-    year -= 1;
-    month = 11;
-  }
-
-  var pDate = this._UTCDate(year, month, 1);
+  var date  = this.refreshDate || this.date || (new Date);
+  var pDate = RomoDate.lastDateOfPrevMonth(date);
   this.doRefreshUI(pDate);
   this.elem.trigger('datepicker:prevRefresh', [pDate, this]);
 }
 
 RomoDatepicker.prototype.doRefreshToNextMonth = function() {
-  var date = this.refreshDate || this.date || (new Date);
-  var year = date.getUTCFullYear();
-  var month = date.getUTCMonth() + 1;
-  if (month > 11) {
-    year += 1;
-    month = 0;
-  }
-
-  var nDate = this._UTCDate(year, month, 1);
+  var date  = this.refreshDate || this.date || (new Date);
+  var nDate = RomoDate.firstDateOfNextMonth(date);
   this.doRefreshUI(nDate);
   this.elem.trigger('datepicker:nextRefresh', [nDate, this]);
 }
@@ -336,11 +317,11 @@ RomoDatepicker.prototype._buildCalendarHeader = function() {
   header.append(row);
 
   row = $('<tr></tr>');
-  row.append($('<th class="romo-datepicker-day">Su</th>'));
+  row.append($('<th class="romo-datepicker-day">S</th>'));
   row.append($('<th class="romo-datepicker-day">M</th>'));
   row.append($('<th class="romo-datepicker-day">T</th>'));
   row.append($('<th class="romo-datepicker-day">W</th>'));
-  row.append($('<th class="romo-datepicker-day">Th</th>'));
+  row.append($('<th class="romo-datepicker-day">T</th>'));
   row.append($('<th class="romo-datepicker-day">F</th>'));
   row.append($('<th class="romo-datepicker-day">S</th>'));
   header.append(row);
@@ -349,66 +330,55 @@ RomoDatepicker.prototype._buildCalendarHeader = function() {
 }
 
 RomoDatepicker.prototype._buildCalendarTitle = function(date) {
-  return this.monthNames[date.getUTCMonth()] + ' ' + date.getUTCFullYear().toString();
+  return RomoDate.format(date, 'MM yyyy');
 }
 
 RomoDatepicker.prototype._buildCalendarBody = function(date) {
-  var ty = this.today.getUTCFullYear();
-  var tm = this.today.getUTCMonth();
-  var td = this.today.getUTCDate();
-  var year = date.getUTCFullYear();
-  var month = date.getUTCMonth();
-  var day = date.getUTCDate();
-  var fomdow = this._UTCDate(year, month, 1).getUTCDay(); // first-of-the-month day-of-the-week
-  if (fomdow == 0) {
-    fomdow = 7;  // don't start calendar on the first-of-the-month, show last week of prev month
+  var fom    = RomoDate.firstDateOfMonth(date); // first-of-month
+  var fomday = fom.getDay();
+  if (fomday == 0) { // don't start calendar starting on the first-of-the-month.
+    fomday = 7;      // show it starting on the last week of the prev month.
   }
-  var iDate = this._UTCDate(year, month, 1 - fomdow);
+  var iDate = RomoDate.vector(fom, -fomday);
   var iWeek = 0;
+
   var html = [];
 
   while (iWeek < 6) { // render 6 weeks in the calendar
-    var y = iDate.getUTCFullYear();
-    var m = iDate.getUTCMonth();
-    var d = iDate.getUTCDate();
-    var dow = iDate.getUTCDay();
     var cls = [];
 
-    if (dow === 0) {
+    if (RomoDate.isDay(iDate, 'Sunday')) {
       html.push('<tr>');
     }
 
     cls.push('romo-datepicker-day');
-    if (dow === 0 || dow === 6) {
+    if (RomoDate.isWeekend(iDate)) {
       cls.push('romo-datepicker-day-weekend');
     }
-    if (y !== year || m !== month) {
+    if (!RomoDate.isSameMonth(iDate, date)) {
       cls.push('romo-datepicker-day-other');
     }
-    if (y === ty && m === tm && d === td) {
+    if (RomoDate.isEqual(iDate, this.today)) {
       cls.push('romo-datepicker-day-today');
     }
-    if (this.date &&
-        y === this.date.getUTCFullYear() &&
-        m === this.date.getUTCMonth() &&
-        d === this.date.getUTCDate()) {
+    if (RomoDate.isEqual(iDate, this.date)) {
       cls.push('selected');
     }
 
     html.push('<td');
     html.push(' class="'+cls.join(' ')+'"');
-    var dt = this._formatDate(iDate);
+    var dt = RomoDate.format(iDate, this.formatString);
     html.push(' title="'+dt+'"');
     html.push(' data-romo-datepicker-value="'+dt+'"');
     html.push('>');
-    html.push(d.toString());
+    html.push(RomoDate.format(iDate, 'd'));
     html.push('</td>');
 
-    if (dow === 6) {
+    if (RomoDate.isDay(iDate, 'Saturday')) {
       html.push('</tr>');
       iWeek += 1;
     }
-    iDate.setUTCDate(iDate.getUTCDate()+1);
+    iDate = RomoDate.next(iDate);
   }
 
   return $(html.join(''));
@@ -417,141 +387,6 @@ RomoDatepicker.prototype._buildCalendarBody = function(date) {
 RomoDatepicker.prototype._highlightItem = function(item) {
   this.calTable.find('TD.romo-datepicker-highlight').removeClass('romo-datepicker-highlight');
   item.addClass('romo-datepicker-highlight');
-}
-
-RomoDatepicker.prototype._formatDate = function(date) {
-  var year = date.getUTCFullYear();
-  var month = date.getUTCMonth() + 1;
-  var day = date.getUTCDate();
-
-  return this.formatValues.reduce(function(prev, curr) {
-    switch (curr) {
-      case "yyyy":
-      case "yyy":
-        prev += year.toString();
-        break;
-      case "yy":
-      case "y":
-        prev += year.toString().slice(-2);
-        break;
-      case "mm":
-        prev += ("00"+ month.toString()).slice(-2); // pad 2 with "0"s
-        break;
-      case "m":
-        prev += month.toString();
-        break;
-      case "dd":
-        prev += ("00"+ day.toString()).slice(-2); // pad 2 with "0"s
-        break;
-      case "d":
-        prev += day.toString();
-        break;
-      default:
-        prev += curr; // delimeter, pass-thru
-    }
-    return prev;
-  }, '');
-}
-
-RomoDatepicker.prototype._parseFormatValues = function(value) {
-  var regex, matches;
-
-  regex = /^([m]{1,2})([^md]+)([d]{1,2})([^dy]+)([y]{2,4})$/; // mm dd yyyy or mm dd yy
-  matches = this._regexMatches(value, regex);
-  if (matches.length === 5) {
-    return matches;
-  }
-
-  regex = /^([y]{3,4})([^ym]+)([m]{1,2})([^md]+)([d]{1,2})$/; // yyyy mm dd
-  matches = this._regexMatches(value, regex);
-  if (matches.length === 5) {
-    return matches;
-  }
-
-  return ['yyyy', '-', 'mm', '-', 'dd'];
-}
-
-RomoDatepicker.prototype._parseDate = function(value) {
-  if (value.trim() === '') {
-    return undefined;
-  }
-
-  var dateValues = this._parseDateValues(value.trim());
-  if (dateValues.length === 0) {
-    return undefined;
-  }
-
-  var year = parseInt(dateValues[0]);
-  if (year < 0) {
-    return undefined;
-  }
-  if (dateValues[0].length > 2 && year < 100) {
-    return undefined;
-  }
-  if (dateValues[0].length === 2 && year < 100) {
-    year = this._currentYear() - (this._currentYear() % 1000) + year;
-  }
-
-  var month = parseInt(dateValues[1]) - 1;
-  if (month < 0 || month > 11) {
-    return undefined;
-  }
-
-  var day = parseInt(dateValues[2]);
-  var date = this._UTCDate(year, month, day);
-  if (date.getUTCMonth() !== month) {
-    return undefined;
-  }
-
-  return date;
-}
-
-RomoDatepicker.prototype._parseDateValues = function(value) {
-  var regex, matches;
-
-  regex = /^([0-9]{1,2})[^0-9]+([0-9]{1,2})[^0-9]+([0-9]{2,4})$/; // mm dd yyyy or mm dd yy
-  matches = this._regexMatches(value, regex);
-  if (matches.length === 3) {
-    return [matches[2], matches[0], matches[1]];
-  }
-
-  regex = /^([0-9]{3,4})[^0-9]+([0-9]{1,2})[^0-9]+([0-9]{1,2})$/; // yyyy mm dd
-  matches = this._regexMatches(value, regex);
-  if (matches.length === 3) {
-    return matches;
-  }
-
-  regex = /^([0-9]{1,2})[^0-9]+([0-9]{1,2})$/; // mm dd
-  matches = this._regexMatches(value, regex);
-  if (matches.length === 2) {
-    return [this._currentYear(), matches[0], matches[1]];
-  }
-
-  return [];
-}
-
-RomoDatepicker.prototype._regexMatches = function(value, regex) {
-  if (regex.test(value) === true) {
-    return regex.exec(value).slice(1);
-  }
-  return [];
-}
-
-RomoDatepicker.prototype._currentYear = function() {
-  return (new Date).getUTCFullYear();
-}
-
-RomoDatepicker.prototype._getTodaysDate = function() {
-  var today = new Date();
-  var dd    = today.getDate();
-  var mm    = today.getMonth();
-  var yyyy  = today.getFullYear();
-
-  return this._UTCDate(yyyy, mm, dd);
-}
-
-RomoDatepicker.prototype._UTCDate = function(year, month, day) {
-  return new Date(Date.UTC.apply(Date, [year, month, day]));
 }
 
 Romo.onInitUI(function(e) {

--- a/lib/romo/dassets.rb
+++ b/lib/romo/dassets.rb
@@ -44,6 +44,7 @@ module Romo::Dassets
       ]
       c.combination "js/romo.js", [
         'js/romo/base.js',
+        'js/romo/date.js',
         'js/romo/word_boundary_filter.js',
         'js/romo/invoke.js',
         'js/romo/onkey.js',

--- a/test/unit/dassets_tests.rb
+++ b/test/unit/dassets_tests.rb
@@ -46,6 +46,7 @@ module Romo::Dassets
 
       exp_js_sources = [
         'js/romo/base.js',
+        'js/romo/date.js',
         'js/romo/word_boundary_filter.js',
         'js/romo/invoke.js',
         'js/romo/onkey.js',


### PR DESCRIPTION
The datepicker component had some private methods for working with
dates.  However, I found I wanted to reuse the date parsing
functions in another app.  This extracts the datepicker methods
into a RomoDate namespace and generalizes them a bit for reuse.
This also adds a few extra methods for things I was doing manually
both in the datepicker and my app.

This also reworks the datepicker to take advantage of these util
methods and removes all manual date handling.  Note: as a side
effect, this switches the datepicker to always use local dates
zero'd out time.  This avoids any weird timezone issues with the
picker determining todays date.  This should have been done all
along but was missed.

Some notes on the RomoDate functions:

* all dates returned are local dates with zero time.  since these
  are date utilities, no time information is needed or should have
  any effect on the calculations.  The `.date()` method casts
  dates in this manner
* the methods are designed to be as functional as possible.  Any
  given dates will not be modified; new date objs are returned.
* the methods are designed to build on each other as much as
  possible to reuse the logic.
* there are many more utility functions that *could* be added
  (such as a "next Mon" function, etc).  I chose not to add any
  functions that I don't have a need for in the datepicker or
  my app.  As needs arise in my apps, I'll add more methods.

![gif](https://cloud.githubusercontent.com/assets/82110/21582526/c4383f8a-d021-11e6-896a-bd642bdb6032.gif)

@jcredding ready for review.