### PR TITLE
indicator text input: update to allow pos on left or right

### DIFF
--- a/assets/css/romo/indicator_text_input.scss
+++ b/assets/css/romo/indicator_text_input.scss
@@ -9,7 +9,6 @@
   display: inline-block;
   position: absolute;
   top: 0px;
-  right: 6px;
   vertical-align: middle;
   cursor: pointer;
 }

--- a/assets/js/romo/datepicker.js
+++ b/assets/js/romo/datepicker.js
@@ -32,6 +32,7 @@ RomoDatepicker.prototype.doInit = function() {
 
 RomoDatepicker.prototype.doBindElem = function() {
   this.elem.attr('autocomplete', 'off');
+  this.elem.attr('data-romo-indicator-text-input-indicator-position', "right");
 
   if (this.elem.data('romo-datepicker-indicator') !== undefined) {
     this.elem.attr('data-romo-indicator-text-input-indicator', this.elem.data('romo-datepicker-indicator'));

--- a/assets/js/romo/indicator_text_input.js
+++ b/assets/js/romo/indicator_text_input.js
@@ -6,8 +6,10 @@ $.fn.romoIndicatorTextInput = function() {
 
 var RomoIndicatorTextInput = function(element) {
   this.elem = $(element);
-  this.defaultIndicatorClass   = undefined;
-  this.defaultIndicatorWidthPx = 0;
+
+  this.defaultIndicatorClass     = undefined;
+  this.defaultIndicatorPaddingPx = 5;
+  this.defaultIndicatorPosition  = 'right';
 
   this.doInit();
   this.doBindElem();
@@ -75,12 +77,18 @@ RomoIndicatorTextInput.prototype.doPlaceIndicatorElem = function() {
       this._hide(this.indicatorElem);
     }
 
-    var indicatorWidthPx = this.elem.data('romo-indicator-text-input-indicator-width-px') || this.defaultIndicatorWidthPx;
-    // left-side spacing
+    var indicatorPaddingPx = this._getIndicatorPaddingPx();
+    var indicatorWidthPx   = this._getIndicatorWidthPx();
+    var indicatorPosition  = this._getIndicatorPosition();
+
+    // add a pixel to account for the default input border
+    this.indicatorElem.css(indicatorPosition, indicatorPaddingPx+1);
+
+    // left-side padding
     // + indicator width
-    // + right-side spacing
-    var indicatorPaddingPx = 4 + indicatorWidthPx + 4;
-    this.elem.css({'padding-right': indicatorPaddingPx + 'px'});
+    // + right-side padding
+    var inputPaddingPx = indicatorPaddingPx + indicatorWidthPx + indicatorPaddingPx;
+    this.elem.css('padding-'+indicatorPosition, inputPaddingPx+'px');
   }
 }
 
@@ -126,6 +134,27 @@ RomoIndicatorTextInput.prototype._show = function(elem) {
 
 RomoIndicatorTextInput.prototype._hide = function(elem) {
   elem.css('display', 'none');
+}
+
+RomoIndicatorTextInput.prototype._getIndicatorPaddingPx = function() {
+  return (
+    this.elem.data('romo-indicator-text-input-indicator-padding-px') ||
+    this.defaultIndicatorPaddingPx
+  );
+}
+
+RomoIndicatorTextInput.prototype._getIndicatorWidthPx = function() {
+  return (
+    this.elem.data('romo-indicator-text-input-indicator-width-px') ||
+    parseInt(Romo.getComputedStyle(this.indicatorElem[0], "width"), 10)
+  );
+}
+
+RomoIndicatorTextInput.prototype._getIndicatorPosition = function() {
+  return (
+    this.elem.data('romo-indicator-text-input-indicator-position') ||
+    this.defaultIndicatorPosition
+  );
 }
 
 Romo.onInitUI(function(e) {

--- a/assets/js/romo/select_dropdown.js
+++ b/assets/js/romo/select_dropdown.js
@@ -385,6 +385,7 @@ RomoSelectDropdown.prototype._buildOptionFilter = function() {
     filter.attr('placeholder', this.elem.data('romo-select-dropdown-filter-placeholder'));
   }
   filter.attr('data-romo-indicator-text-input-elem-display', "block");
+  filter.attr('data-romo-indicator-text-input-indicator-position', "right");
   if (this.elem.data('romo-select-dropdown-filter-indicator') !== undefined) {
     filter.attr('data-romo-indicator-text-input-indicator', this.elem.data('romo-select-dropdown-filter-indicator'));
   }


### PR DESCRIPTION
This updates the indicator text input to allow positioning the
indicator on either the left or the right.  This is prep for
adding a currency text input which will need to place the
currency indicator on the left.

This also cleans up the indicator padding calculations to
detect the indicator elem width so it doesn't have to be manually
set unless you want to use a custom value.  I also made it so you
can customize the padding value to use to account for non-std
borders and such.

I chose to keep the indicator elem positioned on the right by
default but updated the select dropdown and datepicker to manually
set their indicator pos value in case the default changes.

@jcredding ready for review.