### PR TITLE
select: position carets like indicator text inputs position indicators

### DIFF
--- a/assets/css/romo/select.scss
+++ b/assets/css/romo/select.scss
@@ -39,9 +39,10 @@
   width: 100%;
 }
 .romo-select-caret {
+  display: inline-block;
   position: absolute;
-  right: 4px + 1px; /* 4 px for desired spacing + 1 px select styling optical illusion */
   vertical-align: middle;
+  cursor: pointer;
 }
 
 .romo-select-dropdown-option-filter-wrapper {

--- a/assets/js/romo/select.js
+++ b/assets/js/romo/select.js
@@ -7,8 +7,9 @@ $.fn.romoSelect = function() {
 var RomoSelect = function(element) {
   this.elem = $(element);
 
-  this.defaultCaretClass   = undefined;
-  this.defaultCaretWidthPx = 0;
+  this.defaultCaretClass     = undefined;
+  this.defaultCaretPaddingPx = 5;
+  this.defaultCaretPosition  = 'right'
 
   this.doInit();
   this.doBindSelectDropdown();
@@ -154,23 +155,50 @@ RomoSelect.prototype._buildSelectDropdownElem = function() {
     Romo.parentChildElems.add(this.elem, [this.elemWrapper]);
   }, this), 1);
 
+  this.caretElem = $();
   var caretClass = this.elem.data('romo-select-caret') || this.defaultCaretClass;
   if (caretClass !== undefined && caretClass !== 'none') {
-    var caret = $('<i class="romo-select-caret '+caretClass+'"></i>');
-    caret.css({'line-height': romoSelectDropdownElem.css('line-height')});
-    caret.on('click', $.proxy(this.onCaretClick, this));
+    this.caretElem = $('<i class="romo-select-caret '+caretClass+'"></i>');
+    this.caretElem.css('line-height', parseInt(Romo.getComputedStyle(romoSelectDropdownElem[0], "line-height"), 10)+'px');
+    this.caretElem.on('click', $.proxy(this.onCaretClick, this));
+    romoSelectDropdownElem.append(this.caretElem);
 
-    var caretWidthPx = this.elem.data('romo-select-caret-width-px') || this.defaultCaretWidthPx;
-    // left-side spacing
+    var caretPaddingPx = this._getCaretPaddingPx();
+    var caretWidthPx   = this._getCaretWidthPx();
+    var caretPosition  = this._getCaretPosition();
+
+    // add a pixel to account for the default input border
+    this.caretElem.css(caretPosition, caretPaddingPx+1);
+
+    // left-side padding
     // + caret width
-    // - 1 px select styling optical illusion
-    // + right-side spacing
-    var caretPaddingPx = 4 + caretWidthPx - 1 + 4;
-    romoSelectDropdownElem.css({'padding-right': caretPaddingPx + 'px'});
-    romoSelectDropdownElem.append(caret);
+    // + right-side padding
+    var dropdownPaddingPx = caretPaddingPx + caretWidthPx + caretPaddingPx;
+    romoSelectDropdownElem.css('padding-'+caretPosition, dropdownPaddingPx+'px');
   }
 
   return romoSelectDropdownElem;
+}
+
+RomoSelect.prototype._getCaretPaddingPx = function() {
+  return (
+    this.elem.data('romo-select-caret-padding-px') ||
+    this.defaultCaretPaddingPx
+  );
+}
+
+RomoSelect.prototype._getCaretWidthPx = function() {
+  return (
+    this.elem.data('romo-select-caret-width-px') ||
+    parseInt(Romo.getComputedStyle(this.caretElem[0], "width"), 10)
+  );
+}
+
+RomoSelect.prototype._getCaretPosition = function() {
+  return (
+    this.elem.data('romo-select-caret-position') ||
+    this.defaultCaretPosition
+  );
 }
 
 Romo.onInitUI(function(e) {


### PR DESCRIPTION
This updates selects to position their carets like indicator text
inputs position their indicators.  This includes:

* detect caret elem width - no need to always specify a custom
  with if using carets
* api for setting custom caret padding px - defaults to 5px like
  indicator text inputs do
* api for setting custom caret position - this allows you to set
  the caret on the left if you want but default to placing the
  caret on the right
* we can remove the custom css right pos hard-coded value - this
  was super fragile anyway - we don't need it now that we allow
  specifying padding px and left/right position

This is just to keep placing indicators like this consistent and
add some nice customizations to selects.

Here is the regular select caret handling:
![norm-select](https://cloud.githubusercontent.com/assets/82110/22269003/3e266076-e24f-11e6-9a36-42a5718c61c3.jpg)

Here is a customized caret, placing it on the left width 10px of padding on each side:
![odd-select](https://cloud.githubusercontent.com/assets/82110/22269021/4eb37140-e24f-11e6-9b6b-37c1b52beb9e.jpg)

@jcredding ready for review.