### PR TITLE
css: update border radius circle style classes

### DIFF
--- a/assets/css/romo/base.scss
+++ b/assets/css/romo/base.scss
@@ -101,7 +101,7 @@ a.romo-text {
 /* images */
 
 .romo-img-rounded { @include border-radius(6px); }
-.romo-img-circle  { @include border-radius(500px); }
+.romo-img-circle  { @include border-radius(50%); }
 .romo-img-card {
   padding: 3px;
   background-color: $baseBgColor;
@@ -435,8 +435,10 @@ h3 { @include text1; }
 .romo-border2-bottom-left-radius-hover:hover   { @include border2-bottom-left-radius(!important); }
 .romo-rm-border-bottom-left-radius-hover:hover { @include rm-border-bottom-left-radius(!important); }
 
-.romo-border-radius-circle { @include border-radius(500px); }
-.romo-border-radius-circle-hover:hover { @include border-radius(500px); }
+.romo-border-radius-circle             { @include border-radius(50%); }
+.romo-border-radius-circle-hover:hover { @include border-radius(50%); }
+.romo-border-radius-pill               { @include border-radius(500px); }
+.romo-border-radius-pill-hover:hover   { @include border-radius(500px); }
 
 /* spacing */
 

--- a/gh-pages/view_handlers/css/helpers.md
+++ b/gh-pages/view_handlers/css/helpers.md
@@ -169,6 +169,8 @@ Add border radius.
   <div class="romo-border2 romo-border2-bottom-right-radius-hover">.romo-border2-bottom-right-radius-hover</div>
   <div class="romo-border2 romo-border-radius-circle romo-push0-bottom">.romo-border-radius-circle</div>
   <div class="romo-border2 romo-border-radius-circle-hover romo-push0-bottom">.romo-border-radius-circle-hover</div>
+  <div class="romo-border2 romo-border-radius-pill romo-push0-bottom">.romo-border-radius-pill</div>
+  <div class="romo-border2 romo-border-radius-pill-hover romo-push0-bottom">.romo-border-radius-pill-hover</div>
 
 </div>
 


### PR DESCRIPTION
This updates the circle border radius style classes to use the 
`50%` value.  This is closer to the spirit of these style classes.
If your elem is rectangular, the border will be an oval.  If it is
square, the border will be a true circle.

This previous behavior of the circle style classes produced more
of a "pill" shaped border (if rectangular, if square close to a
circle).  To preserve the old behavior and to name it more 
accurately, I've added -pill style classes.

![imagesjsnr](https://cloud.githubusercontent.com/assets/82110/21867038/1fb740c0-d812-11e6-9524-dc8256fc6bb4.jpg)

![imageuhvq3](https://cloud.githubusercontent.com/assets/82110/21866715/ed3921be-d810-11e6-9997-dc69e2b79dbc.jpg)

@jcredding ready for review.