### PR TITLE
add currency text input component; add RomoCurrency format functions

### DIFF
--- a/assets/js/romo/currency.js
+++ b/assets/js/romo/currency.js
@@ -1,0 +1,45 @@
+var RomoCurrency = {
+
+  format: function(numberString, opts) {
+    var unFormattedString = RomoCurrency.unFormat(numberString);
+    if (unFormattedString === '') {
+      return '';
+    }
+
+    opts = opts || {};
+    var symbol           = opts.symbol           || '';
+    var thousandsDelim   = opts.thousandsDelm    || ',';
+    var decimalDelim     = opts.decimalDelim     || '.';
+    var numDecimalPlaces = opts.numDecimalPlaces || 2;
+
+    var number   = Number(unFormattedString);
+    var negative = number < 0 ? '-' : '';
+    var u_d      = Math.abs(number).toFixed(numDecimalPlaces).split('.');
+    var units    = (u_d[0] || '').replace(/(\d)(?=(\d{3})+(?!\d))/g, "$1"+thousandsDelim);
+    var decimals = u_d[1] || '';
+
+    return symbol+negative+units+decimalDelim+decimals;
+  },
+
+  unFormat: function(currencyString, opts) {
+    if (currencyString === undefined || currencyString === '') {
+      return '';
+    }
+
+    var numString = currencyString.replace(/[^0-9\.\-]+/g,"");
+    if (numString === '') {
+      return '';
+    }
+
+    var num = Number(numString);
+    if (isNaN(num)) {
+      return '';
+    } else {
+      opts = opts || {};
+      var numDecimalPlaces = opts.numDecimalPlaces || 2;
+
+      return num.toFixed(numDecimalPlaces);
+    }
+  }
+
+}

--- a/assets/js/romo/currency_text_input.js
+++ b/assets/js/romo/currency_text_input.js
@@ -1,0 +1,168 @@
+$.fn.romoCurrencyTextInput = function() {
+  return $.map(this, function(element) {
+    return new RomoCurrencyTextInput(element);
+  });
+}
+
+var RomoCurrencyTextInput = function(element) {
+  this.elem            = $(element);
+  this.hiddenInputElem = undefined;
+
+  this.defaultIndicatorPosition       = 'left';
+  this.defaultInputNameSuffix         = "romo-currency-display"
+  this.defaultFormatThousandsDelim    = ',';
+  this.defaultFormatDecimalDelim      = '.';
+  this.defaultFormatNumDecimalPlaces  = 2;
+
+  this.doInit();
+  this.doBindElem();
+
+  this.elem.trigger('romoCurrencyTextInput:ready', [this]);
+}
+
+RomoCurrencyTextInput.prototype.doInit = function() {
+  // override as needed
+}
+
+RomoCurrencyTextInput.prototype.doBindElem = function() {
+  this.doBindIndicatorTextInput();
+
+  this.hiddenInputElem = this._getHiddenInputElem();
+  this.elem.before(this.hiddenInputElem);
+  this.elem.attr('name', this._getNewInputName());
+
+  this.elem.on('change', $.proxy(function(e) {
+    this.doUpdateInputValue();
+  }, this));
+  this.elem.on('romoCurrencyTextInput:triggerUpdateInputValue', $.proxy(function(e) {
+    this.doUpdateInputValue();
+  }, this));
+
+  this.doUpdateInputValue();
+}
+
+RomoCurrencyTextInput.prototype.doUpdateInputValue = function() {
+  var unFormattedValue = this._unFormatCurrencyValue(this.elem.val());
+  this.hiddenInputElem.val(unFormattedValue);
+  if (this.elem.data('romo-currency-text-input-format-for-currency') !== false) {
+    this.elem.val(this._formatCurrencyValue(unFormattedValue));
+  } else {
+    this.elem.val(unFormattedValue);
+  }
+}
+
+RomoCurrencyTextInput.prototype.doSetValue = function(value) {
+  this.elem.val(value);
+  this.doUpdateInputValue();
+}
+
+RomoCurrencyTextInput.prototype.doBindIndicatorTextInput = function() {
+  this.elem.attr(
+    'data-romo-indicator-text-input-indicator-position',
+    this.elem.data('romo-currency-text-input-indicator-position') || this.defaultIndicatorPosition
+  );
+
+  if (this.elem.data('romo-currency-text-input-indicator') !== undefined) {
+    this.elem.attr(
+      'data-romo-indicator-text-input-indicator',
+      this.elem.data('romo-currency-text-input-indicator')
+    );
+  }
+  if (this.elem.data('romo-currency-text-input-indicator-width-px') !== undefined) {
+    this.elem.attr(
+      'data-romo-indicator-text-input-indicator-width-px',
+      this.elem.data('romo-currency-text-input-indicator-width-px')
+    );
+  }
+  if (this.elem.data('romo-currency-text-input-indicator-padding-px') !== undefined) {
+    this.elem.attr(
+      'data-romo-indicator-text-input-indicator-padding-px',
+      this.elem.data('romo-currency-text-input-indicator-padding-px')
+    );
+  }
+  if (this.elem.data('romo-currency-text-input-elem-display') !== undefined) {
+    this.elem.attr(
+      'data-romo-indicator-text-input-elem-display',
+      this.elem.data('romo-currency-text-input-elem-display')
+    );
+  }
+  if (this.elem.data('romo-currency-text-input-btn-group') !== undefined) {
+    this.elem.attr(
+      'data-romo-indicator-text-input-btn-group',
+      this.elem.data('romo-currency-text-input-btn-group')
+    );
+  }
+
+  this.elem.on('indicatorTextInput:indicatorClick', $.proxy(function(e) {
+    this.elem.trigger('romoCurrencyTextInput:indicatorClick', []);
+  }, this));
+
+  this.elem.on('romoCurrencyTextInput:triggerPlaceIndicator', $.proxy(function(e) {
+    this.elem.trigger('indicatorTextInput:triggerPlaceIndicator', []);
+  }, this));
+  this.elem.on('romoCurrencyTextInput:triggerEnable', $.proxy(function(e) {
+    this.elem.trigger('indicatorTextInput:triggerEnable', []);
+  }, this));
+  this.elem.on('romoCurrencyTextInput:triggerDisable', $.proxy(function(e) {
+    this.elem.trigger('indicatorTextInput:triggerDisable', []);
+  }, this));
+  this.elem.on('romoCurrencyTextInput:triggerShow', $.proxy(function(e) {
+    this.elem.trigger('indicatorTextInput:triggerShow', []);
+  }, this));
+  this.elem.on('romoCurrencyTextInput:triggerHide', $.proxy(function(e) {
+    this.elem.trigger('indicatorTextInput:triggerHide', []);
+  }, this));
+
+  this.elem.romoIndicatorTextInput();
+}
+
+// private
+
+RomoCurrencyTextInput.prototype._formatCurrencyValue = function(sanitizedValue) {
+  return RomoCurrency.format(sanitizedValue, {
+    'thousandsDelim':   this._getFormatThousandsDelim(),
+    'decimalDelim':     this._getFormatDecimalDelim(),
+    'numDecimalPlaces': this._getFormatNumDecimalPlaces()
+  });
+}
+
+RomoCurrencyTextInput.prototype._unFormatCurrencyValue = function(inputValue) {
+  return RomoCurrency.unFormat(inputValue, {
+    'numDecimalPlaces': this._getFormatNumDecimalPlaces()
+  });
+}
+
+RomoCurrencyTextInput.prototype._getFormatThousandsDelim = function() {
+  return (
+    this.elem.data('romo-currency-text-input-format-thousands-delim') ||
+    this.defaultFormatThousandsDelim
+  );
+}
+
+RomoCurrencyTextInput.prototype._getFormatDecimalDelim = function() {
+  return (
+    this.elem.data('romo-currency-text-input-format-decimal-delim') ||
+    this.defaultFormatDecimalDelim
+  );
+}
+
+RomoCurrencyTextInput.prototype._getFormatNumDecimalPlaces = function() {
+  var places = this.elem.data('romo-currency-text-input-format-num-decimal-places');
+  return !isNaN(places = Math.abs(places)) ? places : this.defaultFormatNumDecimalPlaces;
+}
+
+RomoCurrencyTextInput.prototype._getHiddenInputElem = function() {
+  return $('<input type="hidden" name="'+this.elem.attr('name')+'" value="'+this.elem.val()+'">');;
+}
+
+RomoCurrencyTextInput.prototype._getNewInputName = function() {
+  return (
+    this.elem.attr('name')+
+    '-'+
+    (this.elem.data('romo-currency-text-input-name-suffix') || this.defaultInputNameSuffix)
+  );
+}
+
+Romo.onInitUI(function(e) {
+  Romo.initUIElems(e, '[data-romo-currency-text-input-auto="true"]').romoCurrencyTextInput();
+});

