### PR TITLE
allow disabling the parent removed observer logic; use in Sortable

### DIFF
--- a/assets/js/romo/base.js
+++ b/assets/js/romo/base.js
@@ -275,7 +275,7 @@ var RomoParentChildElems = function() {
   this.elemId   = 0;
   this.elems    = {};
 
-  var childRemovedObserver = new MutationObserver($.proxy(function(mutationRecords) {
+  var parentRemovedObserver = new MutationObserver($.proxy(function(mutationRecords) {
     mutationRecords.forEach($.proxy(function(mutationRecord) {
       if (mutationRecord.type === 'childList' && mutationRecord.removedNodes.length > 0) {
         $.each($(mutationRecord.removedNodes), $.proxy(function(idx, node) {
@@ -285,7 +285,7 @@ var RomoParentChildElems = function() {
     }, this));
   }, this));
 
-  childRemovedObserver.observe($('body')[0], {
+  parentRemovedObserver.observe($('body')[0], {
     childList: true,
     subtree:   true
   });
@@ -296,12 +296,14 @@ RomoParentChildElems.prototype.add = function(parentElem, childElems) {
 }
 
 RomoParentChildElems.prototype.remove = function(nodeElem) {
-  if(nodeElem.data(this.attrName) !== undefined) {
-    this._removeChildElems(nodeElem);  // node is a parent elem itself
+  if (nodeElem.data('romo-parent-removed-observer-disabled') !== true) {
+    if (nodeElem.data(this.attrName) !== undefined) {
+      this._removeChildElems(nodeElem);  // node is a parent elem itself
+    }
+    $.each(nodeElem.find('[data-'+this.attrName+']'), $.proxy(function(idx, parent) {
+      this._removeChildElems($(parent));
+    }, this));
   }
-  $.each(nodeElem.find('[data-'+this.attrName+']'), $.proxy(function(idx, parent) {
-    this._removeChildElems($(parent));
-  }, this));
 }
 
 // private


### PR DESCRIPTION
This fixes a bug where sortable UI was losing all popups (ie
modals, dropdowns, tooltips) when they were sorted.  The problem
was due to the parent removed observer logic that handles cleaning
up popup child elems when their parent elems are removed from the
DOM.

Sortable was implemented before this logic was in place so the
problem didn't occur when Sortable was first designed and
implemented.  When I added the observer logic, I never formally
tested it with Sortable so I missed this error.

The problem occurs b/c when dragging an elem, that elem is removed
from the DOM on drag-start and re-added to the DOM on drag-drop.
This triggers the parent removed observer on drag-start and any
child elems are removed.  So when the elem is re-added it has no
child elems and stuff breaks.  Really, the observer logic should
never be triggered b/c, while technically speaking the elem is
removed from the DOM, it isn't practically removed b/c it will
be added right back in.

This adds logic Sortable now uses to first disable the observer
before dragging the elem.  This prevents the child elems from
being removed while dragging.  Then once the elem is added back
in on drag-drop, the observer is re-enabled.

Note: I had to re-enable the observer in a `setTimeout` to "kick"
the reactor loop and make sure the observer handler had a chance
to run *before* the observer was re-enable.  This ensures all
drag-related observer logic has run before it is re-enabled on
the dragged elem.

@jcredding ready for review.