### PR TITLE
Make non-word characters word boundaries for selects filter

### DIFF
--- a/assets/js/romo/select_dropdown.js
+++ b/assets/js/romo/select_dropdown.js
@@ -171,7 +171,10 @@ RomoSelectDropdown.prototype.doFilterOptionElems = function() {
     this.optionFilter.val(),
     this.romoDropdown.bodyElem.find('LI[data-romo-select-item="opt"]'),
     function(elem) {
-      return elem[0].textContent;
+      // The romo word boundary filter by default considers a space, "-" and "_" as word boundaries.
+      // We want to also consider other non-word characters (such as ":", "/", ".", "?", "=", "&")
+      // as word boundaries as well.
+      return elem[0].textContent.replace(/\W/g, ' ');
     }
   );
 


### PR DESCRIPTION
This updates selects filter to use non-word characters as word
boundaries. This makes it simpler to filter options that have
non-word characters. For example, if an option had "[test]" typing
"test" into the filter previously didn't show the "[test]" option;
with this change it will.

@kellyredding - Ready for review.