### PR TITLE
datepicker: prefer showing as many past dates per month as possible

### DIFF
--- a/assets/js/romo/datepicker.js
+++ b/assets/js/romo/datepicker.js
@@ -334,16 +334,22 @@ RomoDatepicker.prototype._buildCalendarTitle = function(date) {
 }
 
 RomoDatepicker.prototype._buildCalendarBody = function(date) {
-  var fom    = RomoDate.firstDateOfMonth(date); // first-of-month
-  var fomday = fom.getDay();
-  if (fomday == 0) { // don't start calendar starting on the first-of-the-month.
-    fomday = 7;      // show it starting on the last week of the prev month.
-  }
-  var iDate = RomoDate.vector(fom, -fomday);
-  var iWeek = 0;
-
   var html = [];
 
+  // prefer showing as many past dates in each month as possible
+  // calc the most post days we can show and still fit the date's
+  // month in 6 weeks of displayed days:
+  // 7 days * 6 weeks = 42 displayed days
+  // 42 displayed days - {days in month} = {max past days}
+  var fom  = RomoDate.firstDateOfMonth(date); // first-of-month
+  var dim  = RomoDate.daysInMonth(date);      // days-in-month
+  var past = fom.getDay();                    // start on this week's Sunday
+  if ((past+7) <= (42-dim)) {                 // if there is enough room,
+    past = past+7;                            // start on prev week's Sunday
+  }
+  var iDate = RomoDate.vector(fom, -past);
+
+  var iWeek = 0;
   while (iWeek < 6) { // render 6 weeks in the calendar
     var cls = [];
 


### PR DESCRIPTION
This small change will really only make a difference when launching
the calendar the first time.  If the user starts manually browsing
to the next/prev months this is kinda moot.  The idea is that it
is more common to choose (recent) past dates over (recent) future
dates.  This isn't true for all apps (booking future reservations)
but is common for most (searching for recent transactions activity,
running last week's report, etc).  Plus on things that involve
choosing future dates, it is more likely you'd have to manually
advance months.

This is all to say that I'm asserting that last few days of the
previous month will more likely chosen over the first few days of
the next month.  The switches the calendar start date to always
prefer showing as many days of the previous month as possible.
On most month, at least one day in the next month will also be
shown but there is a case where the last day of the current month
is a Saturday so no next month days will be shown.

Overall, I think this is a pretty minor change that might have a
slight UX improvement.  Also it bugged me that the previous
implementation would have cases where over a week of next month's
dates were shown.  This seemed silly to me and I always seemed to
look over them bc I would just say "ahh, I'm at the end of the
month - advance to next month".

This scenario is the same as the prev implementation:
![imageonneb](https://cloud.githubusercontent.com/assets/82110/21593955/a7a14198-d0e2-11e6-9909-844c996619fb.jpg)

Here's a scenario where prev would show over of week of next month's dates; now shows over a week of prev month's dates:
![imageh8ugl](https://cloud.githubusercontent.com/assets/82110/21593962/c88d0ad6-d0e2-11e6-9ae6-8d4d4d680af2.jpg)

Here's a scenario where no dates from next month are shown:
![imagevc47w](https://cloud.githubusercontent.com/assets/82110/21593972/e3eea622-d0e2-11e6-851b-d5e9065f141c.jpg)

Here's a scenario where more from next month are shown than of prev month (this is the only case where that can happen):
![imageweexs](https://cloud.githubusercontent.com/assets/82110/21593987/0c91942c-d0e3-11e6-8368-c5feac0ffa65.jpg)

@jcredding ready for review.  Does this all makes sense?  It is pretty subtle the change, but this way bugs me way less after staring at this datepicker for a while now.  You cool with all this and my explanation?  Thanks man.