--- a/lib/romo/dassets.rb
+++ b/lib/romo/dassets.rb
@@ -45,6 +45,7 @@ module Romo::Dassets
       c.combination "js/romo.js", [
         'js/romo/base.js',
         'js/romo/date.js',
+        'js/romo/currency.js',
         'js/romo/word_boundary_filter.js',
         'js/romo/ajax.js',
         'js/romo/onkey.js',
@@ -52,6 +53,7 @@ module Romo::Dassets
         'js/romo/dropdown.js',
         'js/romo/dropdown_form.js',
         'js/romo/indicator_text_input.js',
+        'js/romo/currency_text_input.js',
         'js/romo/select_dropdown.js',
         'js/romo/select.js',
         'js/romo/datepicker.js',

--- a/test/unit/dassets_tests.rb
+++ b/test/unit/dassets_tests.rb
@@ -47,6 +47,7 @@ module Romo::Dassets
       exp_js_sources = [
         'js/romo/base.js',
         'js/romo/date.js',
+        'js/romo/currency.js',
         'js/romo/word_boundary_filter.js',
         'js/romo/ajax.js',
         'js/romo/onkey.js',
@@ -54,6 +55,7 @@ module Romo::Dassets
         'js/romo/dropdown.js',
         'js/romo/dropdown_form.js',
         'js/romo/indicator_text_input.js',
+        'js/romo/currency_text_input.js',
         'js/romo/select_dropdown.js',
         'js/romo/select.js',
         'js/romo/datepicker.js',


### PR DESCRIPTION
This adds a new text input component for entering currency values.
This input is an indicator text input that can optionally format
the input on change.  It proxies all indicator text input data
attrs and events as well.

This also adds functions to a new `RomoCurrency` namespace for
formatting and un-formatting currency strings.  These are used
internally by the currency text input but they seemed handy
so I decided to make stand-alone functions out of them.

Here's an example of this in action:
![gif](https://cloud.githubusercontent.com/assets/82110/22036139/1b269b82-dcb8-11e6-87fd-c0286ae0b189.gif)


@jcredding ready for review.