### PR TITLE
update to require a parent `.romo` elem for CSS styles to apply

### DIFF
--- a/assets/css/romo/base.scss
+++ b/assets/css/romo/base.scss
@@ -1,571 +1,580 @@
 @import 'css/romo/vars';
 @import 'css/romo/mixins';
 
-/* Globals */
-/* ------- */
+html { height: 100%; }
 
-*, *:before, *:after { @include border-box; }
+body.romo {
 
-html, body { height: 100%; }
+  height: 100%;
 
-body {
   @include rm-push;
   @include bg-base;
+
+}
+
+.romo {
+
+  /* Globals */
+
+  @include border-box;
+
+  *, *:before, *:after { @include border-box; }
+
   color: $baseColor;
   font-weight: normal;
-}
 
-*,
-legend { @include border-base; }
+  *,
+  legend { @include border-base; }
 
-table {
-  max-width: 100%;
-  background-color: transparent;
-  border-collapse: collapse;
-  border-spacing: 0;
-}
+  table {
+    max-width: 100%;
+    background-color: transparent;
+    border-collapse: collapse;
+    border-spacing: 0;
+  }
 
-th,
-td {
-  @include rm-pad;
-  @include rm-border;
-  @include align-left;
-  @include align-middle;
-}
+  th,
+  td {
+    @include rm-pad;
+    @include rm-border;
+    @include align-left;
+    @include align-middle;
+  }
 
-ul, ol { @include list-styled; }
+  ul, ol { @include list-styled; }
 
-img {
-  width: auto\9;
-  height: auto;
-  max-width: 100%;
-  vertical-align: middle;
-  border: 0;
-  -ms-interpolation-mode: bicubic;
-}
+  img {
+    width: auto\9;
+    height: auto;
+    max-width: 100%;
+    vertical-align: middle;
+    border: 0;
+    -ms-interpolation-mode: bicubic;
+  }
 
-/* Typography */
-/* ---------- */
+  /* Typography */
 
-body {
   font-family: $baseFontFamily;
   font-size:   $baseFontSize;
   line-height: $baseLineHeight;
-}
 
-p {
-  margin: 0 0 ($baseLineHeight / 2);
-}
-
-small  { font-size: 85%; } /* Ex: 14px base font * 85% = about 12px */
-strong { font-weight: bold; }
-em     { font-style: italic; }
-
-a,
-a:link,
-a:visited,
-a:hover,
-a:focus,
-a:active {
-  outline: 0;
-}
-
-a,
-a:link,
-a:visited {
-  color: $linkColor;
-  text-decoration: none;
-}
-a:hover,
-a:focus,
-a:active {
-  color: $linkColorHover;
-  text-decoration: underline;
-}
-
-a.romo-text {
-  color: $baseColor;
-  text-decoration: none;
-}
-.romo-link             { color: $linkColor !important; }
-.romo-link:hover,
-.romo-link-hover:hover { color: $linkColorHover !important;}
-
-.romo-cursor-default { cursor: default; }
-.romo-pointer        { cursor: pointer; }
-.romo-grab           { @include cursor-grab; }
-.romo-grabbing       { @include cursor-grabbing; }
-
-.romo-user-select-none{ @include user-select(none); }
-
-/* images */
-
-.romo-img-rounded { @include border-radius(6px); }
-.romo-img-circle  { @include border-radius(50%); }
-.romo-img-card {
-  padding: 3px;
-  background-color: $baseBgColor;
-  border: 1px solid;
-  border: 1px solid rgba(0, 0, 0, 0.2);
-  @include box-shadow(0 1px 3px rgba(0, 0, 0, 0.1));
-}
-
-.romo-img0 { height: $imgHeight0 !important; }
-.romo-img1 { height: $imgHeight1 !important; }
-.romo-img2 { height: $imgHeight2 !important; }
-.romo-img3 { height: $imgHeight3 !important; }
-
-.romo-img-inline0 { line-height: $imgHeight0 !important; @include align-middle; }
-.romo-img-inline1 { line-height: $imgHeight1 !important; @include align-middle; }
-.romo-img-inline2 { line-height: $imgHeight2 !important; @include align-middle; }
-.romo-img-inline3 { line-height: $imgHeight3 !important; @include align-middle; }
-
-/* headings */
-
-h1, h2, h3 {
-  margin: ($baseLineHeight / 2) 0;
-  font-weight: bold;
-  text-rendering: optimizelegibility;
-  small {
-    font-weight: normal;
-    line-height: 1;
+  p {
+    margin: 0 0 ($baseLineHeight / 2);
   }
+
+  small  { font-size: 85%; } /* Ex: 14px base font * 85% = about 12px */
+  strong { font-weight: bold; }
+  em     { font-style: italic; }
+
+  a,
+  a:link,
+  a:visited,
+  a:hover,
+  a:focus,
+  a:active {
+    outline: 0;
+  }
+
+  a,
+  a:link,
+  a:visited {
+    color: $linkColor;
+    text-decoration: none;
+  }
+  a:hover,
+  a:focus,
+  a:active {
+    color: $linkColorHover;
+    text-decoration: underline;
+  }
+
+  /* Typography */
+
+  a.romo-text {
+    color: $baseColor;
+    text-decoration: none;
+  }
+  .romo-link             { color: $linkColor !important; }
+  .romo-link:hover,
+  .romo-link-hover:hover { color: $linkColorHover !important;}
+
+  .romo-cursor-default { cursor: default; }
+  .romo-pointer        { cursor: pointer; }
+  .romo-grab           { @include cursor-grab; }
+  .romo-grabbing       { @include cursor-grabbing; }
+
+  .romo-user-select-none{ @include user-select(none); }
+
+  /* images */
+
+  .romo-img-rounded { @include border-radius(6px); }
+  .romo-img-circle  { @include border-radius(50%); }
+  .romo-img-card {
+    padding: 3px;
+    background-color: $baseBgColor;
+    border: 1px solid;
+    border: 1px solid rgba(0, 0, 0, 0.2);
+    @include box-shadow(0 1px 3px rgba(0, 0, 0, 0.1));
+  }
+
+  .romo-img0 { height: $imgHeight0 !important; }
+  .romo-img1 { height: $imgHeight1 !important; }
+  .romo-img2 { height: $imgHeight2 !important; }
+  .romo-img3 { height: $imgHeight3 !important; }
+
+  .romo-img-inline0 { line-height: $imgHeight0 !important; @include align-middle; }
+  .romo-img-inline1 { line-height: $imgHeight1 !important; @include align-middle; }
+  .romo-img-inline2 { line-height: $imgHeight2 !important; @include align-middle; }
+  .romo-img-inline3 { line-height: $imgHeight3 !important; @include align-middle; }
+
+  /* headings */
+
+  h1, h2, h3 {
+    margin: ($baseLineHeight / 2) 0;
+    font-weight: bold;
+    text-rendering: optimizelegibility;
+    small {
+      font-weight: normal;
+      line-height: 1;
+    }
+  }
+
+  h1 { @include text3; }
+  h2 { @include text2; }
+  h3 { @include text1; }
+
+  /* text size */
+
+  .romo-text0,
+  .romo-text1,
+  .romo-text2,
+  .romo-text3 {
+    text-rendering: optimizelegibility;
+  }
+
+  .romo-text-small,
+  .romo-text0 { @include text0(!important); @include font-weight0; }
+  .romo-text1 { @include text1(!important); @include font-weight1; }
+  .romo-text-large,
+  .romo-text2 { @include text2(!important); @include font-weight2; }
+  .romo-text3 { @include text3(!important); @include font-weight3; }
+
+  .romo-text-small-hover:hover,
+  .romo-text0-hover:hover { @include text0(!important); @include font-weight0; }
+  .romo-text1-hover:hover { @include text1(!important); @include font-weight1; }
+  .romo-text-large-hover:hover,
+  .romo-text2-hover:hover { @include text2(!important); @include font-weight2; }
+  .romo-text3-hover:hover { @include text3(!important); @include font-weight3; }
+
+  .romo-text-inline-small,
+  .romo-text-inline0 { @include line-height0(!important); }
+  .romo-text-inline1 { @include line-height1(!important); }
+  .romo-text-inline-large,
+  .romo-text-inline2 { @include line-height2(!important); }
+  .romo-text-inline3 { @include line-height3(!important); }
+
+  /* text weight */
+
+  .romo-text-normal  { @include font-weight(normal,  !important); }
+  .romo-text-lighter { @include font-weight(lighter, !important); }
+  .romo-text-bold    { @include font-weight(bold,    !important); }
+  .romo-text-bolder  { @include font-weight(bolder,  !important); }
+  .romo-text-100     { @include font-weight(100,     !important); }
+  .romo-text-200     { @include font-weight(200,     !important); }
+  .romo-text-300     { @include font-weight(300,     !important); }
+  .romo-text-400     { @include font-weight(400,     !important); }
+  .romo-text-500     { @include font-weight(500,     !important); }
+  .romo-text-600     { @include font-weight(600,     !important); }
+  .romo-text-700     { @include font-weight(700,     !important); }
+  .romo-text-800     { @include font-weight(800,     !important); }
+  .romo-text-900     { @include font-weight(900,     !important); }
+
+  .romo-text-normal-hover:hover  { @include font-weight(normal,  !important); }
+  .romo-text-lighter-hover:hover { @include font-weight(lighter, !important); }
+  .romo-text-bold-hover:hover    { @include font-weight(bold,    !important); }
+  .romo-text-bolder-hover:hover  { @include font-weight(bolder,  !important); }
+  .romo-text-100-hover:hover     { @include font-weight(100,     !important); }
+  .romo-text-200-hover:hover     { @include font-weight(200,     !important); }
+  .romo-text-300-hover:hover     { @include font-weight(300,     !important); }
+  .romo-text-400-hover:hover     { @include font-weight(400,     !important); }
+  .romo-text-500-hover:hover     { @include font-weight(500,     !important); }
+  .romo-text-600-hover:hover     { @include font-weight(600,     !important); }
+  .romo-text-700-hover:hover     { @include font-weight(700,     !important); }
+  .romo-text-800-hover:hover     { @include font-weight(800,     !important); }
+  .romo-text-900-hover:hover     { @include font-weight(900,     !important); }
+
+  /* text decoration */
+
+  .romo-text-underline     { @include text-decoration-underline(!important); }
+  .romo-text-overline      { @include text-decoration-overline(!important); }
+  .romo-text-line-through,
+  .romo-text-strikethrough { @include text-decoration-line-through(!important); }
+  .romo-text-no-line       { @include text-decoration-none(!important); }
+
+  .romo-text-underline-hover:hover     { @include text-decoration-underline(!important); }
+  .romo-text-overline-hover:hover      { @include text-decoration-overline(!important); }
+  .romo-text-line-through-hover:hover,
+  .romo-text-strikethrough-hover:hover { @include text-decoration-line-through(!important); }
+  .romo-text-no-line-hover:hover       { @include text-decoration-none(!important); }
+
+  /* alignment */
+
+  .romo-align-left   { @include align-left(!important); }
+  .romo-align-center { @include align-center(!important); }
+  .romo-align-right  { @include align-right(!important); }
+
+  .romo-align-top    { @include align-top(!important); }
+  .romo-align-middle { @include align-middle(!important); }
+  .romo-align-bottom { @include align-bottom(!important); }
+
+  /* Scaffolding */
+  /* ----------- */
+
+  /* border helpers */
+
+  .romo-border-solid  { @include border-style(solid,  !important); }
+  .romo-border-dashed { @include border-style(dashed, !important); }
+  .romo-border-dotted { @include border-style(dotted, !important); }
+  .romo-border-double { @include border-style(double, !important); }
+  .romo-border-groove { @include border-style(groove, !important); }
+  .romo-border-inset  { @include border-style(inset,  !important); }
+  .romo-border-hidden { @include border-style(hidden, !important); }
+  .romo-border-none   { @include border-style(none,   !important); }
+
+  .romo-border-solid-hover:hover  { @include border-style(solid,  !important); }
+  .romo-border-dashed-hover:hover { @include border-style(dashed, !important); }
+  .romo-border-dotted-hover:hover { @include border-style(dotted, !important); }
+  .romo-border-double-hover:hover { @include border-style(double, !important); }
+  .romo-border-groove-hover:hover { @include border-style(groove, !important); }
+  .romo-border-inset-hover:hover  { @include border-style(inset,  !important); }
+  .romo-border-hidden-hover:hover { @include border-style(hidden, !important); }
+  .romo-border-none-hover:hover   { @include border-style(none,   !important); }
+
+  .romo-border-solid-top  { @include border-style-top(solid,  !important); }
+  .romo-border-dashed-top { @include border-style-top(dashed, !important); }
+  .romo-border-dotted-top { @include border-style-top(dotted, !important); }
+  .romo-border-double-top { @include border-style-top(double, !important); }
+  .romo-border-groove-top { @include border-style-top(groove, !important); }
+  .romo-border-inset-top  { @include border-style-top(inset,  !important); }
+  .romo-border-hidden-top { @include border-style-top(hidden, !important); }
+  .romo-border-none-top   { @include border-style-top(none,   !important); }
+
+  .romo-border-solid-top-hover:hover  { @include border-style-top(solid,  !important); }
+  .romo-border-dashed-top-hover:hover { @include border-style-top(dashed, !important); }
+  .romo-border-dotted-top-hover:hover { @include border-style-top(dotted, !important); }
+  .romo-border-double-top-hover:hover { @include border-style-top(double, !important); }
+  .romo-border-groove-top-hover:hover { @include border-style-top(groove, !important); }
+  .romo-border-inset-top-hover:hover  { @include border-style-top(inset,  !important); }
+  .romo-border-hidden-top-hover:hover { @include border-style-top(hidden, !important); }
+  .romo-border-none-top-hover:hover   { @include border-style-top(none,   !important); }
+
+  .romo-border-solid-right  { @include border-style-right(solid,  !important); }
+  .romo-border-dashed-right { @include border-style-right(dashed, !important); }
+  .romo-border-dotted-right { @include border-style-right(dotted, !important); }
+  .romo-border-double-right { @include border-style-right(double, !important); }
+  .romo-border-groove-right { @include border-style-right(groove, !important); }
+  .romo-border-inset-right  { @include border-style-right(inset,  !important); }
+  .romo-border-hidden-right { @include border-style-right(hidden, !important); }
+  .romo-border-none-right   { @include border-style-right(none,   !important); }
+
+  .romo-border-solid-right-hover:hover  { @include border-style-right(solid,  !important); }
+  .romo-border-dashed-right-hover:hover { @include border-style-right(dashed, !important); }
+  .romo-border-dotted-right-hover:hover { @include border-style-right(dotted, !important); }
+  .romo-border-double-right-hover:hover { @include border-style-right(double, !important); }
+  .romo-border-groove-right-hover:hover { @include border-style-right(groove, !important); }
+  .romo-border-inset-right-hover:hover  { @include border-style-right(inset,  !important); }
+  .romo-border-hidden-right-hover:hover { @include border-style-right(hidden, !important); }
+  .romo-border-none-right-hover:hover   { @include border-style-right(none,   !important); }
+
+  .romo-border-solid-bottom  { @include border-style-bottom(solid,  !important); }
+  .romo-border-dashed-bottom { @include border-style-bottom(dashed, !important); }
+  .romo-border-dotted-bottom { @include border-style-bottom(dotted, !important); }
+  .romo-border-double-bottom { @include border-style-bottom(double, !important); }
+  .romo-border-groove-bottom { @include border-style-bottom(groove, !important); }
+  .romo-border-inset-bottom  { @include border-style-bottom(inset,  !important); }
+  .romo-border-hidden-bottom { @include border-style-bottom(hidden, !important); }
+  .romo-border-none-bottom   { @include border-style-bottom(none,   !important); }
+
+  .romo-border-solid-bottom-hover:hover  { @include border-style-bottom(solid,  !important); }
+  .romo-border-dashed-bottom-hover:hover { @include border-style-bottom(dashed, !important); }
+  .romo-border-dotted-bottom-hover:hover { @include border-style-bottom(dotted, !important); }
+  .romo-border-double-bottom-hover:hover { @include border-style-bottom(double, !important); }
+  .romo-border-groove-bottom-hover:hover { @include border-style-bottom(groove, !important); }
+  .romo-border-inset-bottom-hover:hover  { @include border-style-bottom(inset,  !important); }
+  .romo-border-hidden-bottom-hover:hover { @include border-style-bottom(hidden, !important); }
+  .romo-border-none-bottom-hover:hover   { @include border-style-bottom(none,   !important); }
+
+  .romo-border-solid-left  { @include border-style-left(solid,  !important); }
+  .romo-border-dashed-left { @include border-style-left(dashed, !important); }
+  .romo-border-dotted-left { @include border-style-left(dotted, !important); }
+  .romo-border-double-left { @include border-style-left(double, !important); }
+  .romo-border-groove-left { @include border-style-left(groove, !important); }
+  .romo-border-inset-left  { @include border-style-left(inset,  !important); }
+  .romo-border-hidden-left { @include border-style-left(hidden, !important); }
+  .romo-border-none-left   { @include border-style-left(none,   !important); }
+
+  .romo-border-solid-left-hover:hover  { @include border-style-left(solid,  !important); }
+  .romo-border-dashed-left-hover:hover { @include border-style-left(dashed, !important); }
+  .romo-border-dotted-left-hover:hover { @include border-style-left(dotted, !important); }
+  .romo-border-double-left-hover:hover { @include border-style-left(double, !important); }
+  .romo-border-groove-left-hover:hover { @include border-style-left(groove, !important); }
+  .romo-border-inset-left-hover:hover  { @include border-style-left(inset,  !important); }
+  .romo-border-hidden-left-hover:hover { @include border-style-left(hidden, !important); }
+  .romo-border-none-left-hover:hover   { @include border-style-left(none,   !important); }
+
+  .romo-border,
+  .romo-border1   { @include border1(!important); }
+  .romo-border0   { @include border0(!important); }
+  .romo-border2   { @include border2(!important); }
+  .romo-rm-border { @include rm-border(!important); }
+
+  .romo-border-hover:hover,
+  .romo-border1-hover:hover   { @include border1(!important); }
+  .romo-border0-hover:hover   { @include border0(!important); }
+  .romo-border2-hover:hover   { @include border2(!important); }
+  .romo-rm-border-hover:hover { @include rm-border(!important); }
+
+  .romo-border-top,
+  .romo-border1-top   { @include border1-top(!important); }
+  .romo-border0-top   { @include border0-top(!important); }
+  .romo-border2-top   { @include border2-top(!important); }
+  .romo-rm-border-top { @include rm-border-top(!important); }
+
+  .romo-border-top-hover:hover,
+  .romo-border1-top-hover:hover   { @include border1-top(!important); }
+  .romo-border0-top-hover:hover   { @include border0-top(!important); }
+  .romo-border2-top-hover:hover   { @include border2-top(!important); }
+  .romo-rm-border-top-hover:hover { @include rm-border-top(!important); }
+
+  .romo-border-right,
+  .romo-border1-right   { @include border1-right(!important); }
+  .romo-border0-right   { @include border0-right(!important); }
+  .romo-border2-right   { @include border2-right(!important); }
+  .romo-rm-border-right { @include rm-border-right(!important); }
+
+  .romo-border-right-hover:hover,
+  .romo-border1-right-hover:hover   { @include border1-right(!important); }
+  .romo-border0-right-hover:hover   { @include border0-right(!important); }
+  .romo-border2-right-hover:hover   { @include border2-right(!important); }
+  .romo-rm-border-right-hover:hover { @include rm-border-right(!important); }
+
+  .romo-border-bottom,
+  .romo-border1-bottom   { @include border1-bottom(!important); }
+  .romo-border0-bottom   { @include border0-bottom(!important); }
+  .romo-border2-bottom   { @include border2-bottom(!important); }
+  .romo-rm-border-bottom { @include rm-border-bottom(!important); }
+
+  .romo-border-bottom-hover:hover,
+  .romo-border1-bottom-hover:hover   { @include border1-bottom(!important); }
+  .romo-border0-bottom-hover:hover   { @include border0-bottom(!important); }
+  .romo-border2-bottom-hover:hover   { @include border2-bottom(!important); }
+  .romo-rm-border-bottom-hover:hover { @include rm-border-bottom(!important); }
+
+  .romo-border-left,
+  .romo-border1-left   { @include border1-left(!important); }
+  .romo-border0-left   { @include border0-left(!important); }
+  .romo-border2-left   { @include border2-left(!important); }
+  .romo-rm-border-left { @include rm-border-left(!important); }
+
+  .romo-border-left-hover:hover,
+  .romo-border1-left-hover:hover   { @include border1-left(!important); }
+  .romo-border0-left-hover:hover   { @include border0-left(!important); }
+  .romo-border2-left-hover:hover   { @include border2-left(!important); }
+  .romo-rm-border-left-hover:hover { @include rm-border-left(!important); }
+
+  .romo-border-radius,
+  .romo-border1-radius   { @include border1-radius(!important); }
+  .romo-border0-radius   { @include border0-radius(!important); }
+  .romo-border2-radius   { @include border2-radius(!important); }
+  .romo-rm-border-radius { @include rm-border-radius(!important); }
+
+  .romo-border-radius-hover:hover,
+  .romo-border1-radius-hover:hover   { @include border1-radius(!important); }
+  .romo-border0-radius-hover:hover   { @include border0-radius(!important); }
+  .romo-border2-radius-hover:hover   { @include border2-radius(!important); }
+  .romo-rm-border-radius-hover:hover { @include rm-border-radius(!important); }
+
+  .romo-border-top-left-radius,
+  .romo-border1-top-left-radius   { @include border1-top-left-radius(!important); }
+  .romo-border0-top-left-radius   { @include border0-top-left-radius(!important); }
+  .romo-border2-top-left-radius   { @include border2-top-left-radius(!important); }
+  .romo-rm-border-top-left-radius { @include rm-border-top-left-radius(!important); }
+
+  .romo-border-top-left-radius-hover:hover,
+  .romo-border1-top-left-radius-hover:hover   { @include border1-top-left-radius(!important); }
+  .romo-border0-top-left-radius-hover:hover   { @include border0-top-left-radius(!important); }
+  .romo-border2-top-left-radius-hover:hover   { @include border2-top-left-radius(!important); }
+  .romo-rm-border-top-left-radius-hover:hover { @include rm-border-top-left-radius(!important); }
+
+  .romo-border-top-right-radius,
+  .romo-border1-top-right-radius   { @include border1-top-right-radius(!important); }
+  .romo-border0-top-right-radius   { @include border0-top-right-radius(!important); }
+  .romo-border2-top-right-radius   { @include border2-top-right-radius(!important); }
+  .romo-rm-border-top-right-radius { @include rm-border-top-right-radius(!important); }
+
+  .romo-border-top-right-radius-hover:hover,
+  .romo-border1-top-right-radius-hover:hover   { @include border1-top-right-radius(!important); }
+  .romo-border0-top-right-radius-hover:hover   { @include border0-top-right-radius(!important); }
+  .romo-border2-top-right-radius-hover:hover   { @include border2-top-right-radius(!important); }
+  .romo-rm-border-top-right-radius-hover:hover { @include rm-border-top-right-radius(!important); }
+
+  .romo-border-bottom-right-radius,
+  .romo-border1-bottom-right-radius   { @include border1-bottom-right-radius(!important); }
+  .romo-border0-bottom-right-radius   { @include border0-bottom-right-radius(!important); }
+  .romo-border2-bottom-right-radius   { @include border2-bottom-right-radius(!important); }
+  .romo-rm-border-bottom-right-radius { @include rm-border-bottom-right-radius(!important); }
+
+  .romo-border-bottom-right-radius-hover:hover,
+  .romo-border1-bottom-right-radius-hover:hover   { @include border1-bottom-right-radius(!important); }
+  .romo-border0-bottom-right-radius-hover:hover   { @include border0-bottom-right-radius(!important); }
+  .romo-border2-bottom-right-radius-hover:hover   { @include border2-bottom-right-radius(!important); }
+  .romo-rm-border-bottom-right-radius-hover:hover { @include rm-border-bottom-right-radius(!important); }
+
+  .romo-border-bottom-left-radius,
+  .romo-border1-bottom-left-radius   { @include border1-bottom-left-radius(!important); }
+  .romo-border0-bottom-left-radius   { @include border0-bottom-left-radius(!important); }
+  .romo-border2-bottom-left-radius   { @include border2-bottom-left-radius(!important); }
+  .romo-rm-border-bottom-left-radius { @include rm-border-bottom-left-radius(!important); }
+
+  .romo-border-bottom-left-radius-hover:hover,
+  .romo-border1-bottom-left-radius-hover:hover   { @include border1-bottom-left-radius(!important); }
+  .romo-border0-bottom-left-radius-hover:hover   { @include border0-bottom-left-radius(!important); }
+  .romo-border2-bottom-left-radius-hover:hover   { @include border2-bottom-left-radius(!important); }
+  .romo-rm-border-bottom-left-radius-hover:hover { @include rm-border-bottom-left-radius(!important); }
+
+  .romo-border-radius-circle             { @include border-radius(50%); }
+  .romo-border-radius-circle-hover:hover { @include border-radius(50%); }
+  .romo-border-radius-pill               { @include border-radius(500px); }
+  .romo-border-radius-pill-hover:hover   { @include border-radius(500px); }
+
+  /* spacing */
+
+  .romo-pad,
+  .romo-pad1   { @include pad1(!important); }
+  .romo-pad0   { @include pad0(!important); }
+  .romo-pad2   { @include pad2(!important); }
+  .romo-pad-none,
+  .romo-rm-pad { @include rm-pad(!important); }
+
+  .romo-pad-top,
+  .romo-pad1-top   { @include pad1-top(!important); }
+  .romo-pad0-top   { @include pad0-top(!important); }
+  .romo-pad2-top   { @include pad2-top(!important); }
+  .romo-pad-none-top,
+  .romo-rm-pad-top { @include rm-pad-top(!important); }
+
+  .romo-pad-right,
+  .romo-pad1-right   { @include pad1-right(!important); }
+  .romo-pad0-right   { @include pad0-right(!important); }
+  .romo-pad2-right   { @include pad2-right(!important); }
+  .romo-pad-none-right,
+  .romo-rm-pad-right { @include rm-pad-right(!important); }
+
+  .romo-pad-bottom,
+  .romo-pad1-bottom   { @include pad1-bottom(!important); }
+  .romo-pad0-bottom   { @include pad0-bottom(!important); }
+  .romo-pad2-bottom   { @include pad2-bottom(!important); }
+  .romo-pad-none-bottom,
+  .romo-rm-pad-bottom { @include rm-pad-bottom(!important); }
+
+  .romo-pad-left,
+  .romo-pad1-left   { @include pad1-left(!important); }
+  .romo-pad0-left   { @include pad0-left(!important); }
+  .romo-pad2-left   { @include pad2-left(!important); }
+  .romo-pad-none-left,
+  .romo-rm-pad-left { @include rm-pad-left(!important); }
+
+  .romo-push,
+  .romo-push1   { @include push1(!important); }
+  .romo-push0   { @include push0(!important); }
+  .romo-push2   { @include push2(!important); }
+  .romo-push-none,
+  .romo-rm-push { @include rm-push(!important); }
+
+  .romo-push-top,
+  .romo-push1-top   { @include push1-top(!important); }
+  .romo-push0-top   { @include push0-top(!important); }
+  .romo-push2-top   { @include push2-top(!important); }
+  .romo-push-none-top,
+  .romo-rm-push-top { @include rm-push-top(!important); }
+
+  .romo-push-right,
+  .romo-push1-right   { @include push1-right(!important); }
+  .romo-push0-right   { @include push0-right(!important); }
+  .romo-push2-right   { @include push2-right(!important); }
+  .romo-push-none-right,
+  .romo-rm-push-right { @include rm-push-right(!important); }
+
+  .romo-push-bottom,
+  .romo-push1-bottom   { @include push1-bottom(!important); }
+  .romo-push0-bottom   { @include push0-bottom(!important); }
+  .romo-push2-bottom   { @include push2-bottom(!important); }
+  .romo-push-none-bottom,
+  .romo-rm-push-bottom { @include rm-push-bottom(!important); }
+
+  .romo-push-left,
+  .romo-push1-left   { @include push1-left(!important); }
+  .romo-push0-left   { @include push0-left(!important); }
+  .romo-push2-left   { @include push2-left(!important); }
+  .romo-push-none-left,
+  .romo-rm-push-left { @include rm-push-left(!important); }
+
+  .romo-push-center { margin: 0 auto !important; }
+
+  /* other helpers */
+
+  .romo-full-width  { width:  100% !important; }
+  .romo-full-height { height: 100% !important; }
+  .romo-match-line-height { line-height: 1 !important; }
+
+  .romo-nowrap        { white-space: nowrap !important; }
+  .romo-crop          { white-space: nowrap !important; overflow: hidden !important; }
+  .romo-ellipsis      { overflow: hidden !important; text-overflow: ellipsis !important; }
+  .romo-crop-ellipsis { white-space: nowrap !important; overflow: hidden !important; text-overflow: ellipsis !important; }
+
+  .romo-inline       { display: inline !important; }
+  .romo-inline-block { display: inline-block !important; }
+  .romo-inline-flex  { @include display-inline-flex(!important); }
+  .romo-flex         { @include display-flex(!important); }
+  .romo-block        { display: block !important; }
+  .romo-display-none { display: none !important;}
+
+  .romo-hover:hover {
+    .romo-inline-hover       { display: inline !important; }
+    .romo-inline-block-hover { display: inline-block !important; }
+    .romo-inline-flex-hover  { @include display-inline-flex(!important); }
+    .romo-flex-hover         { @include display-flex(!important); }
+    .romo-block-hover        { display: block !important; }
+    .romo-display-none-hover { display: none !important;}
+  }
+
+  .romo-relative { position: relative !important; }
+  .romo-absolute { position: absolute !important; }
+  .romo-absolute-fill {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+  }
+  .romo-fixed    { position: fixed !important; }
+
+  .romo-clearfix { @include clearfix; }
+  .romo-pull-left,
+  .romo-float-left  { float: left !important; }
+  .romo-pull-right,
+  .romo-float-right { float: right !important; }
+
+  .romo-overflow-hidden { overflow: hidden !important; }
+  .romo-overflow-auto   { overflow: auto !important; }
+  .romo-overflow-scroll { overflow: scroll !important; }
+
+  .romo-overflow-x-hidden { overflow-x: hidden !important; }
+  .romo-overflow-x-auto   { overflow-x: auto !important; }
+  .romo-overflow-x-scroll { overflow-x: scroll !important; }
+
+  .romo-overflow-y-hidden { overflow-y: hidden !important; }
+  .romo-overflow-y-auto   { overflow-y: auto !important; }
+  .romo-overflow-y-scroll { overflow-y: scroll !important; }
+
 }
-
-h1 { @include text3; }
-h2 { @include text2; }
-h3 { @include text1; }
-
-/* text size */
-
-.romo-text0,
-.romo-text1,
-.romo-text2,
-.romo-text3 {
-  text-rendering: optimizelegibility;
-}
-
-.romo-text-small,
-.romo-text0 { @include text0(!important); @include font-weight0; }
-.romo-text1 { @include text1(!important); @include font-weight1; }
-.romo-text-large,
-.romo-text2 { @include text2(!important); @include font-weight2; }
-.romo-text3 { @include text3(!important); @include font-weight3; }
-
-.romo-text-small-hover:hover,
-.romo-text0-hover:hover { @include text0(!important); @include font-weight0; }
-.romo-text1-hover:hover { @include text1(!important); @include font-weight1; }
-.romo-text-large-hover:hover,
-.romo-text2-hover:hover { @include text2(!important); @include font-weight2; }
-.romo-text3-hover:hover { @include text3(!important); @include font-weight3; }
-
-.romo-text-inline-small,
-.romo-text-inline0 { @include line-height0(!important); }
-.romo-text-inline1 { @include line-height1(!important); }
-.romo-text-inline-large,
-.romo-text-inline2 { @include line-height2(!important); }
-.romo-text-inline3 { @include line-height3(!important); }
-
-/* text weight */
-
-.romo-text-normal  { @include font-weight(normal,  !important); }
-.romo-text-lighter { @include font-weight(lighter, !important); }
-.romo-text-bold    { @include font-weight(bold,    !important); }
-.romo-text-bolder  { @include font-weight(bolder,  !important); }
-.romo-text-100     { @include font-weight(100,     !important); }
-.romo-text-200     { @include font-weight(200,     !important); }
-.romo-text-300     { @include font-weight(300,     !important); }
-.romo-text-400     { @include font-weight(400,     !important); }
-.romo-text-500     { @include font-weight(500,     !important); }
-.romo-text-600     { @include font-weight(600,     !important); }
-.romo-text-700     { @include font-weight(700,     !important); }
-.romo-text-800     { @include font-weight(800,     !important); }
-.romo-text-900     { @include font-weight(900,     !important); }
-
-.romo-text-normal-hover:hover  { @include font-weight(normal,  !important); }
-.romo-text-lighter-hover:hover { @include font-weight(lighter, !important); }
-.romo-text-bold-hover:hover    { @include font-weight(bold,    !important); }
-.romo-text-bolder-hover:hover  { @include font-weight(bolder,  !important); }
-.romo-text-100-hover:hover     { @include font-weight(100,     !important); }
-.romo-text-200-hover:hover     { @include font-weight(200,     !important); }
-.romo-text-300-hover:hover     { @include font-weight(300,     !important); }
-.romo-text-400-hover:hover     { @include font-weight(400,     !important); }
-.romo-text-500-hover:hover     { @include font-weight(500,     !important); }
-.romo-text-600-hover:hover     { @include font-weight(600,     !important); }
-.romo-text-700-hover:hover     { @include font-weight(700,     !important); }
-.romo-text-800-hover:hover     { @include font-weight(800,     !important); }
-.romo-text-900-hover:hover     { @include font-weight(900,     !important); }
-
-/* text decoration */
-
-.romo-text-underline     { @include text-decoration-underline(!important); }
-.romo-text-overline      { @include text-decoration-overline(!important); }
-.romo-text-line-through,
-.romo-text-strikethrough { @include text-decoration-line-through(!important); }
-.romo-text-no-line       { @include text-decoration-none(!important); }
-
-.romo-text-underline-hover:hover     { @include text-decoration-underline(!important); }
-.romo-text-overline-hover:hover      { @include text-decoration-overline(!important); }
-.romo-text-line-through-hover:hover,
-.romo-text-strikethrough-hover:hover { @include text-decoration-line-through(!important); }
-.romo-text-no-line-hover:hover       { @include text-decoration-none(!important); }
-
-/* alignment */
-
-.romo-align-left   { @include align-left(!important); }
-.romo-align-center { @include align-center(!important); }
-.romo-align-right  { @include align-right(!important); }
-
-.romo-align-top    { @include align-top(!important); }
-.romo-align-middle { @include align-middle(!important); }
-.romo-align-bottom { @include align-bottom(!important); }
-
-/* Scaffolding */
-/* ----------- */
-
-/* border helpers */
-
-.romo-border-solid  { @include border-style(solid,  !important); }
-.romo-border-dashed { @include border-style(dashed, !important); }
-.romo-border-dotted { @include border-style(dotted, !important); }
-.romo-border-double { @include border-style(double, !important); }
-.romo-border-groove { @include border-style(groove, !important); }
-.romo-border-inset  { @include border-style(inset,  !important); }
-.romo-border-hidden { @include border-style(hidden, !important); }
-.romo-border-none   { @include border-style(none,   !important); }
-
-.romo-border-solid-hover:hover  { @include border-style(solid,  !important); }
-.romo-border-dashed-hover:hover { @include border-style(dashed, !important); }
-.romo-border-dotted-hover:hover { @include border-style(dotted, !important); }
-.romo-border-double-hover:hover { @include border-style(double, !important); }
-.romo-border-groove-hover:hover { @include border-style(groove, !important); }
-.romo-border-inset-hover:hover  { @include border-style(inset,  !important); }
-.romo-border-hidden-hover:hover { @include border-style(hidden, !important); }
-.romo-border-none-hover:hover   { @include border-style(none,   !important); }
-
-.romo-border-solid-top  { @include border-style-top(solid,  !important); }
-.romo-border-dashed-top { @include border-style-top(dashed, !important); }
-.romo-border-dotted-top { @include border-style-top(dotted, !important); }
-.romo-border-double-top { @include border-style-top(double, !important); }
-.romo-border-groove-top { @include border-style-top(groove, !important); }
-.romo-border-inset-top  { @include border-style-top(inset,  !important); }
-.romo-border-hidden-top { @include border-style-top(hidden, !important); }
-.romo-border-none-top   { @include border-style-top(none,   !important); }
-
-.romo-border-solid-top-hover:hover  { @include border-style-top(solid,  !important); }
-.romo-border-dashed-top-hover:hover { @include border-style-top(dashed, !important); }
-.romo-border-dotted-top-hover:hover { @include border-style-top(dotted, !important); }
-.romo-border-double-top-hover:hover { @include border-style-top(double, !important); }
-.romo-border-groove-top-hover:hover { @include border-style-top(groove, !important); }
-.romo-border-inset-top-hover:hover  { @include border-style-top(inset,  !important); }
-.romo-border-hidden-top-hover:hover { @include border-style-top(hidden, !important); }
-.romo-border-none-top-hover:hover   { @include border-style-top(none,   !important); }
-
-.romo-border-solid-right  { @include border-style-right(solid,  !important); }
-.romo-border-dashed-right { @include border-style-right(dashed, !important); }
-.romo-border-dotted-right { @include border-style-right(dotted, !important); }
-.romo-border-double-right { @include border-style-right(double, !important); }
-.romo-border-groove-right { @include border-style-right(groove, !important); }
-.romo-border-inset-right  { @include border-style-right(inset,  !important); }
-.romo-border-hidden-right { @include border-style-right(hidden, !important); }
-.romo-border-none-right   { @include border-style-right(none,   !important); }
-
-.romo-border-solid-right-hover:hover  { @include border-style-right(solid,  !important); }
-.romo-border-dashed-right-hover:hover { @include border-style-right(dashed, !important); }
-.romo-border-dotted-right-hover:hover { @include border-style-right(dotted, !important); }
-.romo-border-double-right-hover:hover { @include border-style-right(double, !important); }
-.romo-border-groove-right-hover:hover { @include border-style-right(groove, !important); }
-.romo-border-inset-right-hover:hover  { @include border-style-right(inset,  !important); }
-.romo-border-hidden-right-hover:hover { @include border-style-right(hidden, !important); }
-.romo-border-none-right-hover:hover   { @include border-style-right(none,   !important); }
-
-.romo-border-solid-bottom  { @include border-style-bottom(solid,  !important); }
-.romo-border-dashed-bottom { @include border-style-bottom(dashed, !important); }
-.romo-border-dotted-bottom { @include border-style-bottom(dotted, !important); }
-.romo-border-double-bottom { @include border-style-bottom(double, !important); }
-.romo-border-groove-bottom { @include border-style-bottom(groove, !important); }
-.romo-border-inset-bottom  { @include border-style-bottom(inset,  !important); }
-.romo-border-hidden-bottom { @include border-style-bottom(hidden, !important); }
-.romo-border-none-bottom   { @include border-style-bottom(none,   !important); }
-
-.romo-border-solid-bottom-hover:hover  { @include border-style-bottom(solid,  !important); }
-.romo-border-dashed-bottom-hover:hover { @include border-style-bottom(dashed, !important); }
-.romo-border-dotted-bottom-hover:hover { @include border-style-bottom(dotted, !important); }
-.romo-border-double-bottom-hover:hover { @include border-style-bottom(double, !important); }
-.romo-border-groove-bottom-hover:hover { @include border-style-bottom(groove, !important); }
-.romo-border-inset-bottom-hover:hover  { @include border-style-bottom(inset,  !important); }
-.romo-border-hidden-bottom-hover:hover { @include border-style-bottom(hidden, !important); }
-.romo-border-none-bottom-hover:hover   { @include border-style-bottom(none,   !important); }
-
-.romo-border-solid-left  { @include border-style-left(solid,  !important); }
-.romo-border-dashed-left { @include border-style-left(dashed, !important); }
-.romo-border-dotted-left { @include border-style-left(dotted, !important); }
-.romo-border-double-left { @include border-style-left(double, !important); }
-.romo-border-groove-left { @include border-style-left(groove, !important); }
-.romo-border-inset-left  { @include border-style-left(inset,  !important); }
-.romo-border-hidden-left { @include border-style-left(hidden, !important); }
-.romo-border-none-left   { @include border-style-left(none,   !important); }
-
-.romo-border-solid-left-hover:hover  { @include border-style-left(solid,  !important); }
-.romo-border-dashed-left-hover:hover { @include border-style-left(dashed, !important); }
-.romo-border-dotted-left-hover:hover { @include border-style-left(dotted, !important); }
-.romo-border-double-left-hover:hover { @include border-style-left(double, !important); }
-.romo-border-groove-left-hover:hover { @include border-style-left(groove, !important); }
-.romo-border-inset-left-hover:hover  { @include border-style-left(inset,  !important); }
-.romo-border-hidden-left-hover:hover { @include border-style-left(hidden, !important); }
-.romo-border-none-left-hover:hover   { @include border-style-left(none,   !important); }
-
-.romo-border,
-.romo-border1   { @include border1(!important); }
-.romo-border0   { @include border0(!important); }
-.romo-border2   { @include border2(!important); }
-.romo-rm-border { @include rm-border(!important); }
-
-.romo-border-hover:hover,
-.romo-border1-hover:hover   { @include border1(!important); }
-.romo-border0-hover:hover   { @include border0(!important); }
-.romo-border2-hover:hover   { @include border2(!important); }
-.romo-rm-border-hover:hover { @include rm-border(!important); }
-
-.romo-border-top,
-.romo-border1-top   { @include border1-top(!important); }
-.romo-border0-top   { @include border0-top(!important); }
-.romo-border2-top   { @include border2-top(!important); }
-.romo-rm-border-top { @include rm-border-top(!important); }
-
-.romo-border-top-hover:hover,
-.romo-border1-top-hover:hover   { @include border1-top(!important); }
-.romo-border0-top-hover:hover   { @include border0-top(!important); }
-.romo-border2-top-hover:hover   { @include border2-top(!important); }
-.romo-rm-border-top-hover:hover { @include rm-border-top(!important); }
-
-.romo-border-right,
-.romo-border1-right   { @include border1-right(!important); }
-.romo-border0-right   { @include border0-right(!important); }
-.romo-border2-right   { @include border2-right(!important); }
-.romo-rm-border-right { @include rm-border-right(!important); }
-
-.romo-border-right-hover:hover,
-.romo-border1-right-hover:hover   { @include border1-right(!important); }
-.romo-border0-right-hover:hover   { @include border0-right(!important); }
-.romo-border2-right-hover:hover   { @include border2-right(!important); }
-.romo-rm-border-right-hover:hover { @include rm-border-right(!important); }
-
-.romo-border-bottom,
-.romo-border1-bottom   { @include border1-bottom(!important); }
-.romo-border0-bottom   { @include border0-bottom(!important); }
-.romo-border2-bottom   { @include border2-bottom(!important); }
-.romo-rm-border-bottom { @include rm-border-bottom(!important); }
-
-.romo-border-bottom-hover:hover,
-.romo-border1-bottom-hover:hover   { @include border1-bottom(!important); }
-.romo-border0-bottom-hover:hover   { @include border0-bottom(!important); }
-.romo-border2-bottom-hover:hover   { @include border2-bottom(!important); }
-.romo-rm-border-bottom-hover:hover { @include rm-border-bottom(!important); }
-
-.romo-border-left,
-.romo-border1-left   { @include border1-left(!important); }
-.romo-border0-left   { @include border0-left(!important); }
-.romo-border2-left   { @include border2-left(!important); }
-.romo-rm-border-left { @include rm-border-left(!important); }
-
-.romo-border-left-hover:hover,
-.romo-border1-left-hover:hover   { @include border1-left(!important); }
-.romo-border0-left-hover:hover   { @include border0-left(!important); }
-.romo-border2-left-hover:hover   { @include border2-left(!important); }
-.romo-rm-border-left-hover:hover { @include rm-border-left(!important); }
-
-.romo-border-radius,
-.romo-border1-radius   { @include border1-radius(!important); }
-.romo-border0-radius   { @include border0-radius(!important); }
-.romo-border2-radius   { @include border2-radius(!important); }
-.romo-rm-border-radius { @include rm-border-radius(!important); }
-
-.romo-border-radius-hover:hover,
-.romo-border1-radius-hover:hover   { @include border1-radius(!important); }
-.romo-border0-radius-hover:hover   { @include border0-radius(!important); }
-.romo-border2-radius-hover:hover   { @include border2-radius(!important); }
-.romo-rm-border-radius-hover:hover { @include rm-border-radius(!important); }
-
-.romo-border-top-left-radius,
-.romo-border1-top-left-radius   { @include border1-top-left-radius(!important); }
-.romo-border0-top-left-radius   { @include border0-top-left-radius(!important); }
-.romo-border2-top-left-radius   { @include border2-top-left-radius(!important); }
-.romo-rm-border-top-left-radius { @include rm-border-top-left-radius(!important); }
-
-.romo-border-top-left-radius-hover:hover,
-.romo-border1-top-left-radius-hover:hover   { @include border1-top-left-radius(!important); }
-.romo-border0-top-left-radius-hover:hover   { @include border0-top-left-radius(!important); }
-.romo-border2-top-left-radius-hover:hover   { @include border2-top-left-radius(!important); }
-.romo-rm-border-top-left-radius-hover:hover { @include rm-border-top-left-radius(!important); }
-
-.romo-border-top-right-radius,
-.romo-border1-top-right-radius   { @include border1-top-right-radius(!important); }
-.romo-border0-top-right-radius   { @include border0-top-right-radius(!important); }
-.romo-border2-top-right-radius   { @include border2-top-right-radius(!important); }
-.romo-rm-border-top-right-radius { @include rm-border-top-right-radius(!important); }
-
-.romo-border-top-right-radius-hover:hover,
-.romo-border1-top-right-radius-hover:hover   { @include border1-top-right-radius(!important); }
-.romo-border0-top-right-radius-hover:hover   { @include border0-top-right-radius(!important); }
-.romo-border2-top-right-radius-hover:hover   { @include border2-top-right-radius(!important); }
-.romo-rm-border-top-right-radius-hover:hover { @include rm-border-top-right-radius(!important); }
-
-.romo-border-bottom-right-radius,
-.romo-border1-bottom-right-radius   { @include border1-bottom-right-radius(!important); }
-.romo-border0-bottom-right-radius   { @include border0-bottom-right-radius(!important); }
-.romo-border2-bottom-right-radius   { @include border2-bottom-right-radius(!important); }
-.romo-rm-border-bottom-right-radius { @include rm-border-bottom-right-radius(!important); }
-
-.romo-border-bottom-right-radius-hover:hover,
-.romo-border1-bottom-right-radius-hover:hover   { @include border1-bottom-right-radius(!important); }
-.romo-border0-bottom-right-radius-hover:hover   { @include border0-bottom-right-radius(!important); }
-.romo-border2-bottom-right-radius-hover:hover   { @include border2-bottom-right-radius(!important); }
-.romo-rm-border-bottom-right-radius-hover:hover { @include rm-border-bottom-right-radius(!important); }
-
-.romo-border-bottom-left-radius,
-.romo-border1-bottom-left-radius   { @include border1-bottom-left-radius(!important); }
-.romo-border0-bottom-left-radius   { @include border0-bottom-left-radius(!important); }
-.romo-border2-bottom-left-radius   { @include border2-bottom-left-radius(!important); }
-.romo-rm-border-bottom-left-radius { @include rm-border-bottom-left-radius(!important); }
-
-.romo-border-bottom-left-radius-hover:hover,
-.romo-border1-bottom-left-radius-hover:hover   { @include border1-bottom-left-radius(!important); }
-.romo-border0-bottom-left-radius-hover:hover   { @include border0-bottom-left-radius(!important); }
-.romo-border2-bottom-left-radius-hover:hover   { @include border2-bottom-left-radius(!important); }
-.romo-rm-border-bottom-left-radius-hover:hover { @include rm-border-bottom-left-radius(!important); }
-
-.romo-border-radius-circle             { @include border-radius(50%); }
-.romo-border-radius-circle-hover:hover { @include border-radius(50%); }
-.romo-border-radius-pill               { @include border-radius(500px); }
-.romo-border-radius-pill-hover:hover   { @include border-radius(500px); }
-
-/* spacing */
-
-.romo-pad,
-.romo-pad1   { @include pad1(!important); }
-.romo-pad0   { @include pad0(!important); }
-.romo-pad2   { @include pad2(!important); }
-.romo-pad-none,
-.romo-rm-pad { @include rm-pad(!important); }
-
-.romo-pad-top,
-.romo-pad1-top   { @include pad1-top(!important); }
-.romo-pad0-top   { @include pad0-top(!important); }
-.romo-pad2-top   { @include pad2-top(!important); }
-.romo-pad-none-top,
-.romo-rm-pad-top { @include rm-pad-top(!important); }
-
-.romo-pad-right,
-.romo-pad1-right   { @include pad1-right(!important); }
-.romo-pad0-right   { @include pad0-right(!important); }
-.romo-pad2-right   { @include pad2-right(!important); }
-.romo-pad-none-right,
-.romo-rm-pad-right { @include rm-pad-right(!important); }
-
-.romo-pad-bottom,
-.romo-pad1-bottom   { @include pad1-bottom(!important); }
-.romo-pad0-bottom   { @include pad0-bottom(!important); }
-.romo-pad2-bottom   { @include pad2-bottom(!important); }
-.romo-pad-none-bottom,
-.romo-rm-pad-bottom { @include rm-pad-bottom(!important); }
-
-.romo-pad-left,
-.romo-pad1-left   { @include pad1-left(!important); }
-.romo-pad0-left   { @include pad0-left(!important); }
-.romo-pad2-left   { @include pad2-left(!important); }
-.romo-pad-none-left,
-.romo-rm-pad-left { @include rm-pad-left(!important); }
-
-.romo-push,
-.romo-push1   { @include push1(!important); }
-.romo-push0   { @include push0(!important); }
-.romo-push2   { @include push2(!important); }
-.romo-push-none,
-.romo-rm-push { @include rm-push(!important); }
-
-.romo-push-top,
-.romo-push1-top   { @include push1-top(!important); }
-.romo-push0-top   { @include push0-top(!important); }
-.romo-push2-top   { @include push2-top(!important); }
-.romo-push-none-top,
-.romo-rm-push-top { @include rm-push-top(!important); }
-
-.romo-push-right,
-.romo-push1-right   { @include push1-right(!important); }
-.romo-push0-right   { @include push0-right(!important); }
-.romo-push2-right   { @include push2-right(!important); }
-.romo-push-none-right,
-.romo-rm-push-right { @include rm-push-right(!important); }
-
-.romo-push-bottom,
-.romo-push1-bottom   { @include push1-bottom(!important); }
-.romo-push0-bottom   { @include push0-bottom(!important); }
-.romo-push2-bottom   { @include push2-bottom(!important); }
-.romo-push-none-bottom,
-.romo-rm-push-bottom { @include rm-push-bottom(!important); }
-
-.romo-push-left,
-.romo-push1-left   { @include push1-left(!important); }
-.romo-push0-left   { @include push0-left(!important); }
-.romo-push2-left   { @include push2-left(!important); }
-.romo-push-none-left,
-.romo-rm-push-left { @include rm-push-left(!important); }
-
-.romo-push-center { margin: 0 auto !important; }
-
-/* other helpers */
-
-.romo-full-width  { width:  100% !important; }
-.romo-full-height { height: 100% !important; }
-.romo-match-line-height { line-height: 1 !important; }
-
-.romo-nowrap        { white-space: nowrap !important; }
-.romo-crop          { white-space: nowrap !important; overflow: hidden !important; }
-.romo-ellipsis      { overflow: hidden !important; text-overflow: ellipsis !important; }
-.romo-crop-ellipsis { white-space: nowrap !important; overflow: hidden !important; text-overflow: ellipsis !important; }
-
-.romo-inline       { display: inline !important; }
-.romo-inline-block { display: inline-block !important; }
-.romo-inline-flex  { @include display-inline-flex(!important); }
-.romo-flex         { @include display-flex(!important); }
-.romo-block        { display: block !important; }
-.romo-display-none { display: none !important;}
-
-.romo-hover:hover {
-  .romo-inline-hover       { display: inline !important; }
-  .romo-inline-block-hover { display: inline-block !important; }
-  .romo-inline-flex-hover  { @include display-inline-flex(!important); }
-  .romo-flex-hover         { @include display-flex(!important); }
-  .romo-block-hover        { display: block !important; }
-  .romo-display-none-hover { display: none !important;}
-}
-
-.romo-relative { position: relative !important; }
-.romo-absolute { position: absolute !important; }
-.romo-absolute-fill {
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-}
-.romo-fixed    { position: fixed !important; }
-
-.romo-clearfix { @include clearfix; }
-.romo-pull-left,
-.romo-float-left  { float: left !important; }
-.romo-pull-right,
-.romo-float-right { float: right !important; }
-
-.romo-overflow-hidden { overflow: hidden !important; }
-.romo-overflow-auto   { overflow: auto !important; }
-.romo-overflow-scroll { overflow: scroll !important; }
-
-.romo-overflow-x-hidden { overflow-x: hidden !important; }
-.romo-overflow-x-auto   { overflow-x: auto !important; }
-.romo-overflow-x-scroll { overflow-x: scroll !important; }
-
-.romo-overflow-y-hidden { overflow-y: hidden !important; }
-.romo-overflow-y-auto   { overflow-y: auto !important; }
-.romo-overflow-y-scroll { overflow-y: scroll !important; }

--- a/assets/css/romo/buttons.scss
+++ b/assets/css/romo/buttons.scss
@@ -1,201 +1,205 @@
 @import 'css/romo/vars';
 @import 'css/romo/mixins';
 
-a.romo-btn,
-button.romo-btn,
-.romo-btn {
-  display: inline-block;
-  @include rm-push;
-  @include align-center;
-  @include align-middle;
+.romo {
 
-  @include button-bg($btnBg, $btnBgHover, $btnColor);
-  @include border1;
-  border-color: $btnBorder;
-  border-bottom-color: darken($btnBorder, 10%);
-  @include box-shadow(0 1px 1px rgba(0, 0, 0, 0.2));
+  a.romo-btn,
+  button.romo-btn,
+  .romo-btn {
+    display: inline-block;
+    @include rm-push;
+    @include align-center;
+    @include align-middle;
+
+    @include button-bg($btnBg, $btnBgHover, $btnColor);
+    @include border1;
+    border-color: $btnBorder;
+    border-bottom-color: darken($btnBorder, 10%);
+    @include box-shadow(0 1px 1px rgba(0, 0, 0, 0.2));
+  }
+
+  a.romo-btn,
+  button.romo-btn { cursor: pointer; }
+
+  a.romo-btn:hover,
+  button.romo-btn:hover,
+  a.romo-btn:focus,
+  button.romo-btn:focus {
+    color: $btnColorHover;
+    text-decoration: none;
+    background-position: 0 -15px;
+  }
+
+  .romo-btn:focus{ outline: none; }
+  .romo-btn.active,
+  .romo-btn:active {
+    background-image: none;
+    outline: 0;
+    @include box-shadow((inset 0 2px 4px rgba(0,0,0,.15), 0 1px 2px rgba(0,0,0,.05)));
+  }
+
+  .romo-btn.disabled,
+  .romo-btn[disabled] {
+    cursor: $notAllowedCursor;
+    background-image: none;
+    @include opacity(65);
+    @include box-shadow(none);
+  }
+
+  a.romo-btn.romo-btn-small,
+  button.romo-btn.romo-btn.small,
+  .romo-btn.romo-btn-small,
+  a.romo-btn.romo-btn0,
+  button.romo-btn.romo-btn0,
+  .romo-btn.romo-btn0 { @include font-size0; @include font-weight0; @include button-height0; @include button-pad0; }
+  a.romo-btn,
+  button.romo-btn,
+  .romo-btn,
+  a.romo-btn.romo-btn1,
+  button.romo-btn.romo-btn1,
+  .romo-btn.romo-btn1 { @include font-size1; @include font-weight1; @include button-height1; @include button-pad1; }
+  a.romo-btn.romo-btn-large,
+  button.romo-btn.romo-btn-large,
+  .romo-btn.romo-btn-large,
+  a.romo-btn.romo-btn2,
+  button.romo-btn.romo-btn2,
+  .romo-btn.romo-btn2 { @include font-size2; @include font-weight2; @include button-height2; @include button-pad2; }
+  a.romo-btn.romo-btn3,
+  button.romo-btn.romo-btn3,
+  .romo-btn.romo-btn3 { @include font-size3; @include font-weight3; @include button-height3; @include button-pad3; }
+
+  .romo-btn-inline-small,
+  .romo-btn-inline0 { @include button-inline0; }
+  .romo-btn-inline,
+  .romo-btn-inline1 { @include button-inline1; }
+  .romo-btn-inline-large,
+  .romo-btn-inline2 { @include button-inline2; }
+  .romo-btn-inline3 { @include button-inline3; }
+
+  input[type="submit"].romo-btn-block,
+  input[type="reset"].romo-btn-block,
+  input[type="button"].romo-btn-block,
+  .romo-btn-block { display: block; width: 100%; }
+
+  /* emphasis colored buttons */
+
+  a.romo-btn.romo-btn-alt,     button.romo-btn.romo-btn-alt,     .romo-btn.romo-btn-alt     { @include button-bg($btnAltBg,     $btnAltBgHover,     $btnAltColor);     }
+  a.romo-btn.romo-btn-inverse, button.romo-btn.romo-btn-inverse, .romo-btn.romo-btn-inverse { @include button-bg($btnInverseBg, $btnInverseBgHover, $btnInverseColor); }
+  a.romo-btn.romo-btn-warning, button.romo-btn.romo-btn-warning, .romo-btn.romo-btn-warning { @include button-bg($btnWarningBg, $btnWarningBgHover, $btnWarningColor); }
+  a.romo-btn.romo-btn-danger,  button.romo-btn.romo-btn-danger,  .romo-btn.romo-btn-danger  { @include button-bg($btnDangerBg,  $btnDangerBgHover,  $btnDangerColor);  }
+  a.romo-btn.romo-btn-info,    button.romo-btn.romo-btn-info,    .romo-btn.romo-btn-info    { @include button-bg($btnInfoBg,    $btnInfoBgHover,    $btnInfoColor);    }
+  a.romo-btn.romo-btn-success, button.romo-btn.romo-btn-success, .romo-btn.romo-btn-success { @include button-bg($btnSuccessBg, $btnSuccessBgHover, $btnSuccessColor); }
+
+  /* explicit colored buttons */
+
+  a.romo-btn.romo-btn-dark-red,      button.romo-btn.romo-btn-dark-red,      .romo-btn.romo-btn-dark-red      { @include button-bg($btnDarkRedBg,      $btnDarkRedBgHover,      $btnDarkRedColor);      }
+  a.romo-btn.romo-btn-red,           button.romo-btn.romo-btn-red,           .romo-btn.romo-btn-red           { @include button-bg($btnRedBg,          $btnRedBgHover,          $btnRedColor);          }
+  a.romo-btn.romo-btn-light-red,     button.romo-btn.romo-btn-light-red,     .romo-btn.romo-btn-light-red     { @include button-bg($btnLightRedBg,     $btnLightRedBgHover,     $btnLightRedColor);     }
+  a.romo-btn.romo-btn-pastel-red,    button.romo-btn.romo-btn-pastel-red,    .romo-btn.romo-btn-pastel-red    { @include button-bg($btnPastelRedBg,    $btnPastelRedBgHover,    $btnPastelRedColor);    }
+  a.romo-btn.romo-btn-dark-orange,   button.romo-btn.romo-btn-dark-orange,   .romo-btn.romo-btn-dark-orange   { @include button-bg($btnDarkOrangeBg,   $btnDarkOrangeBgHover,   $btnDarkOrangeColor);   }
+  a.romo-btn.romo-btn-orange,        button.romo-btn.romo-btn-orange,        .romo-btn.romo-btn-orange        { @include button-bg($btnOrangeBg,       $btnOrangeBgHover,       $btnOrangeColor);       }
+  a.romo-btn.romo-btn-yellow,        button.romo-btn.romo-btn-yellow,        .romo-btn.romo-btn-yellow        { @include button-bg($btnYellowBg,       $btnYellowBgHover,       $btnYellowColor);       }
+  a.romo-btn.romo-btn-pastel-yellow, button.romo-btn.romo-btn-pastel-yellow, .romo-btn.romo-btn-pastel-yellow { @include button-bg($btnPastelYellowBg, $btnPastelYellowBgHover, $btnPastelYellowColor); }
+  a.romo-btn.romo-btn-purple,        button.romo-btn.romo-btn-purple,        .romo-btn.romo-btn-purple        { @include button-bg($btnPurpleBg,       $btnPurpleBgHover,       $btnPurpleColor);       }
+  a.romo-btn.romo-btn-light-purple,  button.romo-btn.romo-btn-light-purple,  .romo-btn.romo-btn-light-purple  { @include button-bg($btnLightPurpleBg,  $btnLightPurpleBgHover,  $btnLightPurpleColor);  }
+  a.romo-btn.romo-btn-dark-pink,     button.romo-btn.romo-btn-dark-pink,     .romo-btn.romo-btn-dark-pink     { @include button-bg($btnDarkPinkBg,     $btnDarkPinkBgHover,     $btnDarkPinkColor);     }
+  a.romo-btn.romo-btn-hot-pink,      button.romo-btn.romo-btn-hot-pink,      .romo-btn.romo-btn-hot-pink      { @include button-bg($btnHotPinkBg,      $btnHotPinkBgHover,      $btnHotPinkColor);      }
+  a.romo-btn.romo-btn-pink,          button.romo-btn.romo-btn-pink,          .romo-btn.romo-btn-pink          { @include button-bg($btnPinkBg,         $btnPinkBgHover,         $btnPinkColor);         }
+  a.romo-btn.romo-btn-dark-green,    button.romo-btn.romo-btn-dark-green,    .romo-btn.romo-btn-dark-green    { @include button-bg($btnDarkGreenBg,    $btnDarkGreenBgHover,    $btnDarkGreenColor);    }
+  a.romo-btn.romo-btn-green,         button.romo-btn.romo-btn-green,         .romo-btn.romo-btn-green         { @include button-bg($btnGreenBg,        $btnGreenBgHover,        $btnGreenColor);        }
+  a.romo-btn.romo-btn-light-green,   button.romo-btn.romo-btn-light-green,   .romo-btn.romo-btn-light-green   { @include button-bg($btnLightGreenBg,   $btnLightGreenBgHover,   $btnLightGreenColor);   }
+  a.romo-btn.romo-btn-pastel-green,  button.romo-btn.romo-btn-pastel-green,  .romo-btn.romo-btn-pastel-green  { @include button-bg($btnPastelGreenBg,  $btnPastelGreenBgHover,  $btnPastelGreenColor);  }
+  a.romo-btn.romo-btn-navy,          button.romo-btn.romo-btn-navy,          .romo-btn.romo-btn-navy          { @include button-bg($btnNavyBg,         $btnNavyBgHover,         $btnNavyColor);         }
+  a.romo-btn.romo-btn-dark-blue,     button.romo-btn.romo-btn-dark-blue,     .romo-btn.romo-btn-dark-blue     { @include button-bg($btnDarkBlueBg,     $btnDarkBlueBgHover,     $btnDarkBlueColor);     }
+  a.romo-btn.romo-btn-blue,          button.romo-btn.romo-btn-blue,          .romo-btn.romo-btn-blue          { @include button-bg($btnBlueBg,         $btnBlueBgHover,         $btnBlueColor);         }
+  a.romo-btn.romo-btn-light-blue,    button.romo-btn.romo-btn-light-blue,    .romo-btn.romo-btn-light-blue    { @include button-bg($btnLightBlueBg,    $btnLightBlueBgHover,    $btnLightBlueColor);    }
+  a.romo-btn.romo-btn-pastel-blue,   button.romo-btn.romo-btn-pastel-blue,   .romo-btn.romo-btn-pastel-blue   { @include button-bg($btnPastelBlueBg,   $btnPastelBlueBgHover,   $btnPastelBlueColor);   }
+
+  /* link buttons */
+
+  a.romo-btn.romo-btn-link,           button.romo-btn.romo-btn-link,           .romo-btn.romo-btn-link,
+  a.romo-btn.romo-btn-link.active,    button.romo-btn.romo-btn-link.active,    .romo-btn.romo-btn-link.active,
+  a.romo-btn.romo-btn-link:active,    button.romo-btn.romo-btn-link:active,    .romo-btn.romo-btn-link:active,
+  a.romo-btn.romo-btn-link.disabled,  button.romo-btn.romo-btn-link.disabled,  .romo-btn.romo-btn-link.disabled,
+  a.romo-btn.romo-btn-link[disabled], button.romo-btn.romo-btn-link[disabled], .romo-btn.romo-btn-link[disabled] {
+    background-color: transparent;
+    background-image: none;
+    @include box-shadow(none);
+  }
+
+  a.romo-btn.romo-btn-link, button.romo-btn.romo-btn-link { color: $linkColor; }
+
+  a.romo-btn.romo-btn-link:hover, button.romo-btn.romo-btn-link:hover,
+  a.romo-btn.romo-btn-link:focus, button.romo-btn.romo-btn-link:focus {
+    color: $linkColorHover;
+    text-decoration: underline;
+    background-color: transparent;
+  }
+
+  a.romo-btn.romo-btn-link.disabled,        button.romo-btn.romo-btn-link.disabled, .romo-btn.romo-btn-link.disabled,
+  a.romo-btn.romo-btn-link.disabled:hover,  button.romo-btn.romo-btn-link.disabled:hover, .romo-btn.romo-btn-link.disabled:hover,
+  a.romo-btn.romo-btn-link.disabled:focus,  button.romo-btn.romo-btn-link.disabled:focus, .romo-btn.romo-btn-link.disabled:focus,
+  a.romo-btn.romo-btn-link[disabled],       button.romo-btn.romo-btn-link[disabled],      .romo-btn.romo-btn-link[disabled],
+  a.romo-btn.romo-btn-link[disabled]:hover, button.romo-btn.romo-btn-link[disabled]:hover, .romo-btn.romo-btn-link[disabled]:hover,
+  a.romo-btn.romo-btn-link[disabled]:focus, button.romo-btn.romo-btn-link[disabled]:focus, .romo-btn.romo-btn-link[disabled]:focus {
+    color: $disabledColor;
+  }
+
+  .romo-btn-group { @include display-inline-flex(!important); }
+  .romo-btn-group > * { display: inherit; }
+
+  .romo-btn-group .romo-btn:not(:last-child) { @include rm-border-right; }
+
+  .romo-btn-group.romo-btn-group-border-radius  .romo-btn:first-child,
+  .romo-btn-group.romo-btn-group-border1-radius .romo-btn:first-child { @include border1-top-left-radius; @include border1-bottom-left-radius; }
+  .romo-btn-group.romo-btn-group-border0-radius .romo-btn:first-child { @include border0-top-left-radius; @include border0-bottom-left-radius; }
+  .romo-btn-group.romo-btn-group-border2-radius .romo-btn:first-child { @include border2-top-left-radius; @include border2-bottom-left-radius; }
+
+  .romo-btn-group.romo-btn-group-border-radius  .romo-btn:last-child,
+  .romo-btn-group.romo-btn-group-border1-radius .romo-btn:last-child { @include border1-top-right-radius; @include border1-bottom-right-radius; }
+  .romo-btn-group.romo-btn-group-border0-radius .romo-btn:last-child { @include border0-top-right-radius; @include border0-bottom-right-radius; }
+  .romo-btn-group.romo-btn-group-border2-radius .romo-btn:last-child { @include border2-top-right-radius; @include border2-bottom-right-radius; }
+
+  .romo-btn-group-vertical                            { display: inline-block; }
+  .romo-btn-group-vertical .romo-btn                  { display: block; max-width: 100%; }
+  .romo-btn-group-vertical .romo-btn:not(:last-child) { @include rm-border-bottom; }
+
+  .romo-btn-group-vertical.romo-btn-group-border-radius  .romo-btn:first-child,
+  .romo-btn-group-vertical.romo-btn-group-border1-radius .romo-btn:first-child { @include border1-top-left-radius; @include border1-top-right-radius; }
+  .romo-btn-group-vertical.romo-btn-group-border0-radius .romo-btn:first-child { @include border0-top-left-radius; @include border0-top-right-radius; }
+  .romo-btn-group-vertical.romo-btn-group-border2-radius .romo-btn:first-child { @include border2-top-left-radius; @include border2-top-right-radius; }
+
+  .romo-btn-group-vertical.romo-btn-group-border-radius  .romo-btn:last-child,
+  .romo-btn-group-vertical.romo-btn-group-border1-radius .romo-btn:last-child { @include border1-bottom-left-radius; @include border1-bottom-right-radius; }
+  .romo-btn-group-vertical.romo-btn-group-border0-radius .romo-btn:last-child { @include border0-bottom-left-radius; @include border0-bottom-right-radius; }
+  .romo-btn-group-vertical.romo-btn-group-border2-radius .romo-btn:last-child { @include border2-bottom-left-radius; @include border2-bottom-right-radius; }
+
+  .romo-btn-group .romo-btn-group-vertical:not(:last-child) .romo-btn { @include rm-border-right; }
+  .romo-btn-group .romo-btn-group-vertical:last-child       .romo-btn { @include border1-right; }
+
+  .romo-btn-group.romo-btn-group-border-radius  .romo-btn-group-vertical .romo-btn,
+  .romo-btn-group.romo-btn-group-border1-radius .romo-btn-group-vertical .romo-btn { @include rm-border-radius; }
+  .romo-btn-group.romo-btn-group-border0-radius .romo-btn-group-vertical .romo-btn { @include rm-border-radius; }
+  .romo-btn-group.romo-btn-group-border2-radius .romo-btn-group-vertical .romo-btn { @include rm-border-radius; }
+
+  .romo-btn-group.romo-btn-group-border-radius  .romo-btn-group-vertical:first-child .romo-btn:first-child,
+  .romo-btn-group.romo-btn-group-border1-radius .romo-btn-group-vertical:first-child .romo-btn:first-child { @include border1-top-left-radius; }
+  .romo-btn-group.romo-btn-group-border0-radius .romo-btn-group-vertical:first-child .romo-btn:first-child { @include border0-top-left-radius; }
+  .romo-btn-group.romo-btn-group-border2-radius .romo-btn-group-vertical:first-child .romo-btn:first-child { @include border2-top-left-radius; }
+
+  .romo-btn-group.romo-btn-group-border-radius  .romo-btn-group-vertical:first-child .romo-btn:last-child,
+  .romo-btn-group.romo-btn-group-border1-radius .romo-btn-group-vertical:first-child .romo-btn:last-child { @include border1-bottom-left-radius; }
+  .romo-btn-group.romo-btn-group-border0-radius .romo-btn-group-vertical:first-child .romo-btn:last-child { @include border0-bottom-left-radius; }
+  .romo-btn-group.romo-btn-group-border2-radius .romo-btn-group-vertical:first-child .romo-btn:last-child { @include border2-bottom-left-radius; }
+
+  .romo-btn-group.romo-btn-group-border-radius  .romo-btn-group-vertical:last-child .romo-btn:first-child,
+  .romo-btn-group.romo-btn-group-border1-radius .romo-btn-group-vertical:last-child .romo-btn:first-child { @include border1-top-right-radius; }
+  .romo-btn-group.romo-btn-group-border0-radius .romo-btn-group-vertical:last-child .romo-btn:first-child { @include border0-top-right-radius; }
+  .romo-btn-group.romo-btn-group-border2-radius .romo-btn-group-vertical:last-child .romo-btn:first-child { @include border2-top-right-radius; }
+
+  .romo-btn-group.romo-btn-group-border-radius  .romo-btn-group-vertical:last-child .romo-btn:last-child,
+  .romo-btn-group.romo-btn-group-border1-radius .romo-btn-group-vertical:last-child .romo-btn:last-child { @include border1-bottom-right-radius; }
+  .romo-btn-group.romo-btn-group-border0-radius .romo-btn-group-vertical:last-child .romo-btn:last-child { @include border0-bottom-right-radius; }
+  .romo-btn-group.romo-btn-group-border2-radius .romo-btn-group-vertical:last-child .romo-btn:last-child { @include border2-bottom-right-radius; }
+
 }
-
-a.romo-btn,
-button.romo-btn { cursor: pointer; }
-
-a.romo-btn:hover,
-button.romo-btn:hover,
-a.romo-btn:focus,
-button.romo-btn:focus {
-  color: $btnColorHover;
-  text-decoration: none;
-  background-position: 0 -15px;
-}
-
-.romo-btn:focus{ outline: none; }
-.romo-btn.active,
-.romo-btn:active {
-  background-image: none;
-  outline: 0;
-  @include box-shadow((inset 0 2px 4px rgba(0,0,0,.15), 0 1px 2px rgba(0,0,0,.05)));
-}
-
-.romo-btn.disabled,
-.romo-btn[disabled] {
-  cursor: $notAllowedCursor;
-  background-image: none;
-  @include opacity(65);
-  @include box-shadow(none);
-}
-
-a.romo-btn.romo-btn-small,
-button.romo-btn.romo-btn.small,
-.romo-btn.romo-btn-small,
-a.romo-btn.romo-btn0,
-button.romo-btn.romo-btn0,
-.romo-btn.romo-btn0 { @include font-size0; @include font-weight0; @include button-height0; @include button-pad0; }
-a.romo-btn,
-button.romo-btn,
-.romo-btn,
-a.romo-btn.romo-btn1,
-button.romo-btn.romo-btn1,
-.romo-btn.romo-btn1 { @include font-size1; @include font-weight1; @include button-height1; @include button-pad1; }
-a.romo-btn.romo-btn-large,
-button.romo-btn.romo-btn-large,
-.romo-btn.romo-btn-large,
-a.romo-btn.romo-btn2,
-button.romo-btn.romo-btn2,
-.romo-btn.romo-btn2 { @include font-size2; @include font-weight2; @include button-height2; @include button-pad2; }
-a.romo-btn.romo-btn3,
-button.romo-btn.romo-btn3,
-.romo-btn.romo-btn3 { @include font-size3; @include font-weight3; @include button-height3; @include button-pad3; }
-
-.romo-btn-inline-small,
-.romo-btn-inline0 { @include button-inline0; }
-.romo-btn-inline,
-.romo-btn-inline1 { @include button-inline1; }
-.romo-btn-inline-large,
-.romo-btn-inline2 { @include button-inline2; }
-.romo-btn-inline3 { @include button-inline3; }
-
-input[type="submit"].romo-btn-block,
-input[type="reset"].romo-btn-block,
-input[type="button"].romo-btn-block,
-.romo-btn-block { display: block; width: 100%; }
-
-/* emphasis colored buttons */
-
-a.romo-btn.romo-btn-alt,     button.romo-btn.romo-btn-alt,     .romo-btn.romo-btn-alt     { @include button-bg($btnAltBg,     $btnAltBgHover,     $btnAltColor);     }
-a.romo-btn.romo-btn-inverse, button.romo-btn.romo-btn-inverse, .romo-btn.romo-btn-inverse { @include button-bg($btnInverseBg, $btnInverseBgHover, $btnInverseColor); }
-a.romo-btn.romo-btn-warning, button.romo-btn.romo-btn-warning, .romo-btn.romo-btn-warning { @include button-bg($btnWarningBg, $btnWarningBgHover, $btnWarningColor); }
-a.romo-btn.romo-btn-danger,  button.romo-btn.romo-btn-danger,  .romo-btn.romo-btn-danger  { @include button-bg($btnDangerBg,  $btnDangerBgHover,  $btnDangerColor);  }
-a.romo-btn.romo-btn-info,    button.romo-btn.romo-btn-info,    .romo-btn.romo-btn-info    { @include button-bg($btnInfoBg,    $btnInfoBgHover,    $btnInfoColor);    }
-a.romo-btn.romo-btn-success, button.romo-btn.romo-btn-success, .romo-btn.romo-btn-success { @include button-bg($btnSuccessBg, $btnSuccessBgHover, $btnSuccessColor); }
-
-/* explicit colored buttons */
-
-a.romo-btn.romo-btn-dark-red,      button.romo-btn.romo-btn-dark-red,      .romo-btn.romo-btn-dark-red      { @include button-bg($btnDarkRedBg,      $btnDarkRedBgHover,      $btnDarkRedColor);      }
-a.romo-btn.romo-btn-red,           button.romo-btn.romo-btn-red,           .romo-btn.romo-btn-red           { @include button-bg($btnRedBg,          $btnRedBgHover,          $btnRedColor);          }
-a.romo-btn.romo-btn-light-red,     button.romo-btn.romo-btn-light-red,     .romo-btn.romo-btn-light-red     { @include button-bg($btnLightRedBg,     $btnLightRedBgHover,     $btnLightRedColor);     }
-a.romo-btn.romo-btn-pastel-red,    button.romo-btn.romo-btn-pastel-red,    .romo-btn.romo-btn-pastel-red    { @include button-bg($btnPastelRedBg,    $btnPastelRedBgHover,    $btnPastelRedColor);    }
-a.romo-btn.romo-btn-dark-orange,   button.romo-btn.romo-btn-dark-orange,   .romo-btn.romo-btn-dark-orange   { @include button-bg($btnDarkOrangeBg,   $btnDarkOrangeBgHover,   $btnDarkOrangeColor);   }
-a.romo-btn.romo-btn-orange,        button.romo-btn.romo-btn-orange,        .romo-btn.romo-btn-orange        { @include button-bg($btnOrangeBg,       $btnOrangeBgHover,       $btnOrangeColor);       }
-a.romo-btn.romo-btn-yellow,        button.romo-btn.romo-btn-yellow,        .romo-btn.romo-btn-yellow        { @include button-bg($btnYellowBg,       $btnYellowBgHover,       $btnYellowColor);       }
-a.romo-btn.romo-btn-pastel-yellow, button.romo-btn.romo-btn-pastel-yellow, .romo-btn.romo-btn-pastel-yellow { @include button-bg($btnPastelYellowBg, $btnPastelYellowBgHover, $btnPastelYellowColor); }
-a.romo-btn.romo-btn-purple,        button.romo-btn.romo-btn-purple,        .romo-btn.romo-btn-purple        { @include button-bg($btnPurpleBg,       $btnPurpleBgHover,       $btnPurpleColor);       }
-a.romo-btn.romo-btn-light-purple,  button.romo-btn.romo-btn-light-purple,  .romo-btn.romo-btn-light-purple  { @include button-bg($btnLightPurpleBg,  $btnLightPurpleBgHover,  $btnLightPurpleColor);  }
-a.romo-btn.romo-btn-dark-pink,     button.romo-btn.romo-btn-dark-pink,     .romo-btn.romo-btn-dark-pink     { @include button-bg($btnDarkPinkBg,     $btnDarkPinkBgHover,     $btnDarkPinkColor);     }
-a.romo-btn.romo-btn-hot-pink,      button.romo-btn.romo-btn-hot-pink,      .romo-btn.romo-btn-hot-pink      { @include button-bg($btnHotPinkBg,      $btnHotPinkBgHover,      $btnHotPinkColor);      }
-a.romo-btn.romo-btn-pink,          button.romo-btn.romo-btn-pink,          .romo-btn.romo-btn-pink          { @include button-bg($btnPinkBg,         $btnPinkBgHover,         $btnPinkColor);         }
-a.romo-btn.romo-btn-dark-green,    button.romo-btn.romo-btn-dark-green,    .romo-btn.romo-btn-dark-green    { @include button-bg($btnDarkGreenBg,    $btnDarkGreenBgHover,    $btnDarkGreenColor);    }
-a.romo-btn.romo-btn-green,         button.romo-btn.romo-btn-green,         .romo-btn.romo-btn-green         { @include button-bg($btnGreenBg,        $btnGreenBgHover,        $btnGreenColor);        }
-a.romo-btn.romo-btn-light-green,   button.romo-btn.romo-btn-light-green,   .romo-btn.romo-btn-light-green   { @include button-bg($btnLightGreenBg,   $btnLightGreenBgHover,   $btnLightGreenColor);   }
-a.romo-btn.romo-btn-pastel-green,  button.romo-btn.romo-btn-pastel-green,  .romo-btn.romo-btn-pastel-green  { @include button-bg($btnPastelGreenBg,  $btnPastelGreenBgHover,  $btnPastelGreenColor);  }
-a.romo-btn.romo-btn-navy,          button.romo-btn.romo-btn-navy,          .romo-btn.romo-btn-navy          { @include button-bg($btnNavyBg,         $btnNavyBgHover,         $btnNavyColor);         }
-a.romo-btn.romo-btn-dark-blue,     button.romo-btn.romo-btn-dark-blue,     .romo-btn.romo-btn-dark-blue     { @include button-bg($btnDarkBlueBg,     $btnDarkBlueBgHover,     $btnDarkBlueColor);     }
-a.romo-btn.romo-btn-blue,          button.romo-btn.romo-btn-blue,          .romo-btn.romo-btn-blue          { @include button-bg($btnBlueBg,         $btnBlueBgHover,         $btnBlueColor);         }
-a.romo-btn.romo-btn-light-blue,    button.romo-btn.romo-btn-light-blue,    .romo-btn.romo-btn-light-blue    { @include button-bg($btnLightBlueBg,    $btnLightBlueBgHover,    $btnLightBlueColor);    }
-a.romo-btn.romo-btn-pastel-blue,   button.romo-btn.romo-btn-pastel-blue,   .romo-btn.romo-btn-pastel-blue   { @include button-bg($btnPastelBlueBg,   $btnPastelBlueBgHover,   $btnPastelBlueColor);   }
-
-/* link buttons */
-
-a.romo-btn.romo-btn-link,           button.romo-btn.romo-btn-link,           .romo-btn.romo-btn-link,
-a.romo-btn.romo-btn-link.active,    button.romo-btn.romo-btn-link.active,    .romo-btn.romo-btn-link.active,
-a.romo-btn.romo-btn-link:active,    button.romo-btn.romo-btn-link:active,    .romo-btn.romo-btn-link:active,
-a.romo-btn.romo-btn-link.disabled,  button.romo-btn.romo-btn-link.disabled,  .romo-btn.romo-btn-link.disabled,
-a.romo-btn.romo-btn-link[disabled], button.romo-btn.romo-btn-link[disabled], .romo-btn.romo-btn-link[disabled] {
-  background-color: transparent;
-  background-image: none;
-  @include box-shadow(none);
-}
-
-a.romo-btn.romo-btn-link, button.romo-btn.romo-btn-link { color: $linkColor; }
-
-a.romo-btn.romo-btn-link:hover, button.romo-btn.romo-btn-link:hover,
-a.romo-btn.romo-btn-link:focus, button.romo-btn.romo-btn-link:focus {
-  color: $linkColorHover;
-  text-decoration: underline;
-  background-color: transparent;
-}
-
-a.romo-btn.romo-btn-link.disabled,        button.romo-btn.romo-btn-link.disabled, .romo-btn.romo-btn-link.disabled,
-a.romo-btn.romo-btn-link.disabled:hover,  button.romo-btn.romo-btn-link.disabled:hover, .romo-btn.romo-btn-link.disabled:hover,
-a.romo-btn.romo-btn-link.disabled:focus,  button.romo-btn.romo-btn-link.disabled:focus, .romo-btn.romo-btn-link.disabled:focus,
-a.romo-btn.romo-btn-link[disabled],       button.romo-btn.romo-btn-link[disabled],      .romo-btn.romo-btn-link[disabled],
-a.romo-btn.romo-btn-link[disabled]:hover, button.romo-btn.romo-btn-link[disabled]:hover, .romo-btn.romo-btn-link[disabled]:hover,
-a.romo-btn.romo-btn-link[disabled]:focus, button.romo-btn.romo-btn-link[disabled]:focus, .romo-btn.romo-btn-link[disabled]:focus {
-  color: $disabledColor;
-}
-
-.romo-btn-group { @include display-inline-flex(!important); }
-.romo-btn-group > * { display: inherit; }
-
-.romo-btn-group .romo-btn:not(:last-child) { @include rm-border-right; }
-
-.romo-btn-group.romo-btn-group-border-radius  .romo-btn:first-child,
-.romo-btn-group.romo-btn-group-border1-radius .romo-btn:first-child { @include border1-top-left-radius; @include border1-bottom-left-radius; }
-.romo-btn-group.romo-btn-group-border0-radius .romo-btn:first-child { @include border0-top-left-radius; @include border0-bottom-left-radius; }
-.romo-btn-group.romo-btn-group-border2-radius .romo-btn:first-child { @include border2-top-left-radius; @include border2-bottom-left-radius; }
-
-.romo-btn-group.romo-btn-group-border-radius  .romo-btn:last-child,
-.romo-btn-group.romo-btn-group-border1-radius .romo-btn:last-child { @include border1-top-right-radius; @include border1-bottom-right-radius; }
-.romo-btn-group.romo-btn-group-border0-radius .romo-btn:last-child { @include border0-top-right-radius; @include border0-bottom-right-radius; }
-.romo-btn-group.romo-btn-group-border2-radius .romo-btn:last-child { @include border2-top-right-radius; @include border2-bottom-right-radius; }
-
-.romo-btn-group-vertical                            { display: inline-block; }
-.romo-btn-group-vertical .romo-btn                  { display: block; max-width: 100%; }
-.romo-btn-group-vertical .romo-btn:not(:last-child) { @include rm-border-bottom; }
-
-.romo-btn-group-vertical.romo-btn-group-border-radius  .romo-btn:first-child,
-.romo-btn-group-vertical.romo-btn-group-border1-radius .romo-btn:first-child { @include border1-top-left-radius; @include border1-top-right-radius; }
-.romo-btn-group-vertical.romo-btn-group-border0-radius .romo-btn:first-child { @include border0-top-left-radius; @include border0-top-right-radius; }
-.romo-btn-group-vertical.romo-btn-group-border2-radius .romo-btn:first-child { @include border2-top-left-radius; @include border2-top-right-radius; }
-
-.romo-btn-group-vertical.romo-btn-group-border-radius  .romo-btn:last-child,
-.romo-btn-group-vertical.romo-btn-group-border1-radius .romo-btn:last-child { @include border1-bottom-left-radius; @include border1-bottom-right-radius; }
-.romo-btn-group-vertical.romo-btn-group-border0-radius .romo-btn:last-child { @include border0-bottom-left-radius; @include border0-bottom-right-radius; }
-.romo-btn-group-vertical.romo-btn-group-border2-radius .romo-btn:last-child { @include border2-bottom-left-radius; @include border2-bottom-right-radius; }
-
-.romo-btn-group .romo-btn-group-vertical:not(:last-child) .romo-btn { @include rm-border-right; }
-.romo-btn-group .romo-btn-group-vertical:last-child       .romo-btn { @include border1-right; }
-
-.romo-btn-group.romo-btn-group-border-radius  .romo-btn-group-vertical .romo-btn,
-.romo-btn-group.romo-btn-group-border1-radius .romo-btn-group-vertical .romo-btn { @include rm-border-radius; }
-.romo-btn-group.romo-btn-group-border0-radius .romo-btn-group-vertical .romo-btn { @include rm-border-radius; }
-.romo-btn-group.romo-btn-group-border2-radius .romo-btn-group-vertical .romo-btn { @include rm-border-radius; }
-
-.romo-btn-group.romo-btn-group-border-radius  .romo-btn-group-vertical:first-child .romo-btn:first-child,
-.romo-btn-group.romo-btn-group-border1-radius .romo-btn-group-vertical:first-child .romo-btn:first-child { @include border1-top-left-radius; }
-.romo-btn-group.romo-btn-group-border0-radius .romo-btn-group-vertical:first-child .romo-btn:first-child { @include border0-top-left-radius; }
-.romo-btn-group.romo-btn-group-border2-radius .romo-btn-group-vertical:first-child .romo-btn:first-child { @include border2-top-left-radius; }
-
-.romo-btn-group.romo-btn-group-border-radius  .romo-btn-group-vertical:first-child .romo-btn:last-child,
-.romo-btn-group.romo-btn-group-border1-radius .romo-btn-group-vertical:first-child .romo-btn:last-child { @include border1-bottom-left-radius; }
-.romo-btn-group.romo-btn-group-border0-radius .romo-btn-group-vertical:first-child .romo-btn:last-child { @include border0-bottom-left-radius; }
-.romo-btn-group.romo-btn-group-border2-radius .romo-btn-group-vertical:first-child .romo-btn:last-child { @include border2-bottom-left-radius; }
-
-.romo-btn-group.romo-btn-group-border-radius  .romo-btn-group-vertical:last-child .romo-btn:first-child,
-.romo-btn-group.romo-btn-group-border1-radius .romo-btn-group-vertical:last-child .romo-btn:first-child { @include border1-top-right-radius; }
-.romo-btn-group.romo-btn-group-border0-radius .romo-btn-group-vertical:last-child .romo-btn:first-child { @include border0-top-right-radius; }
-.romo-btn-group.romo-btn-group-border2-radius .romo-btn-group-vertical:last-child .romo-btn:first-child { @include border2-top-right-radius; }
-
-.romo-btn-group.romo-btn-group-border-radius  .romo-btn-group-vertical:last-child .romo-btn:last-child,
-.romo-btn-group.romo-btn-group-border1-radius .romo-btn-group-vertical:last-child .romo-btn:last-child { @include border1-bottom-right-radius; }
-.romo-btn-group.romo-btn-group-border0-radius .romo-btn-group-vertical:last-child .romo-btn:last-child { @include border0-bottom-right-radius; }
-.romo-btn-group.romo-btn-group-border2-radius .romo-btn-group-vertical:last-child .romo-btn:last-child { @include border2-bottom-right-radius; }

--- a/assets/css/romo/colors.scss
+++ b/assets/css/romo/colors.scss
@@ -1,212 +1,216 @@
 @import 'css/romo/vars';
 @import 'css/romo/mixins';
 
-/* basics */
+.romo {
 
-.romo-text-base  { @include text-base(!important);  }
-.romo-text-alt   { @include text-alt(!important);   }
-.romo-text-muted { @include text-muted(!important); }
+  /* basics */
 
-.romo-text-base-hover:hover,  a.romo-text-base:hover,  a.romo-text-base:focus  { @include text-base-hover(!important);  }
-.romo-text-alt-hover:hover,   a.romo-text-alt:hover,   a.romo-text-alt:focus   { @include text-alt-hover(!important);   }
-.romo-text-muted-hover:hover, a.romo-text-muted:hover, a.romo-text-muted:focus { @include text-muted-hover(!important); }
+  .romo-text-base  { @include text-base(!important);  }
+  .romo-text-alt   { @include text-alt(!important);   }
+  .romo-text-muted { @include text-muted(!important); }
 
-.romo-bg-base  { @include bg-base(!important);  }
-.romo-bg-alt   { @include bg-alt(!important);   }
-.romo-bg-muted { @include bg-muted(!important); }
+  .romo-text-base-hover:hover,  a.romo-text-base:hover,  a.romo-text-base:focus  { @include text-base-hover(!important);  }
+  .romo-text-alt-hover:hover,   a.romo-text-alt:hover,   a.romo-text-alt:focus   { @include text-alt-hover(!important);   }
+  .romo-text-muted-hover:hover, a.romo-text-muted:hover, a.romo-text-muted:focus { @include text-muted-hover(!important); }
 
-.romo-bg-base-hover:hover,  a.romo-bg-base:hover,  a.romo-bg-base:focus  { @include bg-base-hover(!important);  }
-.romo-bg-alt-hover:hover,   a.romo-bg-alt:hover,   a.romo-bg-alt:focus   { @include bg-alt-hover(!important);   }
-.romo-bg-muted-hover:hover, a.romo-bg-muted:hover, a.romo-bg-muted:focus { @include bg-muted-hover(!important); }
+  .romo-bg-base  { @include bg-base(!important);  }
+  .romo-bg-alt   { @include bg-alt(!important);   }
+  .romo-bg-muted { @include bg-muted(!important); }
 
-.romo-border-base  { @include border-base(!important);  }
-.romo-border-alt   { @include border-alt(!important);   }
-.romo-border-muted { @include border-muted(!important); }
+  .romo-bg-base-hover:hover,  a.romo-bg-base:hover,  a.romo-bg-base:focus  { @include bg-base-hover(!important);  }
+  .romo-bg-alt-hover:hover,   a.romo-bg-alt:hover,   a.romo-bg-alt:focus   { @include bg-alt-hover(!important);   }
+  .romo-bg-muted-hover:hover, a.romo-bg-muted:hover, a.romo-bg-muted:focus { @include bg-muted-hover(!important); }
 
-.romo-border-muted-hover:hover, a.romo-border-muted:hover, a.romo-border-muted:focus { @include border-muted(!important); }
+  .romo-border-base  { @include border-base(!important);  }
+  .romo-border-alt   { @include border-alt(!important);   }
+  .romo-border-muted { @include border-muted(!important); }
 
-/* other */
+  .romo-border-muted-hover:hover, a.romo-border-muted:hover, a.romo-border-muted:focus { @include border-muted(!important); }
 
-.romo-text-border-base { @include text-border-base(!important); }
-.romo-text-border-alt  { @include text-border-alt(!important);  }
-.romo-text-disabled    { @include text-disabled(!important);    }
+  /* other */
 
-.romo-bg-hover { @include bg-hover(!important); }
+  .romo-text-border-base { @include text-border-base(!important); }
+  .romo-text-border-alt  { @include text-border-alt(!important);  }
+  .romo-text-disabled    { @include text-disabled(!important);    }
 
-/* emphasis */
+  .romo-bg-hover { @include bg-hover(!important); }
 
-.romo-text-warning     { @include text-warning(!important);     }
-.romo-text-danger      { @include text-danger(!important);      }
-.romo-text-info        { @include text-info(!important);        }
-.romo-text-success     { @include text-success(!important);     }
-.romo-text-inverse     { @include text-inverse(!important);     }
+  /* emphasis */
 
-.romo-text-warning-hover:hover, a.romo-text-warning:hover, a.romo-text-warning:focus { @include text-warning-hover(!important); }
-.romo-text-danger-hover:hover,  a.romo-text-danger:hover,  a.romo-text-danger:focus  { @include text-danger-hover(!important);  }
-.romo-text-info-hover:hover,    a.romo-text-info:hover,    a.romo-text-info:focus    { @include text-info-hover(!important);    }
-.romo-text-success-hover:hover, a.romo-text-success:hover, a.romo-text-success:focus { @include text-success-hover(!important); }
-.romo-text-inverse-hover:hover, a.romo-text-inverse:hover, a.romo-text-inverse:focus { @include text-inverse-hover(!important); }
+  .romo-text-warning     { @include text-warning(!important);     }
+  .romo-text-danger      { @include text-danger(!important);      }
+  .romo-text-info        { @include text-info(!important);        }
+  .romo-text-success     { @include text-success(!important);     }
+  .romo-text-inverse     { @include text-inverse(!important);     }
 
-.romo-bg-warning { @include bg-warning(!important); }
-.romo-bg-danger  { @include bg-danger(!important);  }
-.romo-bg-info    { @include bg-info(!important);    }
-.romo-bg-success { @include bg-success(!important); }
-.romo-bg-inverse { @include bg-inverse(!important); }
+  .romo-text-warning-hover:hover, a.romo-text-warning:hover, a.romo-text-warning:focus { @include text-warning-hover(!important); }
+  .romo-text-danger-hover:hover,  a.romo-text-danger:hover,  a.romo-text-danger:focus  { @include text-danger-hover(!important);  }
+  .romo-text-info-hover:hover,    a.romo-text-info:hover,    a.romo-text-info:focus    { @include text-info-hover(!important);    }
+  .romo-text-success-hover:hover, a.romo-text-success:hover, a.romo-text-success:focus { @include text-success-hover(!important); }
+  .romo-text-inverse-hover:hover, a.romo-text-inverse:hover, a.romo-text-inverse:focus { @include text-inverse-hover(!important); }
 
-.romo-bg-warning-hover:hover, a.romo-bg-warning:hover, a.romo-bg-warning:focus { @include bg-warning-hover(!important); }
-.romo-bg-danger-hover:hover,  a.romo-bg-danger:hover,  a.romo-bg-danger:focus  { @include bg-danger-hover(!important);  }
-.romo-bg-info-hover:hover,    a.romo-bg-info:hover,    a.romo-bg-info:focus    { @include bg-info-hover(!important);    }
-.romo-bg-success-hover:hover, a.romo-bg-success:hover, a.romo-bg-success:focus { @include bg-success-hover(!important); }
-.romo-bg-inverse-hover:hover, a.romo-bg-inverse:hover, a.romo-bg-inverse:focus { @include bg-inverse-hover(!important); }
+  .romo-bg-warning { @include bg-warning(!important); }
+  .romo-bg-danger  { @include bg-danger(!important);  }
+  .romo-bg-info    { @include bg-info(!important);    }
+  .romo-bg-success { @include bg-success(!important); }
+  .romo-bg-inverse { @include bg-inverse(!important); }
 
-.romo-border-warning { @include border-warning(!important); }
-.romo-border-danger  { @include border-danger(!important);  }
-.romo-border-info    { @include border-info(!important);    }
-.romo-border-success { @include border-success(!important); }
-.romo-border-inverse { @include border-inverse(!important); }
+  .romo-bg-warning-hover:hover, a.romo-bg-warning:hover, a.romo-bg-warning:focus { @include bg-warning-hover(!important); }
+  .romo-bg-danger-hover:hover,  a.romo-bg-danger:hover,  a.romo-bg-danger:focus  { @include bg-danger-hover(!important);  }
+  .romo-bg-info-hover:hover,    a.romo-bg-info:hover,    a.romo-bg-info:focus    { @include bg-info-hover(!important);    }
+  .romo-bg-success-hover:hover, a.romo-bg-success:hover, a.romo-bg-success:focus { @include bg-success-hover(!important); }
+  .romo-bg-inverse-hover:hover, a.romo-bg-inverse:hover, a.romo-bg-inverse:focus { @include bg-inverse-hover(!important); }
 
-.romo-border-warning-hover:hover, a.romo-border-warning:hover, a.romo-border-warning:focus { @include border-warning(!important); }
-.romo-border-danger-hover:hover,  a.romo-border-danger:hover,  a.romo-border-danger:focus  { @include border-danger(!important);  }
-.romo-border-info-hover:hover,    a.romo-border-info:hover,    a.romo-border-info:focus    { @include border-info(!important);    }
-.romo-border-success-hover:hover, a.romo-border-success:hover, a.romo-border-success:focus { @include border-success(!important); }
-.romo-border-inverse-hover:hover, a.romo-border-inverse:hover, a.romo-border-inverse:focus { @include border-inverse(!important); }
+  .romo-border-warning { @include border-warning(!important); }
+  .romo-border-danger  { @include border-danger(!important);  }
+  .romo-border-info    { @include border-info(!important);    }
+  .romo-border-success { @include border-success(!important); }
+  .romo-border-inverse { @include border-inverse(!important); }
 
-/* emphasis */
+  .romo-border-warning-hover:hover, a.romo-border-warning:hover, a.romo-border-warning:focus { @include border-warning(!important); }
+  .romo-border-danger-hover:hover,  a.romo-border-danger:hover,  a.romo-border-danger:focus  { @include border-danger(!important);  }
+  .romo-border-info-hover:hover,    a.romo-border-info:hover,    a.romo-border-info:focus    { @include border-info(!important);    }
+  .romo-border-success-hover:hover, a.romo-border-success:hover, a.romo-border-success:focus { @include border-success(!important); }
+  .romo-border-inverse-hover:hover, a.romo-border-inverse:hover, a.romo-border-inverse:focus { @include border-inverse(!important); }
 
-.romo-text-dark-red      { @include text-dark-red(!important);      }
-.romo-text-red           { @include text-red(!important);           }
-.romo-text-light-red     { @include text-light-red(!important);     }
-.romo-text-pastel-red    { @include text-pastel-red(!important);    }
-.romo-text-dark-orange   { @include text-dark-orange(!important);   }
-.romo-text-orange        { @include text-orange(!important);        }
-.romo-text-yellow        { @include text-yellow(!important);        }
-.romo-text-pastel-yellow { @include text-pastel-yellow(!important); }
-.romo-text-purple        { @include text-purple(!important);        }
-.romo-text-light-purple  { @include text-light-purple(!important);  }
-.romo-text-dark-pink     { @include text-dark-pink(!important);     }
-.romo-text-hot-pink      { @include text-hot-pink(!important);      }
-.romo-text-pink          { @include text-pink(!important);          }
-.romo-text-dark-green    { @include text-dark-green(!important);    }
-.romo-text-green         { @include text-green(!important);         }
-.romo-text-light-green   { @include text-light-green(!important);   }
-.romo-text-pastel-green  { @include text-pastel-green(!important);  }
-.romo-text-navy          { @include text-navy(!important);          }
-.romo-text-dark-blue     { @include text-dark-blue(!important);     }
-.romo-text-blue          { @include text-blue(!important);          }
-.romo-text-light-blue    { @include text-light-blue(!important);    }
-.romo-text-pastel-blue   { @include text-pastel-blue(!important);   }
+  /* emphasis */
 
-.romo-text-dark-red-hover:hover,      a.romo-text-dark-red:hover,      a.romo-text-dark-red:focus      { @include text-dark-red-hover(!important);      }
-.romo-text-red-hover:hover,           a.romo-text-red:hover,           a.romo-text-red:focus           { @include text-red-hover(!important);           }
-.romo-text-light-red-hover:hover,     a.romo-text-light-red:hover,     a.romo-text-light-red:focus     { @include text-light-red-hover(!important);     }
-.romo-text-pastel-red-hover:hover,    a.romo-text-pastel-red:hover,    a.romo-text-pastel-red:focus    { @include text-pastel-red-hover(!important);    }
-.romo-text-dark-orange-hover:hover,   a.romo-text-dark-orange:hover,   a.romo-text-dark-orange:focus   { @include text-dark-orange-hover(!important);   }
-.romo-text-orange-hover:hover,        a.romo-text-orange:hover,        a.romo-text-orange:focus        { @include text-orange-hover(!important);        }
-.romo-text-yellow-hover:hover,        a.romo-text-yellow:hover,        a.romo-text-yellow:focus        { @include text-yellow-hover(!important);        }
-.romo-text-pastel-yellow-hover:hover, a.romo-text-pastel-yellow:hover, a.romo-text-pastel-yellow:focus { @include text-pastel-yellow-hover(!important); }
-.romo-text-purple-hover:hover,        a.romo-text-purple:hover,        a.romo-text-purple:focus        { @include text-purple-hover(!important);        }
-.romo-text-light-purple-hover:hover,  a.romo-text-light-purple:hover,  a.romo-text-light-purple:focus  { @include text-light-purple-hover(!important);  }
-.romo-text-dark-pink-hover:hover,     a.romo-text-dark-pink:hover,     a.romo-text-dark-pink:focus     { @include text-dark-pink-hover(!important);     }
-.romo-text-hot-pink-hover:hover,      a.romo-text-hot-pink:hover,      a.romo-text-hot-pink:focus      { @include text-hot-pink-hover(!important);      }
-.romo-text-pink-hover:hover,          a.romo-text-pink:hover,          a.romo-text-pink:focus          { @include text-pink-hover(!important);          }
-.romo-text-dark-green-hover:hover,    a.romo-text-dark-green:hover,    a.romo-text-dark-green:focus    { @include text-dark-green-hover(!important);    }
-.romo-text-green-hover:hover,         a.romo-text-green:hover,         a.romo-text-green:focus         { @include text-green-hover(!important);         }
-.romo-text-light-green-hover:hover,   a.romo-text-light-green:hover,   a.romo-text-light-green:focus   { @include text-light-green-hover(!important);   }
-.romo-text-pastel-green-hover:hover,  a.romo-text-pastel-green:hover,  a.romo-text-pastel-green:focus  { @include text-pastel-green-hover(!important);  }
-.romo-text-navy-hover:hover,          a.romo-text-navy:hover,          a.romo-text-navy:focus          { @include text-navy-hover(!important);          }
-.romo-text-dark-blue-hover:hover,     a.romo-text-dark-blue:hover,     a.romo-text-dark-blue:focus     { @include text-dark-blue-hover(!important);     }
-.romo-text-blue-hover:hover,          a.romo-text-blue:hover,          a.romo-text-blue:focus          { @include text-blue-hover(!important);          }
-.romo-text-light-blue-hover:hover,    a.romo-text-light-blue:hover,    a.romo-text-light-blue:focus    { @include text-light-blue-hover(!important);    }
-.romo-text-pastel-blue-hover:hover,   a.romo-text-pastel-blue:hover,   a.romo-text-pastel-blue:focus   { @include text-pastel-blue-hover(!important);   }
+  .romo-text-dark-red      { @include text-dark-red(!important);      }
+  .romo-text-red           { @include text-red(!important);           }
+  .romo-text-light-red     { @include text-light-red(!important);     }
+  .romo-text-pastel-red    { @include text-pastel-red(!important);    }
+  .romo-text-dark-orange   { @include text-dark-orange(!important);   }
+  .romo-text-orange        { @include text-orange(!important);        }
+  .romo-text-yellow        { @include text-yellow(!important);        }
+  .romo-text-pastel-yellow { @include text-pastel-yellow(!important); }
+  .romo-text-purple        { @include text-purple(!important);        }
+  .romo-text-light-purple  { @include text-light-purple(!important);  }
+  .romo-text-dark-pink     { @include text-dark-pink(!important);     }
+  .romo-text-hot-pink      { @include text-hot-pink(!important);      }
+  .romo-text-pink          { @include text-pink(!important);          }
+  .romo-text-dark-green    { @include text-dark-green(!important);    }
+  .romo-text-green         { @include text-green(!important);         }
+  .romo-text-light-green   { @include text-light-green(!important);   }
+  .romo-text-pastel-green  { @include text-pastel-green(!important);  }
+  .romo-text-navy          { @include text-navy(!important);          }
+  .romo-text-dark-blue     { @include text-dark-blue(!important);     }
+  .romo-text-blue          { @include text-blue(!important);          }
+  .romo-text-light-blue    { @include text-light-blue(!important);    }
+  .romo-text-pastel-blue   { @include text-pastel-blue(!important);   }
 
-.romo-bg-dark-red      { @include bg-dark-red(!important);      }
-.romo-bg-red           { @include bg-red(!important);           }
-.romo-bg-light-red     { @include bg-light-red(!important);     }
-.romo-bg-pastel-red    { @include bg-pastel-red(!important);    }
-.romo-bg-dark-orange   { @include bg-dark-orange(!important);   }
-.romo-bg-orange        { @include bg-orange(!important);        }
-.romo-bg-yellow        { @include bg-yellow(!important);        }
-.romo-bg-pastel-yellow { @include bg-pastel-yellow(!important); }
-.romo-bg-purple        { @include bg-purple(!important);        }
-.romo-bg-light-purple  { @include bg-light-purple(!important);  }
-.romo-bg-dark-pink     { @include bg-dark-pink(!important);     }
-.romo-bg-hot-pink      { @include bg-hot-pink(!important);      }
-.romo-bg-pink          { @include bg-pink(!important);          }
-.romo-bg-dark-green    { @include bg-dark-green(!important);    }
-.romo-bg-green         { @include bg-green(!important);         }
-.romo-bg-light-green   { @include bg-light-green(!important);   }
-.romo-bg-pastel-green  { @include bg-pastel-green(!important);  }
-.romo-bg-navy          { @include bg-navy(!important);          }
-.romo-bg-dark-blue     { @include bg-dark-blue(!important);     }
-.romo-bg-blue          { @include bg-blue(!important);          }
-.romo-bg-light-blue    { @include bg-light-blue(!important);    }
-.romo-bg-pastel-blue   { @include bg-pastel-blue(!important);   }
+  .romo-text-dark-red-hover:hover,      a.romo-text-dark-red:hover,      a.romo-text-dark-red:focus      { @include text-dark-red-hover(!important);      }
+  .romo-text-red-hover:hover,           a.romo-text-red:hover,           a.romo-text-red:focus           { @include text-red-hover(!important);           }
+  .romo-text-light-red-hover:hover,     a.romo-text-light-red:hover,     a.romo-text-light-red:focus     { @include text-light-red-hover(!important);     }
+  .romo-text-pastel-red-hover:hover,    a.romo-text-pastel-red:hover,    a.romo-text-pastel-red:focus    { @include text-pastel-red-hover(!important);    }
+  .romo-text-dark-orange-hover:hover,   a.romo-text-dark-orange:hover,   a.romo-text-dark-orange:focus   { @include text-dark-orange-hover(!important);   }
+  .romo-text-orange-hover:hover,        a.romo-text-orange:hover,        a.romo-text-orange:focus        { @include text-orange-hover(!important);        }
+  .romo-text-yellow-hover:hover,        a.romo-text-yellow:hover,        a.romo-text-yellow:focus        { @include text-yellow-hover(!important);        }
+  .romo-text-pastel-yellow-hover:hover, a.romo-text-pastel-yellow:hover, a.romo-text-pastel-yellow:focus { @include text-pastel-yellow-hover(!important); }
+  .romo-text-purple-hover:hover,        a.romo-text-purple:hover,        a.romo-text-purple:focus        { @include text-purple-hover(!important);        }
+  .romo-text-light-purple-hover:hover,  a.romo-text-light-purple:hover,  a.romo-text-light-purple:focus  { @include text-light-purple-hover(!important);  }
+  .romo-text-dark-pink-hover:hover,     a.romo-text-dark-pink:hover,     a.romo-text-dark-pink:focus     { @include text-dark-pink-hover(!important);     }
+  .romo-text-hot-pink-hover:hover,      a.romo-text-hot-pink:hover,      a.romo-text-hot-pink:focus      { @include text-hot-pink-hover(!important);      }
+  .romo-text-pink-hover:hover,          a.romo-text-pink:hover,          a.romo-text-pink:focus          { @include text-pink-hover(!important);          }
+  .romo-text-dark-green-hover:hover,    a.romo-text-dark-green:hover,    a.romo-text-dark-green:focus    { @include text-dark-green-hover(!important);    }
+  .romo-text-green-hover:hover,         a.romo-text-green:hover,         a.romo-text-green:focus         { @include text-green-hover(!important);         }
+  .romo-text-light-green-hover:hover,   a.romo-text-light-green:hover,   a.romo-text-light-green:focus   { @include text-light-green-hover(!important);   }
+  .romo-text-pastel-green-hover:hover,  a.romo-text-pastel-green:hover,  a.romo-text-pastel-green:focus  { @include text-pastel-green-hover(!important);  }
+  .romo-text-navy-hover:hover,          a.romo-text-navy:hover,          a.romo-text-navy:focus          { @include text-navy-hover(!important);          }
+  .romo-text-dark-blue-hover:hover,     a.romo-text-dark-blue:hover,     a.romo-text-dark-blue:focus     { @include text-dark-blue-hover(!important);     }
+  .romo-text-blue-hover:hover,          a.romo-text-blue:hover,          a.romo-text-blue:focus          { @include text-blue-hover(!important);          }
+  .romo-text-light-blue-hover:hover,    a.romo-text-light-blue:hover,    a.romo-text-light-blue:focus    { @include text-light-blue-hover(!important);    }
+  .romo-text-pastel-blue-hover:hover,   a.romo-text-pastel-blue:hover,   a.romo-text-pastel-blue:focus   { @include text-pastel-blue-hover(!important);   }
 
-.romo-bg-dark-red-hover:hover,      a.romo-bg-dark-red-hover:hover,      a.romo-bg-dark-red-hover:focus      { @include bg-dark-red-hover(!important);      }
-.romo-bg-red-hover:hover,           a.romo-bg-red-hover:hover,           a.romo-bg-red-hover:focus           { @include bg-red-hover(!important);           }
-.romo-bg-light-red-hover:hover,     a.romo-bg-light-red-hover:hover,     a.romo-bg-light-red-hover:focus     { @include bg-light-red-hover(!important);     }
-.romo-bg-pastel-red-hover:hover,    a.romo-bg-pastel-red-hover:hover,    a.romo-bg-pastel-red-hover:focus    { @include bg-pastel-red-hover(!important);    }
-.romo-bg-dark-orange-hover:hover,   a.romo-bg-dark-orange-hover:hover,   a.romo-bg-dark-orange-hover:focus   { @include bg-dark-orange-hover(!important);   }
-.romo-bg-orange-hover:hover,        a.romo-bg-orange-hover:hover,        a.romo-bg-orange-hover:focus        { @include bg-orange-hover(!important);        }
-.romo-bg-yellow-hover:hover,        a.romo-bg-yellow-hover:hover,        a.romo-bg-yellow-hover:focus        { @include bg-yellow-hover(!important);        }
-.romo-bg-pastel-yellow-hover:hover, a.romo-bg-pastel-yellow-hover:hover, a.romo-bg-pastel-yellow-hover:focus { @include bg-pastel-yellow-hover(!important); }
-.romo-bg-purple-hover:hover,        a.romo-bg-purple-hover:hover,        a.romo-bg-purple-hover:focus        { @include bg-purple-hover(!important);        }
-.romo-bg-light-purple-hover:hover,  a.romo-bg-light-purple-hover:hover,  a.romo-bg-light-purple-hover:focus  { @include bg-light-purple-hover(!important);  }
-.romo-bg-dark-pink-hover:hover,     a.romo-bg-dark-pink-hover:hover,     a.romo-bg-dark-pink-hover:focus     { @include bg-dark-pink-hover(!important);     }
-.romo-bg-hot-pink-hover:hover,      a.romo-bg-hot-pink-hover:hover,      a.romo-bg-hot-pink-hover:focus      { @include bg-hot-pink-hover(!important);      }
-.romo-bg-pink-hover:hover,          a.romo-bg-pink-hover:hover,          a.romo-bg-pink-hover:focus          { @include bg-pink-hover(!important);          }
-.romo-bg-dark-green-hover:hover,    a.romo-bg-dark-green-hover:hover,    a.romo-bg-dark-green-hover:focus    { @include bg-dark-green-hover(!important);    }
-.romo-bg-green-hover:hover,         a.romo-bg-green-hover:hover,         a.romo-bg-green-hover:focus         { @include bg-green-hover(!important);         }
-.romo-bg-light-green-hover:hover,   a.romo-bg-light-green-hover:hover,   a.romo-bg-light-green-hover:focus   { @include bg-light-green-hover(!important);   }
-.romo-bg-pastel-green-hover:hover,  a.romo-bg-pastel-green-hover:hover,  a.romo-bg-pastel-green-hover:focus  { @include bg-pastel-green-hover(!important);  }
-.romo-bg-navy-hover:hover,          a.romo-bg-navy-hover:hover,          a.romo-bg-navy-hover:focus          { @include bg-navy-hover(!important);          }
-.romo-bg-dark-blue-hover:hover,     a.romo-bg-dark-blue-hover:hover,     a.romo-bg-dark-blue-hover:focus     { @include bg-dark-blue-hover(!important);     }
-.romo-bg-blue-hover:hover,          a.romo-bg-blue-hover:hover,          a.romo-bg-blue-hover:focus          { @include bg-blue-hover(!important);          }
-.romo-bg-light-blue-hover:hover,    a.romo-bg-light-blue-hover:hover,    a.romo-bg-light-blue-hover:focus    { @include bg-light-blue-hover(!important);    }
-.romo-bg-pastel-blue-hover:hover,   a.romo-bg-pastel-blue-hover:hover,   a.romo-bg-pastel-blue-hover:focus   { @include bg-pastel-blue-hover(!important);   }
+  .romo-bg-dark-red      { @include bg-dark-red(!important);      }
+  .romo-bg-red           { @include bg-red(!important);           }
+  .romo-bg-light-red     { @include bg-light-red(!important);     }
+  .romo-bg-pastel-red    { @include bg-pastel-red(!important);    }
+  .romo-bg-dark-orange   { @include bg-dark-orange(!important);   }
+  .romo-bg-orange        { @include bg-orange(!important);        }
+  .romo-bg-yellow        { @include bg-yellow(!important);        }
+  .romo-bg-pastel-yellow { @include bg-pastel-yellow(!important); }
+  .romo-bg-purple        { @include bg-purple(!important);        }
+  .romo-bg-light-purple  { @include bg-light-purple(!important);  }
+  .romo-bg-dark-pink     { @include bg-dark-pink(!important);     }
+  .romo-bg-hot-pink      { @include bg-hot-pink(!important);      }
+  .romo-bg-pink          { @include bg-pink(!important);          }
+  .romo-bg-dark-green    { @include bg-dark-green(!important);    }
+  .romo-bg-green         { @include bg-green(!important);         }
+  .romo-bg-light-green   { @include bg-light-green(!important);   }
+  .romo-bg-pastel-green  { @include bg-pastel-green(!important);  }
+  .romo-bg-navy          { @include bg-navy(!important);          }
+  .romo-bg-dark-blue     { @include bg-dark-blue(!important);     }
+  .romo-bg-blue          { @include bg-blue(!important);          }
+  .romo-bg-light-blue    { @include bg-light-blue(!important);    }
+  .romo-bg-pastel-blue   { @include bg-pastel-blue(!important);   }
 
-.romo-border-dark-red      { @include border-dark-red(!important);      }
-.romo-border-red           { @include border-red(!important);           }
-.romo-border-light-red     { @include border-light-red(!important);     }
-.romo-border-pastel-red    { @include border-pastel-red(!important);    }
-.romo-border-dark-orange   { @include border-dark-orange(!important);   }
-.romo-border-orange        { @include border-orange(!important);        }
-.romo-border-yellow        { @include border-yellow(!important);        }
-.romo-border-pastel-yellow { @include border-pastel-yellow(!important); }
-.romo-border-purple        { @include border-purple(!important);        }
-.romo-border-light-purple  { @include border-light-purple(!important);  }
-.romo-border-dark-pink     { @include border-dark-pink(!important);     }
-.romo-border-hot-pink      { @include border-hot-pink(!important);      }
-.romo-border-pink          { @include border-pink(!important);          }
-.romo-border-dark-green    { @include border-dark-green(!important);    }
-.romo-border-pastel-green  { @include border-pastel-green(!important);  }
-.romo-border-green         { @include border-green(!important);         }
-.romo-border-light-green   { @include border-light-green(!important);   }
-.romo-border-navy          { @include border-navy(!important);          }
-.romo-border-dark-blue     { @include border-dark-blue(!important);     }
-.romo-border-blue          { @include border-blue(!important);          }
-.romo-border-light-blue    { @include border-light-blue(!important);    }
-.romo-border-pastel-blue   { @include border-pastel-blue(!important);   }
+  .romo-bg-dark-red-hover:hover,      a.romo-bg-dark-red-hover:hover,      a.romo-bg-dark-red-hover:focus      { @include bg-dark-red-hover(!important);      }
+  .romo-bg-red-hover:hover,           a.romo-bg-red-hover:hover,           a.romo-bg-red-hover:focus           { @include bg-red-hover(!important);           }
+  .romo-bg-light-red-hover:hover,     a.romo-bg-light-red-hover:hover,     a.romo-bg-light-red-hover:focus     { @include bg-light-red-hover(!important);     }
+  .romo-bg-pastel-red-hover:hover,    a.romo-bg-pastel-red-hover:hover,    a.romo-bg-pastel-red-hover:focus    { @include bg-pastel-red-hover(!important);    }
+  .romo-bg-dark-orange-hover:hover,   a.romo-bg-dark-orange-hover:hover,   a.romo-bg-dark-orange-hover:focus   { @include bg-dark-orange-hover(!important);   }
+  .romo-bg-orange-hover:hover,        a.romo-bg-orange-hover:hover,        a.romo-bg-orange-hover:focus        { @include bg-orange-hover(!important);        }
+  .romo-bg-yellow-hover:hover,        a.romo-bg-yellow-hover:hover,        a.romo-bg-yellow-hover:focus        { @include bg-yellow-hover(!important);        }
+  .romo-bg-pastel-yellow-hover:hover, a.romo-bg-pastel-yellow-hover:hover, a.romo-bg-pastel-yellow-hover:focus { @include bg-pastel-yellow-hover(!important); }
+  .romo-bg-purple-hover:hover,        a.romo-bg-purple-hover:hover,        a.romo-bg-purple-hover:focus        { @include bg-purple-hover(!important);        }
+  .romo-bg-light-purple-hover:hover,  a.romo-bg-light-purple-hover:hover,  a.romo-bg-light-purple-hover:focus  { @include bg-light-purple-hover(!important);  }
+  .romo-bg-dark-pink-hover:hover,     a.romo-bg-dark-pink-hover:hover,     a.romo-bg-dark-pink-hover:focus     { @include bg-dark-pink-hover(!important);     }
+  .romo-bg-hot-pink-hover:hover,      a.romo-bg-hot-pink-hover:hover,      a.romo-bg-hot-pink-hover:focus      { @include bg-hot-pink-hover(!important);      }
+  .romo-bg-pink-hover:hover,          a.romo-bg-pink-hover:hover,          a.romo-bg-pink-hover:focus          { @include bg-pink-hover(!important);          }
+  .romo-bg-dark-green-hover:hover,    a.romo-bg-dark-green-hover:hover,    a.romo-bg-dark-green-hover:focus    { @include bg-dark-green-hover(!important);    }
+  .romo-bg-green-hover:hover,         a.romo-bg-green-hover:hover,         a.romo-bg-green-hover:focus         { @include bg-green-hover(!important);         }
+  .romo-bg-light-green-hover:hover,   a.romo-bg-light-green-hover:hover,   a.romo-bg-light-green-hover:focus   { @include bg-light-green-hover(!important);   }
+  .romo-bg-pastel-green-hover:hover,  a.romo-bg-pastel-green-hover:hover,  a.romo-bg-pastel-green-hover:focus  { @include bg-pastel-green-hover(!important);  }
+  .romo-bg-navy-hover:hover,          a.romo-bg-navy-hover:hover,          a.romo-bg-navy-hover:focus          { @include bg-navy-hover(!important);          }
+  .romo-bg-dark-blue-hover:hover,     a.romo-bg-dark-blue-hover:hover,     a.romo-bg-dark-blue-hover:focus     { @include bg-dark-blue-hover(!important);     }
+  .romo-bg-blue-hover:hover,          a.romo-bg-blue-hover:hover,          a.romo-bg-blue-hover:focus          { @include bg-blue-hover(!important);          }
+  .romo-bg-light-blue-hover:hover,    a.romo-bg-light-blue-hover:hover,    a.romo-bg-light-blue-hover:focus    { @include bg-light-blue-hover(!important);    }
+  .romo-bg-pastel-blue-hover:hover,   a.romo-bg-pastel-blue-hover:hover,   a.romo-bg-pastel-blue-hover:focus   { @include bg-pastel-blue-hover(!important);   }
 
-.romo-border-dark-red-hover:hover,      a.romo-border-dark-red-hover:hover,      a.romo-border-dark-red-hover:focus      { @include border-dark-red(!important);      }
-.romo-border-red-hover:hover,           a.romo-border-red-hover:hover,           a.romo-border-red-hover:focus           { @include border-red(!important);           }
-.romo-border-light-red-hover:hover,     a.romo-border-light-red-hover:hover,     a.romo-border-light-red-hover:focus     { @include border-light-red(!important);     }
-.romo-border-pastel-red-hover:hover,    a.romo-border-pastel-red-hover:hover,    a.romo-border-pastel-red-hover:focus    { @include border-pastel-red(!important);    }
-.romo-border-dark-orange-hover:hover,   a.romo-border-dark-orange-hover:hover,   a.romo-border-dark-orange-hover:focus   { @include border-dark-orange(!important);   }
-.romo-border-orange-hover:hover,        a.romo-border-orange-hover:hover,        a.romo-border-orange-hover:focus        { @include border-orange(!important);        }
-.romo-border-yellow-hover:hover,        a.romo-border-yellow-hover:hover,        a.romo-border-yellow-hover:focus        { @include border-yellow(!important);        }
-.romo-border-pastel-yellow-hover:hover, a.romo-border-pastel-yellow-hover:hover, a.romo-border-pastel-yellow-hover:focus { @include border-pastel-yellow(!important); }
-.romo-border-purple-hover:hover,        a.romo-border-purple-hover:hover,        a.romo-border-purple-hover:focus        { @include border-purple(!important);        }
-.romo-border-light-purple-hover:hover,  a.romo-border-light-purple-hover:hover,  a.romo-border-light-purple-hover:focus  { @include border-light-purple(!important);  }
-.romo-border-dark-pink-hover:hover,     a.romo-border-dark-pink-hover:hover,     a.romo-border-dark-pink-hover:focus     { @include border-dark-pink(!important);     }
-.romo-border-hot-pink-hover:hover,      a.romo-border-hot-pink-hover:hover,      a.romo-border-hot-pink-hover:focus      { @include border-hot-pink(!important);      }
-.romo-border-pink-hover:hover,          a.romo-border-pink-hover:hover,          a.romo-border-pink-hover:focus          { @include border-pink(!important);          }
-.romo-border-dark-green-hover:hover,    a.romo-border-dark-green-hover:hover,    a.romo-border-dark-green-hover:focus    { @include border-dark-green(!important);    }
-.romo-border-green-hover:hover,         a.romo-border-green-hover:hover,         a.romo-border-green-hover:focus         { @include border-green(!important);         }
-.romo-border-light-green-hover:hover,   a.romo-border-light-green-hover:hover,   a.romo-border-light-green-hover:focus   { @include border-light-green(!important);   }
-.romo-border-pastel-green-hover:hover,  a.romo-border-pastel-green-hover:hover,  a.romo-border-pastel-green-hover:focus  { @include border-pastel-green(!important);  }
-.romo-border-navy-hover:hover,          a.romo-border-navy-hover:hover,          a.romo-border-navy-hover:focus          { @include border-navy(!important);          }
-.romo-border-dark-blue-hover:hover,     a.romo-border-dark-blue-hover:hover,     a.romo-border-dark-blue-hover:focus     { @include border-dark-blue(!important);     }
-.romo-border-blue-hover:hover,          a.romo-border-blue-hover:hover,          a.romo-border-blue-hover:focus          { @include border-blue(!important);          }
-.romo-border-light-blue-hover:hover,    a.romo-border-light-blue-hover:hover,    a.romo-border-light-blue-hover:focus    { @include border-light-blue(!important);    }
-.romo-border-pastel-blue-hover:hover,   a.romo-border-pastel-blue-hover:hover,   a.romo-border-pastel-blue-hover:focus   { @include border-pastel-blue(!important);   }
+  .romo-border-dark-red      { @include border-dark-red(!important);      }
+  .romo-border-red           { @include border-red(!important);           }
+  .romo-border-light-red     { @include border-light-red(!important);     }
+  .romo-border-pastel-red    { @include border-pastel-red(!important);    }
+  .romo-border-dark-orange   { @include border-dark-orange(!important);   }
+  .romo-border-orange        { @include border-orange(!important);        }
+  .romo-border-yellow        { @include border-yellow(!important);        }
+  .romo-border-pastel-yellow { @include border-pastel-yellow(!important); }
+  .romo-border-purple        { @include border-purple(!important);        }
+  .romo-border-light-purple  { @include border-light-purple(!important);  }
+  .romo-border-dark-pink     { @include border-dark-pink(!important);     }
+  .romo-border-hot-pink      { @include border-hot-pink(!important);      }
+  .romo-border-pink          { @include border-pink(!important);          }
+  .romo-border-dark-green    { @include border-dark-green(!important);    }
+  .romo-border-pastel-green  { @include border-pastel-green(!important);  }
+  .romo-border-green         { @include border-green(!important);         }
+  .romo-border-light-green   { @include border-light-green(!important);   }
+  .romo-border-navy          { @include border-navy(!important);          }
+  .romo-border-dark-blue     { @include border-dark-blue(!important);     }
+  .romo-border-blue          { @include border-blue(!important);          }
+  .romo-border-light-blue    { @include border-light-blue(!important);    }
+  .romo-border-pastel-blue   { @include border-pastel-blue(!important);   }
+
+  .romo-border-dark-red-hover:hover,      a.romo-border-dark-red-hover:hover,      a.romo-border-dark-red-hover:focus      { @include border-dark-red(!important);      }
+  .romo-border-red-hover:hover,           a.romo-border-red-hover:hover,           a.romo-border-red-hover:focus           { @include border-red(!important);           }
+  .romo-border-light-red-hover:hover,     a.romo-border-light-red-hover:hover,     a.romo-border-light-red-hover:focus     { @include border-light-red(!important);     }
+  .romo-border-pastel-red-hover:hover,    a.romo-border-pastel-red-hover:hover,    a.romo-border-pastel-red-hover:focus    { @include border-pastel-red(!important);    }
+  .romo-border-dark-orange-hover:hover,   a.romo-border-dark-orange-hover:hover,   a.romo-border-dark-orange-hover:focus   { @include border-dark-orange(!important);   }
+  .romo-border-orange-hover:hover,        a.romo-border-orange-hover:hover,        a.romo-border-orange-hover:focus        { @include border-orange(!important);        }
+  .romo-border-yellow-hover:hover,        a.romo-border-yellow-hover:hover,        a.romo-border-yellow-hover:focus        { @include border-yellow(!important);        }
+  .romo-border-pastel-yellow-hover:hover, a.romo-border-pastel-yellow-hover:hover, a.romo-border-pastel-yellow-hover:focus { @include border-pastel-yellow(!important); }
+  .romo-border-purple-hover:hover,        a.romo-border-purple-hover:hover,        a.romo-border-purple-hover:focus        { @include border-purple(!important);        }
+  .romo-border-light-purple-hover:hover,  a.romo-border-light-purple-hover:hover,  a.romo-border-light-purple-hover:focus  { @include border-light-purple(!important);  }
+  .romo-border-dark-pink-hover:hover,     a.romo-border-dark-pink-hover:hover,     a.romo-border-dark-pink-hover:focus     { @include border-dark-pink(!important);     }
+  .romo-border-hot-pink-hover:hover,      a.romo-border-hot-pink-hover:hover,      a.romo-border-hot-pink-hover:focus      { @include border-hot-pink(!important);      }
+  .romo-border-pink-hover:hover,          a.romo-border-pink-hover:hover,          a.romo-border-pink-hover:focus          { @include border-pink(!important);          }
+  .romo-border-dark-green-hover:hover,    a.romo-border-dark-green-hover:hover,    a.romo-border-dark-green-hover:focus    { @include border-dark-green(!important);    }
+  .romo-border-green-hover:hover,         a.romo-border-green-hover:hover,         a.romo-border-green-hover:focus         { @include border-green(!important);         }
+  .romo-border-light-green-hover:hover,   a.romo-border-light-green-hover:hover,   a.romo-border-light-green-hover:focus   { @include border-light-green(!important);   }
+  .romo-border-pastel-green-hover:hover,  a.romo-border-pastel-green-hover:hover,  a.romo-border-pastel-green-hover:focus  { @include border-pastel-green(!important);  }
+  .romo-border-navy-hover:hover,          a.romo-border-navy-hover:hover,          a.romo-border-navy-hover:focus          { @include border-navy(!important);          }
+  .romo-border-dark-blue-hover:hover,     a.romo-border-dark-blue-hover:hover,     a.romo-border-dark-blue-hover:focus     { @include border-dark-blue(!important);     }
+  .romo-border-blue-hover:hover,          a.romo-border-blue-hover:hover,          a.romo-border-blue-hover:focus          { @include border-blue(!important);          }
+  .romo-border-light-blue-hover:hover,    a.romo-border-light-blue-hover:hover,    a.romo-border-light-blue-hover:focus    { @include border-light-blue(!important);    }
+  .romo-border-pastel-blue-hover:hover,   a.romo-border-pastel-blue-hover:hover,   a.romo-border-pastel-blue-hover:focus   { @include border-pastel-blue(!important);   }
+
+}

--- a/assets/css/romo/datepicker.scss
+++ b/assets/css/romo/datepicker.scss
@@ -1,74 +1,78 @@
 @import 'css/romo/vars';
 @import 'css/romo/mixins';
 
-.romo-datepicker-wrapper {
-  position: relative;
-}
+.romo {
 
-.romo-datepicker-indicator {
-  display: inline-block;
-  position: absolute;
-  right: 6px;
-  vertical-align: middle;
-  cursor: pointer;
-}
-.romo-datepicker-indicator.disabled {
-  cursor: $notAllowedCursor;
-  color: $disabledColor;
-}
+  .romo-datepicker-wrapper {
+    position: relative;
+  }
 
-.romo-datepicker-calendar {
-  padding: $spacingSize0;
-  @include user-select(none);
+  .romo-datepicker-indicator {
+    display: inline-block;
+    position: absolute;
+    right: 6px;
+    vertical-align: middle;
+    cursor: pointer;
+  }
+  .romo-datepicker-indicator.disabled {
+    cursor: $notAllowedCursor;
+    color: $disabledColor;
+  }
 
-  background-color: $inputBgColor;
-  color: $inputColor;
-}
+  .romo-datepicker-calendar {
+    padding: $spacingSize0;
+    @include user-select(none);
 
-.romo-datepicker-calendar table {
-  background-color: transparent;
-  border-collapse: collapse;
-  border-spacing: 0;
-  width: 100%;
-}
+    background-color: $inputBgColor;
+    color: $inputColor;
+  }
 
-.romo-datepicker-calendar th,
-.romo-datepicker-calendar td {
-  width: 14.285714286%; /* 100% / 7 */
-  text-align: center;
-}
+  .romo-datepicker-calendar table {
+    background-color: transparent;
+    border-collapse: collapse;
+    border-spacing: 0;
+    width: 100%;
+  }
 
-.romo-datepicker-calendar .romo-datepicker-prev,
-.romo-datepicker-calendar .romo-datepicker-next,
-.romo-datepicker-calendar TD.romo-datepicker-day:not(.disabled) {
-  cursor: pointer;
-}
+  .romo-datepicker-calendar th,
+  .romo-datepicker-calendar td {
+    width: 14.285714286%; /* 100% / 7 */
+    text-align: center;
+  }
 
-.romo-datepicker-calendar TD.romo-datepicker-day-weekend {
-  background: $altBgColor;
-}
+  .romo-datepicker-calendar .romo-datepicker-prev,
+  .romo-datepicker-calendar .romo-datepicker-next,
+  .romo-datepicker-calendar TD.romo-datepicker-day:not(.disabled) {
+    cursor: pointer;
+  }
 
-.romo-datepicker-calendar .romo-datepicker-prev:hover,
-.romo-datepicker-calendar .romo-datepicker-next:hover,
-.romo-datepicker-calendar TD.romo-datepicker-day.romo-datepicker-highlight:not(.disabled) {
-  background: darken($altBgColor, 10%);
-}
+  .romo-datepicker-calendar TD.romo-datepicker-day-weekend {
+    background: $altBgColor;
+  }
 
-.romo-datepicker-calendar TD.romo-datepicker-day.disabled {
-  cursor: $notAllowedCursor;
-  color: $disabledColor;
-}
+  .romo-datepicker-calendar .romo-datepicker-prev:hover,
+  .romo-datepicker-calendar .romo-datepicker-next:hover,
+  .romo-datepicker-calendar TD.romo-datepicker-day.romo-datepicker-highlight:not(.disabled) {
+    background: darken($altBgColor, 10%);
+  }
 
-.romo-datepicker-calendar TD.romo-datepicker-day-other {
-  color: darken($inputDisabledColor, 20%);;
-}
+  .romo-datepicker-calendar TD.romo-datepicker-day.disabled {
+    cursor: $notAllowedCursor;
+    color: $disabledColor;
+  }
 
-.romo-datepicker-calendar TD.romo-datepicker-day-today {
-  border: 1px solid $inputColor;
-}
+  .romo-datepicker-calendar TD.romo-datepicker-day-other {
+    color: darken($inputDisabledColor, 20%);;
+  }
 
-.romo-datepicker-calendar TD.romo-datepicker-day.selected,
-.romo-datepicker-calendar TD.romo-datepicker-day.selected.romo-datepicker-highlight {
-  background-color: $inputHighlightBgColor;
-  color: $inputBgColor;
+  .romo-datepicker-calendar TD.romo-datepicker-day-today {
+    border: 1px solid $inputColor;
+  }
+
+  .romo-datepicker-calendar TD.romo-datepicker-day.selected,
+  .romo-datepicker-calendar TD.romo-datepicker-day.selected.romo-datepicker-highlight {
+    background-color: $inputHighlightBgColor;
+    color: $inputBgColor;
+  }
+
 }

--- a/assets/css/romo/dropdown.scss
+++ b/assets/css/romo/dropdown.scss
@@ -1,33 +1,37 @@
 @import 'css/romo/vars';
 @import 'css/romo/mixins';
 
-.romo-dropdown,
-[data-romo-dropdown-close="true"] {
-  cursor: pointer;
-}
+.romo {
 
-.romo-dropdown-popup {
-  position: absolute;
-  float: left;
-  @include border0;
+  .romo-dropdown,
+  [data-romo-dropdown-close="true"] {
+    cursor: pointer;
+  }
 
-  background-color: $baseBgColor;
-  border-color: $baseBorderColor;
-  border-color: rgba(0, 0, 0, 0.2);
-}
+  .romo-dropdown-popup {
+    position: absolute;
+    float: left;
+    @include border0;
 
-.romo-dropdown-popup[data-romo-dropdown-fixed="true"] {
-  position: fixed;
-}
+    background-color: $baseBgColor;
+    border-color: $baseBorderColor;
+    border-color: rgba(0, 0, 0, 0.2);
+  }
 
-.romo-dropdown-popup[data-romo-dropdown-position="bottom"] {
-  @include box-shadow(0 5px 10px rgba(0, 0, 0, 0.2));
-}
+  .romo-dropdown-popup[data-romo-dropdown-fixed="true"] {
+    position: fixed;
+  }
 
-.romo-dropdown-popup[data-romo-dropdown-position="top"] {
-  @include box-shadow(0 -3px 10px rgba(0, 0, 0, 0.2));
-}
+  .romo-dropdown-popup[data-romo-dropdown-position="bottom"] {
+    @include box-shadow(0 5px 10px rgba(0, 0, 0, 0.2));
+  }
 
-.romo-dropdown-popup:not([class*="romo-dropdown-open"]) {
-  display: none;
+  .romo-dropdown-popup[data-romo-dropdown-position="top"] {
+    @include box-shadow(0 -3px 10px rgba(0, 0, 0, 0.2));
+  }
+
+  .romo-dropdown-popup:not([class*="romo-dropdown-open"]) {
+    display: none;
+  }
+
 }

--- a/assets/css/romo/forms.scss
+++ b/assets/css/romo/forms.scss
@@ -1,218 +1,222 @@
 @import 'css/romo/vars';
 @import 'css/romo/mixins';
 
-/* defaults */
+.romo {
 
-form { @include rm-push; @include rm-pad; }
-label { display: block; }
+  /* defaults */
 
-/* basic */
+  form { @include rm-push; @include rm-pad; }
+  label { display: block; }
 
-.romo-form fieldset {
-  @include rm-push;
-  @include rm-pad;
-  @include rm-border;
-}
+  /* basic */
 
-.romo-form legend {
-  display: block;
-  width: 100%;
-  @include rm-push;
-  @include rm-pad;
-  @include push0-bottom;
-  @include rm-border;
-  @include border1-bottom;
-}
+  .romo-form fieldset {
+    @include rm-push;
+    @include rm-pad;
+    @include rm-border;
+  }
 
-.romo-form input,
-.romo-form select,
-.romo-form textarea,
-input.romo-select-dropdown-option-filter {
-  font-size: 100%;
-  @include rm-push;
-  @include align-middle;
-}
+  .romo-form legend {
+    display: block;
+    width: 100%;
+    @include rm-push;
+    @include rm-pad;
+    @include push0-bottom;
+    @include rm-border;
+    @include border1-bottom;
+  }
 
-.romo-form label.romo-radio,
-.romo-form label.romo-checkbox {
-  span,
-  input[type="radio"],
-  input[type="checkbox"] {
-    line-height: 1;
+  .romo-form input,
+  .romo-form select,
+  .romo-form textarea,
+  input.romo-select-dropdown-option-filter {
+    font-size: 100%;
+    @include rm-push;
     @include align-middle;
   }
-}
 
-.romo-form input,
-input.romo-select-dropdown-option-filter {
-  *overflow: visible;
-  line-height: normal;
-}
+  .romo-form label.romo-radio,
+  .romo-form label.romo-checkbox {
+    span,
+    input[type="radio"],
+    input[type="checkbox"] {
+      line-height: 1;
+      @include align-middle;
+    }
+  }
 
-.romo-form textarea {
-  overflow: auto; @include align-top;
-}
+  .romo-form input,
+  input.romo-select-dropdown-option-filter {
+    *overflow: visible;
+    line-height: normal;
+  }
 
-.romo-form label,
-.romo-form select,
-.romo-form input[type="button"],
-.romo-form input[type="reset"],
-.romo-form input[type="submit"],
-.romo-form input[type="radio"],
-.romo-form input[type="checkbox"] { cursor: pointer; }
+  .romo-form textarea {
+    overflow: auto; @include align-top;
+  }
 
-.romo-form input[disabled],
-.romo-form select[disabled],
-.romo-form textarea[disabled],
-.romo-form input[readonly],
-.romo-form select[readonly],
-.romo-form textarea[readonly],
-input.romo-select-dropdown-option-filter[disabled],
-input.romo-select-dropdown-option-filter[readonly] { cursor: $notAllowedCursor; }
+  .romo-form label,
+  .romo-form select,
+  .romo-form input[type="button"],
+  .romo-form input[type="reset"],
+  .romo-form input[type="submit"],
+  .romo-form input[type="radio"],
+  .romo-form input[type="checkbox"] { cursor: pointer; }
 
-.romo-form select {
-  font-weight: normal;
-  background-color: $inputBgColor;
-  @include border1;
-}
-.romo-form select optgroup { @include select-optgroup; }
-.romo-form select option { @include select-option; }
+  .romo-form input[disabled],
+  .romo-form select[disabled],
+  .romo-form textarea[disabled],
+  .romo-form input[readonly],
+  .romo-form select[readonly],
+  .romo-form textarea[readonly],
+  input.romo-select-dropdown-option-filter[disabled],
+  input.romo-select-dropdown-option-filter[readonly] { cursor: $notAllowedCursor; }
 
-.romo-form textarea,
-.romo-form input[type="text"],
-.romo-form input[type="password"],
-.romo-form input[type="datetime"],
-.romo-form input[type="datetime-local"],
-.romo-form input[type="date"],
-.romo-form input[type="month"],
-.romo-form input[type="time"],
-.romo-form input[type="week"],
-.romo-form input[type="number"],
-.romo-form input[type="email"],
-.romo-form input[type="url"],
-.romo-form input[type="search"],
-.romo-form input[type="tel"],
-.romo-form input[type="color"],
-input.romo-select-dropdown-option-filter {
-  font-weight: normal;
-  background-color: $inputBgColor;
-  @include border1;
-  @include box-shadow(inset 0 1px 1px rgba(0, 0, 0, 0.075));
-}
+  .romo-form select {
+    font-weight: normal;
+    background-color: $inputBgColor;
+    @include border1;
+  }
+  .romo-form select optgroup { @include select-optgroup; }
+  .romo-form select option { @include select-option; }
 
-.romo-form select:focus,
-.romo-form textarea:focus,
-.romo-form input[type="text"]:focus,
-.romo-form input[type="password"]:focus,
-.romo-form input[type="datetime"]:focus,
-.romo-form input[type="datetime-local"]:focus,
-.romo-form input[type="date"]:focus,
-.romo-form input[type="month"]:focus,
-.romo-form input[type="time"]:focus,
-.romo-form input[type="week"]:focus,
-.romo-form input[type="number"]:focus,
-.romo-form input[type="email"]:focus,
-.romo-form input[type="url"]:focus,
-.romo-form input[type="search"]:focus,
-.romo-form input[type="tel"]:focus,
-.romo-form input[type="color"]:focus,
-input.romo-select-dropdown-option-filter:focus {
-  @include input-focus;
-}
+  .romo-form textarea,
+  .romo-form input[type="text"],
+  .romo-form input[type="password"],
+  .romo-form input[type="datetime"],
+  .romo-form input[type="datetime-local"],
+  .romo-form input[type="date"],
+  .romo-form input[type="month"],
+  .romo-form input[type="time"],
+  .romo-form input[type="week"],
+  .romo-form input[type="number"],
+  .romo-form input[type="email"],
+  .romo-form input[type="url"],
+  .romo-form input[type="search"],
+  .romo-form input[type="tel"],
+  .romo-form input[type="color"],
+  input.romo-select-dropdown-option-filter {
+    font-weight: normal;
+    background-color: $inputBgColor;
+    @include border1;
+    @include box-shadow(inset 0 1px 1px rgba(0, 0, 0, 0.075));
+  }
 
-.romo-form input[disabled],
-.romo-form select[disabled],
-.romo-form textarea[disabled],
-.romo-form input[readonly],
-.romo-form select[readonly],
-.romo-form textarea[readonly],
-input.romo-select-dropdown-option-filter[disabled],
-input.romo-select-dropdown-option-filter[readonly] { background-color: $inputDisabledColor; }
+  .romo-form select:focus,
+  .romo-form textarea:focus,
+  .romo-form input[type="text"]:focus,
+  .romo-form input[type="password"]:focus,
+  .romo-form input[type="datetime"]:focus,
+  .romo-form input[type="datetime-local"]:focus,
+  .romo-form input[type="date"]:focus,
+  .romo-form input[type="month"]:focus,
+  .romo-form input[type="time"]:focus,
+  .romo-form input[type="week"]:focus,
+  .romo-form input[type="number"]:focus,
+  .romo-form input[type="email"]:focus,
+  .romo-form input[type="url"]:focus,
+  .romo-form input[type="search"]:focus,
+  .romo-form input[type="tel"]:focus,
+  .romo-form input[type="color"]:focus,
+  input.romo-select-dropdown-option-filter:focus {
+    @include input-focus;
+  }
 
-.romo-form input[type="radio"][disabled],
-.romo-form input[type="checkbox"][disabled],
-.romo-form input[type="radio"][readonly],
-.romo-form input[type="checkbox"][readonly] { background-color: transparent };
+  .romo-form input[disabled],
+  .romo-form select[disabled],
+  .romo-form textarea[disabled],
+  .romo-form input[readonly],
+  .romo-form select[readonly],
+  .romo-form textarea[readonly],
+  input.romo-select-dropdown-option-filter[disabled],
+  input.romo-select-dropdown-option-filter[readonly] { background-color: $inputDisabledColor; }
 
-.romo-form select,
-.romo-form input[type="text"],
-.romo-form input[type="password"],
-.romo-form input[type="datetime"],
-.romo-form input[type="datetime-local"],
-.romo-form input[type="date"],
-.romo-form input[type="month"],
-.romo-form input[type="time"],
-.romo-form input[type="week"],
-.romo-form input[type="number"],
-.romo-form input[type="email"],
-.romo-form input[type="url"],
-.romo-form input[type="search"],
-.romo-form input[type="tel"],
-.romo-form input[type="color"],
-input.romo-select-dropdown-option-filter {
-  height: $inputHeight;
-  line-height: $baseLineHeight;
-  @include align-middle;
-}
+  .romo-form input[type="radio"][disabled],
+  .romo-form input[type="checkbox"][disabled],
+  .romo-form input[type="radio"][readonly],
+  .romo-form input[type="checkbox"][readonly] { background-color: transparent };
 
-input.romo-select-dropdown-option-filter {
-  height: $inputFilterHeight;
-}
+  .romo-form select,
+  .romo-form input[type="text"],
+  .romo-form input[type="password"],
+  .romo-form input[type="datetime"],
+  .romo-form input[type="datetime-local"],
+  .romo-form input[type="date"],
+  .romo-form input[type="month"],
+  .romo-form input[type="time"],
+  .romo-form input[type="week"],
+  .romo-form input[type="number"],
+  .romo-form input[type="email"],
+  .romo-form input[type="url"],
+  .romo-form input[type="search"],
+  .romo-form input[type="tel"],
+  .romo-form input[type="color"],
+  input.romo-select-dropdown-option-filter {
+    height: $inputHeight;
+    line-height: $baseLineHeight;
+    @include align-middle;
+  }
 
-.romo-form textarea,
-.romo-form input[type="text"],
-.romo-form input[type="password"],
-.romo-form input[type="datetime"],
-.romo-form input[type="datetime-local"],
-.romo-form input[type="date"],
-.romo-form input[type="month"],
-.romo-form input[type="time"],
-.romo-form input[type="week"],
-.romo-form input[type="number"],
-.romo-form input[type="email"],
-.romo-form input[type="url"],
-.romo-form input[type="search"],
-.romo-form input[type="tel"],
-.romo-form input[type="color"],
-input.romo-select-dropdown-option-filter {
-  display: inline-block;
-  padding: 4px 6px;
-  color: $inputColor;
-}
+  input.romo-select-dropdown-option-filter {
+    height: $inputFilterHeight;
+  }
 
-input.romo-select-dropdown-option-filter {
-  display: block;
-  width: 100%;
-}
+  .romo-form textarea,
+  .romo-form input[type="text"],
+  .romo-form input[type="password"],
+  .romo-form input[type="datetime"],
+  .romo-form input[type="datetime-local"],
+  .romo-form input[type="date"],
+  .romo-form input[type="month"],
+  .romo-form input[type="time"],
+  .romo-form input[type="week"],
+  .romo-form input[type="number"],
+  .romo-form input[type="email"],
+  .romo-form input[type="url"],
+  .romo-form input[type="search"],
+  .romo-form input[type="tel"],
+  .romo-form input[type="color"],
+  input.romo-select-dropdown-option-filter {
+    display: inline-block;
+    padding: 4px 6px;
+    color: $inputColor;
+  }
 
-.romo-form textarea,
-.romo-form select[multiple],
-.romo-form select[size] { height: auto; }
+  input.romo-select-dropdown-option-filter {
+    display: block;
+    width: 100%;
+  }
 
-.romo-form input[type="file"] {
-  height: ($baseLineHeight / 2) * 3;      /* 30px */
-  line-height: ($baseLineHeight / 2) * 3; /* 30px */
-}
+  .romo-form textarea,
+  .romo-form select[multiple],
+  .romo-form select[size] { height: auto; }
 
-.romo-input,
-.romo-input1 { width: $inputSize1; }
-.romo-input-small,
-.romo-input0 { width: $inputSize0; }
-.romo-input-large,
-.romo-input2 { width: $inputSize2; }
+  .romo-form input[type="file"] {
+    height: ($baseLineHeight / 2) * 3;      /* 30px */
+    line-height: ($baseLineHeight / 2) * 3; /* 30px */
+  }
 
-.romo-input-block { width: 100%; display: block; }
+  .romo-input,
+  .romo-input1 { width: $inputSize1; }
+  .romo-input-small,
+  .romo-input0 { width: $inputSize0; }
+  .romo-input-large,
+  .romo-input2 { width: $inputSize2; }
 
-.romo-form input[type="file"],
-.romo-form input[type="image"],
-.romo-form input[type="submit"],
-.romo-form input[type="reset"],
-.romo-form input[type="button"],
-.romo-form input[type="radio"],
-.romo-form input[type="checkbox"] { width: auto; }
+  .romo-input-block { width: 100%; display: block; }
 
-.romo-form .romo-input-inline,
-.romo-form .romo-input-help {
-  line-height: $inputHeight;
-  @include align-middle;
+  .romo-form input[type="file"],
+  .romo-form input[type="image"],
+  .romo-form input[type="submit"],
+  .romo-form input[type="reset"],
+  .romo-form input[type="button"],
+  .romo-form input[type="radio"],
+  .romo-form input[type="checkbox"] { width: auto; }
+
+  .romo-form .romo-input-inline,
+  .romo-form .romo-input-help {
+    line-height: $inputHeight;
+    @include align-middle;
+  }
+
 }

--- a/assets/css/romo/grid.scss
+++ b/assets/css/romo/grid.scss
@@ -1,273 +1,277 @@
 @import 'css/romo/vars';
 @import 'css/romo/mixins';
 
-.romo-row {
-  @include display-flex;
-  @include flex-direction(row);
-  @include flex-wrap(nowrap);
-  @include flex-justify-content(center);
-  @include flex-align-items(flex-start);
+.romo {
+
+  .romo-row {
+    @include display-flex;
+    @include flex-direction(row);
+    @include flex-wrap(nowrap);
+    @include flex-justify-content(center);
+    @include flex-align-items(flex-start);
+  }
+
+  .romo-span { min-height: 1px; }
+
+  .romo-row-pull-left,
+  .romo-row-align-left   { @include flex-justify-content(flex-start); }
+  .romo-row-pull-right,
+  .romo-row-align-right  { @include flex-justify-content(flex-end); }
+  .romo-row-push-between { @include flex-justify-content(space-between); }
+  .romo-row-push-around  { @include flex-justify-content(space-around); }
+
+  .romo-row-align-top     { @include flex-align-items(flex-start); }
+  .romo-row-align-middle  { @include flex-align-items(center); }
+  .romo-row-align-bottom  { @include flex-align-items(flex-end); }
+  .romo-row-align-stretch { @include flex-align-items(stretch); }
+
+  .romo-span-fill {
+    @include flex-grow(1);
+    @include flex-shrink(1);
+  }
+
+  .romo-span-align-top     { @include flex-align-self(flex-start); }
+  .romo-span-align-middle  { @include flex-align-self(center); }
+  .romo-span-align-bottom  { @include flex-align-self(flex-end); }
+  .romo-span-align-stretch { @include flex-align-self(stretch); }
+
+  /* float mode (for browsers that don't support Flexbox */
+
+  .romo-row-float { @include clearfix; }
+  .romo-row-float > .romo-span { float: left; }
+
+  /* widths */
+
+  .romo-1-1 { @include grid-span(1, 1); }
+
+  .romo-1-2 { @include grid-span(1, 2); }
+  .romo-2-2 { @include grid-span(2, 2); }
+
+  .romo-1-3 { @include grid-span(1, 3); }
+  .romo-2-3 { @include grid-span(2, 3); }
+  .romo-3-3 { @include grid-span(3, 3); }
+
+  .romo-1-4 { @include grid-span(1, 4); }
+  .romo-2-4 { @include grid-span(2, 4); }
+  .romo-3-4 { @include grid-span(3, 4); }
+  .romo-4-4 { @include grid-span(4, 4); }
+
+  .romo-1-5 { @include grid-span(1, 5); }
+  .romo-2-5 { @include grid-span(2, 5); }
+  .romo-3-5 { @include grid-span(3, 5); }
+  .romo-4-5 { @include grid-span(4, 5); }
+  .romo-5-5 { @include grid-span(5, 5); }
+
+  .romo-1-6 { @include grid-span(1, 6); }
+  .romo-2-6 { @include grid-span(2, 6); }
+  .romo-3-6 { @include grid-span(3, 6); }
+  .romo-4-6 { @include grid-span(4, 6); }
+  .romo-5-6 { @include grid-span(5, 6); }
+  .romo-6-6 { @include grid-span(6, 6); }
+
+  .romo-1-7 { @include grid-span(1, 7); }
+  .romo-2-7 { @include grid-span(2, 7); }
+  .romo-3-7 { @include grid-span(3, 7); }
+  .romo-4-7 { @include grid-span(4, 7); }
+  .romo-5-7 { @include grid-span(5, 7); }
+  .romo-6-7 { @include grid-span(6, 7); }
+  .romo-7-7 { @include grid-span(7, 7); }
+
+  .romo-1-8 { @include grid-span(1, 8); }
+  .romo-2-8 { @include grid-span(2, 8); }
+  .romo-3-8 { @include grid-span(3, 8); }
+  .romo-4-8 { @include grid-span(4, 8); }
+  .romo-5-8 { @include grid-span(5, 8); }
+  .romo-6-8 { @include grid-span(6, 8); }
+  .romo-7-8 { @include grid-span(7, 8); }
+  .romo-8-8 { @include grid-span(8, 8); }
+
+  .romo-1-9 { @include grid-span(1, 9); }
+  .romo-2-9 { @include grid-span(2, 9); }
+  .romo-3-9 { @include grid-span(3, 9); }
+  .romo-4-9 { @include grid-span(4, 9); }
+  .romo-5-9 { @include grid-span(5, 9); }
+  .romo-6-9 { @include grid-span(6, 9); }
+  .romo-7-9 { @include grid-span(7, 9); }
+  .romo-8-9 { @include grid-span(8, 9); }
+  .romo-9-9 { @include grid-span(9, 9); }
+
+  .romo-1-10  { @include grid-span(1,  10); }
+  .romo-2-10  { @include grid-span(2,  10); }
+  .romo-3-10  { @include grid-span(3,  10); }
+  .romo-4-10  { @include grid-span(4,  10); }
+  .romo-5-10  { @include grid-span(5,  10); }
+  .romo-6-10  { @include grid-span(6,  10); }
+  .romo-7-10  { @include grid-span(7,  10); }
+  .romo-8-10  { @include grid-span(8,  10); }
+  .romo-9-10  { @include grid-span(9,  10); }
+  .romo-10-10 { @include grid-span(10, 10); }
+
+  .romo-1-11  { @include grid-span(1,  11); }
+  .romo-2-11  { @include grid-span(2,  11); }
+  .romo-3-11  { @include grid-span(3,  11); }
+  .romo-4-11  { @include grid-span(4,  11); }
+  .romo-5-11  { @include grid-span(5,  11); }
+  .romo-6-11  { @include grid-span(6,  11); }
+  .romo-7-11  { @include grid-span(7,  11); }
+  .romo-8-11  { @include grid-span(8,  11); }
+  .romo-9-11  { @include grid-span(9,  11); }
+  .romo-10-11 { @include grid-span(10, 11); }
+  .romo-11-11 { @include grid-span(11, 11); }
+
+  .romo-1-12  { @include grid-span(1,  12); }
+  .romo-2-12  { @include grid-span(2,  12); }
+  .romo-3-12  { @include grid-span(3,  12); }
+  .romo-4-12  { @include grid-span(4,  12); }
+  .romo-5-12  { @include grid-span(5,  12); }
+  .romo-6-12  { @include grid-span(6,  12); }
+  .romo-7-12  { @include grid-span(7,  12); }
+  .romo-8-12  { @include grid-span(8,  12); }
+  .romo-9-12  { @include grid-span(9,  12); }
+  .romo-10-12 { @include grid-span(10, 12); }
+  .romo-11-12 { @include grid-span(11, 12); }
+  .romo-12-12 { @include grid-span(12, 12); }
+
+  .romo-1-24  { @include grid-span(1,  24); }
+  .romo-2-24  { @include grid-span(2,  24); }
+  .romo-3-24  { @include grid-span(3,  24); }
+  .romo-4-24  { @include grid-span(4,  24); }
+  .romo-5-24  { @include grid-span(5,  24); }
+  .romo-6-24  { @include grid-span(6,  24); }
+  .romo-7-24  { @include grid-span(7,  24); }
+  .romo-8-24  { @include grid-span(8,  24); }
+  .romo-9-24  { @include grid-span(9,  24); }
+  .romo-10-24 { @include grid-span(10, 24); }
+  .romo-11-24 { @include grid-span(11, 24); }
+  .romo-12-24 { @include grid-span(12, 24); }
+  .romo-13-24 { @include grid-span(13, 24); }
+  .romo-14-24 { @include grid-span(14, 24); }
+  .romo-15-24 { @include grid-span(15, 24); }
+  .romo-16-24 { @include grid-span(16, 24); }
+  .romo-17-24 { @include grid-span(17, 24); }
+  .romo-18-24 { @include grid-span(18, 24); }
+  .romo-19-24 { @include grid-span(19, 24); }
+  .romo-20-24 { @include grid-span(20, 24); }
+  .romo-21-24 { @include grid-span(21, 24); }
+  .romo-22-24 { @include grid-span(22, 24); }
+  .romo-23-24 { @include grid-span(23, 24); }
+  .romo-24-24 { @include grid-span(24, 24); }
+
+  /* offsets */
+
+  .romo-offset-1-1 { @include grid-offset(1, 1); }
+
+  .romo-offset-1-2 { @include grid-offset(1, 2); }
+  .romo-offset-2-2 { @include grid-offset(2, 2); }
+
+  .romo-offset-1-3 { @include grid-offset(1, 3); }
+  .romo-offset-2-3 { @include grid-offset(2, 3); }
+  .romo-offset-3-3 { @include grid-offset(3, 3); }
+
+  .romo-offset-1-4 { @include grid-offset(1, 4); }
+  .romo-offset-2-4 { @include grid-offset(2, 4); }
+  .romo-offset-3-4 { @include grid-offset(3, 4); }
+  .romo-offset-4-4 { @include grid-offset(4, 4); }
+
+  .romo-offset-1-5 { @include grid-offset(1, 5); }
+  .romo-offset-2-5 { @include grid-offset(2, 5); }
+  .romo-offset-3-5 { @include grid-offset(3, 5); }
+  .romo-offset-4-5 { @include grid-offset(4, 5); }
+  .romo-offset-5-5 { @include grid-offset(5, 5); }
+
+  .romo-offset-1-6 { @include grid-offset(1, 6); }
+  .romo-offset-2-6 { @include grid-offset(2, 6); }
+  .romo-offset-3-6 { @include grid-offset(3, 6); }
+  .romo-offset-4-6 { @include grid-offset(4, 6); }
+  .romo-offset-5-6 { @include grid-offset(5, 6); }
+  .romo-offset-6-6 { @include grid-offset(6, 6); }
+
+  .romo-offset-1-7 { @include grid-offset(1, 7); }
+  .romo-offset-2-7 { @include grid-offset(2, 7); }
+  .romo-offset-3-7 { @include grid-offset(3, 7); }
+  .romo-offset-4-7 { @include grid-offset(4, 7); }
+  .romo-offset-5-7 { @include grid-offset(5, 7); }
+  .romo-offset-6-7 { @include grid-offset(6, 7); }
+  .romo-offset-7-7 { @include grid-offset(7, 7); }
+
+  .romo-offset-1-8 { @include grid-offset(1, 8); }
+  .romo-offset-2-8 { @include grid-offset(2, 8); }
+  .romo-offset-3-8 { @include grid-offset(3, 8); }
+  .romo-offset-4-8 { @include grid-offset(4, 8); }
+  .romo-offset-5-8 { @include grid-offset(5, 8); }
+  .romo-offset-6-8 { @include grid-offset(6, 8); }
+  .romo-offset-7-8 { @include grid-offset(7, 8); }
+  .romo-offset-8-8 { @include grid-offset(8, 8); }
+
+  .romo-offset-1-9 { @include grid-offset(1, 9); }
+  .romo-offset-2-9 { @include grid-offset(2, 9); }
+  .romo-offset-3-9 { @include grid-offset(3, 9); }
+  .romo-offset-4-9 { @include grid-offset(4, 9); }
+  .romo-offset-5-9 { @include grid-offset(5, 9); }
+  .romo-offset-6-9 { @include grid-offset(6, 9); }
+  .romo-offset-7-9 { @include grid-offset(7, 9); }
+  .romo-offset-8-9 { @include grid-offset(8, 9); }
+  .romo-offset-9-9 { @include grid-offset(9, 9); }
+
+  .romo-offset-1-10  { @include grid-offset(1,  10); }
+  .romo-offset-2-10  { @include grid-offset(2,  10); }
+  .romo-offset-3-10  { @include grid-offset(3,  10); }
+  .romo-offset-4-10  { @include grid-offset(4,  10); }
+  .romo-offset-5-10  { @include grid-offset(5,  10); }
+  .romo-offset-6-10  { @include grid-offset(6,  10); }
+  .romo-offset-7-10  { @include grid-offset(7,  10); }
+  .romo-offset-8-10  { @include grid-offset(8,  10); }
+  .romo-offset-9-10  { @include grid-offset(9,  10); }
+  .romo-offset-10-10 { @include grid-offset(10, 10); }
+
+  .romo-offset-1-11  { @include grid-offset(1,  11); }
+  .romo-offset-2-11  { @include grid-offset(2,  11); }
+  .romo-offset-3-11  { @include grid-offset(3,  11); }
+  .romo-offset-4-11  { @include grid-offset(4,  11); }
+  .romo-offset-5-11  { @include grid-offset(5,  11); }
+  .romo-offset-6-11  { @include grid-offset(6,  11); }
+  .romo-offset-7-11  { @include grid-offset(7,  11); }
+  .romo-offset-8-11  { @include grid-offset(8,  11); }
+  .romo-offset-9-11  { @include grid-offset(9,  11); }
+  .romo-offset-10-11 { @include grid-offset(10, 11); }
+  .romo-offset-11-11 { @include grid-offset(11, 11); }
+
+  .romo-offset-1-12  { @include grid-offset(1,  12); }
+  .romo-offset-2-12  { @include grid-offset(2,  12); }
+  .romo-offset-3-12  { @include grid-offset(3,  12); }
+  .romo-offset-4-12  { @include grid-offset(4,  12); }
+  .romo-offset-5-12  { @include grid-offset(5,  12); }
+  .romo-offset-6-12  { @include grid-offset(6,  12); }
+  .romo-offset-7-12  { @include grid-offset(7,  12); }
+  .romo-offset-8-12  { @include grid-offset(8,  12); }
+  .romo-offset-9-12  { @include grid-offset(9,  12); }
+  .romo-offset-10-12 { @include grid-offset(10, 12); }
+  .romo-offset-11-12 { @include grid-offset(11, 12); }
+  .romo-offset-12-12 { @include grid-offset(12, 12); }
+
+  .romo-offset-1-24  { @include grid-offset(1,  24); }
+  .romo-offset-2-24  { @include grid-offset(2,  24); }
+  .romo-offset-3-24  { @include grid-offset(3,  24); }
+  .romo-offset-4-24  { @include grid-offset(4,  24); }
+  .romo-offset-5-24  { @include grid-offset(5,  24); }
+  .romo-offset-6-24  { @include grid-offset(6,  24); }
+  .romo-offset-7-24  { @include grid-offset(7,  24); }
+  .romo-offset-8-24  { @include grid-offset(8,  24); }
+  .romo-offset-9-24  { @include grid-offset(9,  24); }
+  .romo-offset-10-24 { @include grid-offset(10, 24); }
+  .romo-offset-11-24 { @include grid-offset(11, 24); }
+  .romo-offset-12-24 { @include grid-offset(12, 24); }
+  .romo-offset-13-24 { @include grid-offset(13, 24); }
+  .romo-offset-14-24 { @include grid-offset(14, 24); }
+  .romo-offset-15-24 { @include grid-offset(15, 24); }
+  .romo-offset-16-24 { @include grid-offset(16, 24); }
+  .romo-offset-17-24 { @include grid-offset(17, 24); }
+  .romo-offset-18-24 { @include grid-offset(18, 24); }
+  .romo-offset-19-24 { @include grid-offset(19, 24); }
+  .romo-offset-20-24 { @include grid-offset(20, 24); }
+  .romo-offset-21-24 { @include grid-offset(21, 24); }
+  .romo-offset-22-24 { @include grid-offset(22, 24); }
+  .romo-offset-23-24 { @include grid-offset(23, 24); }
+  .romo-offset-24-24 { @include grid-offset(24, 24); }
+
 }
-
-.romo-span { min-height: 1px; }
-
-.romo-row-pull-left,
-.romo-row-align-left   { @include flex-justify-content(flex-start); }
-.romo-row-pull-right,
-.romo-row-align-right  { @include flex-justify-content(flex-end); }
-.romo-row-push-between { @include flex-justify-content(space-between); }
-.romo-row-push-around  { @include flex-justify-content(space-around); }
-
-.romo-row-align-top     { @include flex-align-items(flex-start); }
-.romo-row-align-middle  { @include flex-align-items(center); }
-.romo-row-align-bottom  { @include flex-align-items(flex-end); }
-.romo-row-align-stretch { @include flex-align-items(stretch); }
-
-.romo-span-fill {
-  @include flex-grow(1);
-  @include flex-shrink(1);
-}
-
-.romo-span-align-top     { @include flex-align-self(flex-start); }
-.romo-span-align-middle  { @include flex-align-self(center); }
-.romo-span-align-bottom  { @include flex-align-self(flex-end); }
-.romo-span-align-stretch { @include flex-align-self(stretch); }
-
-/* float mode (for browsers that don't support Flexbox */
-
-.romo-row-float { @include clearfix; }
-.romo-row-float > .romo-span { float: left; }
-
-/* widths */
-
-.romo-1-1 { @include grid-span(1, 1); }
-
-.romo-1-2 { @include grid-span(1, 2); }
-.romo-2-2 { @include grid-span(2, 2); }
-
-.romo-1-3 { @include grid-span(1, 3); }
-.romo-2-3 { @include grid-span(2, 3); }
-.romo-3-3 { @include grid-span(3, 3); }
-
-.romo-1-4 { @include grid-span(1, 4); }
-.romo-2-4 { @include grid-span(2, 4); }
-.romo-3-4 { @include grid-span(3, 4); }
-.romo-4-4 { @include grid-span(4, 4); }
-
-.romo-1-5 { @include grid-span(1, 5); }
-.romo-2-5 { @include grid-span(2, 5); }
-.romo-3-5 { @include grid-span(3, 5); }
-.romo-4-5 { @include grid-span(4, 5); }
-.romo-5-5 { @include grid-span(5, 5); }
-
-.romo-1-6 { @include grid-span(1, 6); }
-.romo-2-6 { @include grid-span(2, 6); }
-.romo-3-6 { @include grid-span(3, 6); }
-.romo-4-6 { @include grid-span(4, 6); }
-.romo-5-6 { @include grid-span(5, 6); }
-.romo-6-6 { @include grid-span(6, 6); }
-
-.romo-1-7 { @include grid-span(1, 7); }
-.romo-2-7 { @include grid-span(2, 7); }
-.romo-3-7 { @include grid-span(3, 7); }
-.romo-4-7 { @include grid-span(4, 7); }
-.romo-5-7 { @include grid-span(5, 7); }
-.romo-6-7 { @include grid-span(6, 7); }
-.romo-7-7 { @include grid-span(7, 7); }
-
-.romo-1-8 { @include grid-span(1, 8); }
-.romo-2-8 { @include grid-span(2, 8); }
-.romo-3-8 { @include grid-span(3, 8); }
-.romo-4-8 { @include grid-span(4, 8); }
-.romo-5-8 { @include grid-span(5, 8); }
-.romo-6-8 { @include grid-span(6, 8); }
-.romo-7-8 { @include grid-span(7, 8); }
-.romo-8-8 { @include grid-span(8, 8); }
-
-.romo-1-9 { @include grid-span(1, 9); }
-.romo-2-9 { @include grid-span(2, 9); }
-.romo-3-9 { @include grid-span(3, 9); }
-.romo-4-9 { @include grid-span(4, 9); }
-.romo-5-9 { @include grid-span(5, 9); }
-.romo-6-9 { @include grid-span(6, 9); }
-.romo-7-9 { @include grid-span(7, 9); }
-.romo-8-9 { @include grid-span(8, 9); }
-.romo-9-9 { @include grid-span(9, 9); }
-
-.romo-1-10  { @include grid-span(1,  10); }
-.romo-2-10  { @include grid-span(2,  10); }
-.romo-3-10  { @include grid-span(3,  10); }
-.romo-4-10  { @include grid-span(4,  10); }
-.romo-5-10  { @include grid-span(5,  10); }
-.romo-6-10  { @include grid-span(6,  10); }
-.romo-7-10  { @include grid-span(7,  10); }
-.romo-8-10  { @include grid-span(8,  10); }
-.romo-9-10  { @include grid-span(9,  10); }
-.romo-10-10 { @include grid-span(10, 10); }
-
-.romo-1-11  { @include grid-span(1,  11); }
-.romo-2-11  { @include grid-span(2,  11); }
-.romo-3-11  { @include grid-span(3,  11); }
-.romo-4-11  { @include grid-span(4,  11); }
-.romo-5-11  { @include grid-span(5,  11); }
-.romo-6-11  { @include grid-span(6,  11); }
-.romo-7-11  { @include grid-span(7,  11); }
-.romo-8-11  { @include grid-span(8,  11); }
-.romo-9-11  { @include grid-span(9,  11); }
-.romo-10-11 { @include grid-span(10, 11); }
-.romo-11-11 { @include grid-span(11, 11); }
-
-.romo-1-12  { @include grid-span(1,  12); }
-.romo-2-12  { @include grid-span(2,  12); }
-.romo-3-12  { @include grid-span(3,  12); }
-.romo-4-12  { @include grid-span(4,  12); }
-.romo-5-12  { @include grid-span(5,  12); }
-.romo-6-12  { @include grid-span(6,  12); }
-.romo-7-12  { @include grid-span(7,  12); }
-.romo-8-12  { @include grid-span(8,  12); }
-.romo-9-12  { @include grid-span(9,  12); }
-.romo-10-12 { @include grid-span(10, 12); }
-.romo-11-12 { @include grid-span(11, 12); }
-.romo-12-12 { @include grid-span(12, 12); }
-
-.romo-1-24  { @include grid-span(1,  24); }
-.romo-2-24  { @include grid-span(2,  24); }
-.romo-3-24  { @include grid-span(3,  24); }
-.romo-4-24  { @include grid-span(4,  24); }
-.romo-5-24  { @include grid-span(5,  24); }
-.romo-6-24  { @include grid-span(6,  24); }
-.romo-7-24  { @include grid-span(7,  24); }
-.romo-8-24  { @include grid-span(8,  24); }
-.romo-9-24  { @include grid-span(9,  24); }
-.romo-10-24 { @include grid-span(10, 24); }
-.romo-11-24 { @include grid-span(11, 24); }
-.romo-12-24 { @include grid-span(12, 24); }
-.romo-13-24 { @include grid-span(13, 24); }
-.romo-14-24 { @include grid-span(14, 24); }
-.romo-15-24 { @include grid-span(15, 24); }
-.romo-16-24 { @include grid-span(16, 24); }
-.romo-17-24 { @include grid-span(17, 24); }
-.romo-18-24 { @include grid-span(18, 24); }
-.romo-19-24 { @include grid-span(19, 24); }
-.romo-20-24 { @include grid-span(20, 24); }
-.romo-21-24 { @include grid-span(21, 24); }
-.romo-22-24 { @include grid-span(22, 24); }
-.romo-23-24 { @include grid-span(23, 24); }
-.romo-24-24 { @include grid-span(24, 24); }
-
-/* offsets */
-
-.romo-offset-1-1 { @include grid-offset(1, 1); }
-
-.romo-offset-1-2 { @include grid-offset(1, 2); }
-.romo-offset-2-2 { @include grid-offset(2, 2); }
-
-.romo-offset-1-3 { @include grid-offset(1, 3); }
-.romo-offset-2-3 { @include grid-offset(2, 3); }
-.romo-offset-3-3 { @include grid-offset(3, 3); }
-
-.romo-offset-1-4 { @include grid-offset(1, 4); }
-.romo-offset-2-4 { @include grid-offset(2, 4); }
-.romo-offset-3-4 { @include grid-offset(3, 4); }
-.romo-offset-4-4 { @include grid-offset(4, 4); }
-
-.romo-offset-1-5 { @include grid-offset(1, 5); }
-.romo-offset-2-5 { @include grid-offset(2, 5); }
-.romo-offset-3-5 { @include grid-offset(3, 5); }
-.romo-offset-4-5 { @include grid-offset(4, 5); }
-.romo-offset-5-5 { @include grid-offset(5, 5); }
-
-.romo-offset-1-6 { @include grid-offset(1, 6); }
-.romo-offset-2-6 { @include grid-offset(2, 6); }
-.romo-offset-3-6 { @include grid-offset(3, 6); }
-.romo-offset-4-6 { @include grid-offset(4, 6); }
-.romo-offset-5-6 { @include grid-offset(5, 6); }
-.romo-offset-6-6 { @include grid-offset(6, 6); }
-
-.romo-offset-1-7 { @include grid-offset(1, 7); }
-.romo-offset-2-7 { @include grid-offset(2, 7); }
-.romo-offset-3-7 { @include grid-offset(3, 7); }
-.romo-offset-4-7 { @include grid-offset(4, 7); }
-.romo-offset-5-7 { @include grid-offset(5, 7); }
-.romo-offset-6-7 { @include grid-offset(6, 7); }
-.romo-offset-7-7 { @include grid-offset(7, 7); }
-
-.romo-offset-1-8 { @include grid-offset(1, 8); }
-.romo-offset-2-8 { @include grid-offset(2, 8); }
-.romo-offset-3-8 { @include grid-offset(3, 8); }
-.romo-offset-4-8 { @include grid-offset(4, 8); }
-.romo-offset-5-8 { @include grid-offset(5, 8); }
-.romo-offset-6-8 { @include grid-offset(6, 8); }
-.romo-offset-7-8 { @include grid-offset(7, 8); }
-.romo-offset-8-8 { @include grid-offset(8, 8); }
-
-.romo-offset-1-9 { @include grid-offset(1, 9); }
-.romo-offset-2-9 { @include grid-offset(2, 9); }
-.romo-offset-3-9 { @include grid-offset(3, 9); }
-.romo-offset-4-9 { @include grid-offset(4, 9); }
-.romo-offset-5-9 { @include grid-offset(5, 9); }
-.romo-offset-6-9 { @include grid-offset(6, 9); }
-.romo-offset-7-9 { @include grid-offset(7, 9); }
-.romo-offset-8-9 { @include grid-offset(8, 9); }
-.romo-offset-9-9 { @include grid-offset(9, 9); }
-
-.romo-offset-1-10  { @include grid-offset(1,  10); }
-.romo-offset-2-10  { @include grid-offset(2,  10); }
-.romo-offset-3-10  { @include grid-offset(3,  10); }
-.romo-offset-4-10  { @include grid-offset(4,  10); }
-.romo-offset-5-10  { @include grid-offset(5,  10); }
-.romo-offset-6-10  { @include grid-offset(6,  10); }
-.romo-offset-7-10  { @include grid-offset(7,  10); }
-.romo-offset-8-10  { @include grid-offset(8,  10); }
-.romo-offset-9-10  { @include grid-offset(9,  10); }
-.romo-offset-10-10 { @include grid-offset(10, 10); }
-
-.romo-offset-1-11  { @include grid-offset(1,  11); }
-.romo-offset-2-11  { @include grid-offset(2,  11); }
-.romo-offset-3-11  { @include grid-offset(3,  11); }
-.romo-offset-4-11  { @include grid-offset(4,  11); }
-.romo-offset-5-11  { @include grid-offset(5,  11); }
-.romo-offset-6-11  { @include grid-offset(6,  11); }
-.romo-offset-7-11  { @include grid-offset(7,  11); }
-.romo-offset-8-11  { @include grid-offset(8,  11); }
-.romo-offset-9-11  { @include grid-offset(9,  11); }
-.romo-offset-10-11 { @include grid-offset(10, 11); }
-.romo-offset-11-11 { @include grid-offset(11, 11); }
-
-.romo-offset-1-12  { @include grid-offset(1,  12); }
-.romo-offset-2-12  { @include grid-offset(2,  12); }
-.romo-offset-3-12  { @include grid-offset(3,  12); }
-.romo-offset-4-12  { @include grid-offset(4,  12); }
-.romo-offset-5-12  { @include grid-offset(5,  12); }
-.romo-offset-6-12  { @include grid-offset(6,  12); }
-.romo-offset-7-12  { @include grid-offset(7,  12); }
-.romo-offset-8-12  { @include grid-offset(8,  12); }
-.romo-offset-9-12  { @include grid-offset(9,  12); }
-.romo-offset-10-12 { @include grid-offset(10, 12); }
-.romo-offset-11-12 { @include grid-offset(11, 12); }
-.romo-offset-12-12 { @include grid-offset(12, 12); }
-
-.romo-offset-1-24  { @include grid-offset(1,  24); }
-.romo-offset-2-24  { @include grid-offset(2,  24); }
-.romo-offset-3-24  { @include grid-offset(3,  24); }
-.romo-offset-4-24  { @include grid-offset(4,  24); }
-.romo-offset-5-24  { @include grid-offset(5,  24); }
-.romo-offset-6-24  { @include grid-offset(6,  24); }
-.romo-offset-7-24  { @include grid-offset(7,  24); }
-.romo-offset-8-24  { @include grid-offset(8,  24); }
-.romo-offset-9-24  { @include grid-offset(9,  24); }
-.romo-offset-10-24 { @include grid-offset(10, 24); }
-.romo-offset-11-24 { @include grid-offset(11, 24); }
-.romo-offset-12-24 { @include grid-offset(12, 24); }
-.romo-offset-13-24 { @include grid-offset(13, 24); }
-.romo-offset-14-24 { @include grid-offset(14, 24); }
-.romo-offset-15-24 { @include grid-offset(15, 24); }
-.romo-offset-16-24 { @include grid-offset(16, 24); }
-.romo-offset-17-24 { @include grid-offset(17, 24); }
-.romo-offset-18-24 { @include grid-offset(18, 24); }
-.romo-offset-19-24 { @include grid-offset(19, 24); }
-.romo-offset-20-24 { @include grid-offset(20, 24); }
-.romo-offset-21-24 { @include grid-offset(21, 24); }
-.romo-offset-22-24 { @include grid-offset(22, 24); }
-.romo-offset-23-24 { @include grid-offset(23, 24); }
-.romo-offset-24-24 { @include grid-offset(24, 24); }

--- a/assets/css/romo/grid_table.scss
+++ b/assets/css/romo/grid_table.scss
@@ -1,285 +1,289 @@
 @import 'css/romo/vars';
 @import 'css/romo/mixins';
 
-.romo-grid-table {
-  width: 100%;
-  background-color: transparent;
-  @include rm-pad;
-  @include rm-push;
+.romo {
+
+  .romo-grid-table {
+    width: 100%;
+    background-color: transparent;
+    @include rm-pad;
+    @include rm-push;
+  }
+
+  ul.romo-grid-table,
+  ol.romo-grid-table { @include list-unstyled(!important); }
+
+  .romo-grid-table > .romo-row { @include border1-bottom; }
+
+  .romo-grid-table.romo-grid-table-header > .romo-row:first-child > .romo-span { @include font-weight(bold); }
+  .romo-grid-table.romo-grid-table-header > .romo-row:first-child > .romo-span { @include align-bottom; }
+
+  .romo-grid-table > .romo-row > .romo-span {
+    @include rm-pad;
+    @include rm-push;
+    @include align-left;
+    @include align-middle;
+  }
+
+  .romo-grid-table-alt { @include bg-alt; }
+
+  .romo-grid-table-striped:not(.romo-grid-table-header) > .romo-row:nth-child(odd) { @include bg-striped; }
+  .romo-grid-table-striped:not(.romo-grid-table-header).romo-grid-table-striped-alt > .romo-row:nth-child(odd) { @include bg-base; }
+  .romo-grid-table-striped.romo-grid-table-header > .romo-row:nth-child(even) { @include bg-striped; }
+  .romo-grid-table-striped.romo-grid-table-header.romo-grid-table-striped-alt > .romo-row:nth-child(even) { @include bg-base; }
+  .romo-grid-table-striped.romo-grid-table-striped-alt { @include bg-striped; }
+
+  .romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row:hover,
+  .romo-grid-table-hover:not(.romo-grid-table-header).romo-grid-table-alt > .romo-row:hover,
+  .romo-grid-table-hover:not(.romo-grid-table-header).romo-grid-table-striped > .romo-row:hover,
+  .romo-grid-table-hover:not(.romo-grid-table-header).romo-grid-table-striped-alt > .romo-row:hover { @include bg-hover; }
+  .romo-grid-table-hover.romo-grid-table-header > .romo-row:not(:first-child):hover,
+  .romo-grid-table-hover.romo-grid-table-header.romo-grid-table-alt > .romo-row:not(:first-child):hover { @include bg-hover; }
+
+  .romo-grid-table-border,
+  .romo-grid-table-border1     { @include border1;            }
+  .romo-grid-table-border0     { @include border0;            }
+  .romo-grid-table-border2     { @include border2;            }
+  .romo-grid-table-border-none { @include border-style(none); }
+
+  .romo-grid-table.romo-grid-table-border      > .romo-row,
+  .romo-grid-table.romo-grid-table-border1     > .romo-row { @include border1-bottom;     }
+  .romo-grid-table.romo-grid-table-border0     > .romo-row { @include border0-bottom;     }
+  .romo-grid-table.romo-grid-table-border2     > .romo-row { @include border2-bottom;     }
+  .romo-grid-table.romo-grid-table-border-none > .romo-row { @include border-style(none); }
+
+  .romo-grid-table.romo-grid-table-border      > .romo-row > .romo-span,
+  .romo-grid-table.romo-grid-table-border1     > .romo-row > .romo-span { @include border1-right;      white-space: nowrap; overflow: hidden; }
+  .romo-grid-table.romo-grid-table-border0     > .romo-row > .romo-span { @include border0-right;      white-space: nowrap; overflow: hidden; }
+  .romo-grid-table.romo-grid-table-border2     > .romo-row > .romo-span { @include border2-right;      white-space: nowrap; overflow: hidden; }
+  .romo-grid-table.romo-grid-table-border-none > .romo-row > .romo-span { @include border-style(none); white-space: nowrap; overflow: hidden; }
+
+  .romo-grid-table[class*="romo-grid-table-border"] > .romo-row > .romo-span:last-child { @include rm-border-right; }
+  .romo-grid-table[class*="romo-grid-table-border"] > .romo-row:last-child { @include rm-border-bottom; }
+
+  .romo-grid-table.romo-grid-table-pad    > .romo-row > .romo-span,
+  .romo-grid-table.romo-grid-table-pad1   > .romo-row > .romo-span { @include pad1;   }
+  .romo-grid-table.romo-grid-table-pad0   > .romo-row > .romo-span { @include pad0;   }
+  .romo-grid-table.romo-grid-table-pad2   > .romo-row > .romo-span { @include pad2;   }
+  .romo-grid-table.romo-grid-table-rm-pad > .romo-row > .romo-span { @include rm-pad; }
+
+  .romo-grid-table.romo-table-pad-top    > .romo-row > .romo-span,
+  .romo-grid-table.romo-table-pad1-top   > .romo-row > .romo-span { @include pad1-top;   }
+  .romo-grid-table.romo-table-pad0-top   > .romo-row > .romo-span { @include pad0-top;   }
+  .romo-grid-table.romo-table-pad2-top   > .romo-row > .romo-span { @include pad2-top;   }
+  .romo-grid-table.romo-table-rm-pad-top > .romo-row > .romo-span { @include rm-pad-top; }
+
+  .romo-grid-table.romo-table-pad-right    > .romo-row > .romo-span,
+  .romo-grid-table.romo-table-pad1-right   > .romo-row > .romo-span { @include pad1-right;   }
+  .romo-grid-table.romo-table-pad0-right   > .romo-row > .romo-span { @include pad0-right;   }
+  .romo-grid-table.romo-table-pad2-right   > .romo-row > .romo-span { @include pad2-right;   }
+  .romo-grid-table.romo-table-rm-pad-right > .romo-row > .romo-span { @include rm-pad-right; }
+
+  .romo-grid-table.romo-table-pad-bottom    > .romo-row > .romo-span,
+  .romo-grid-table.romo-table-pad1-bottom   > .romo-row > .romo-span { @include pad1-bottom;   }
+  .romo-grid-table.romo-table-pad0-bottom   > .romo-row > .romo-span { @include pad0-bottom;   }
+  .romo-grid-table.romo-table-pad2-bottom   > .romo-row > .romo-span { @include pad2-bottom;   }
+  .romo-grid-table.romo-table-rm-pad-bottom > .romo-row > .romo-span { @include rm-pad-bottom; }
+
+  .romo-grid-table.romo-table-pad-left    > .romo-row > .romo-span,
+  .romo-grid-table.romo-table-pad1-left   > .romo-row > .romo-span { @include pad1-left;   }
+  .romo-grid-table.romo-table-pad0-left   > .romo-row > .romo-span { @include pad0-left;   }
+  .romo-grid-table.romo-table-pad2-left   > .romo-row > .romo-span { @include pad2-left;   }
+  .romo-grid-table.romo-table-rm-pad-left > .romo-row > .romo-span { @include rm-pad-left; }
+
+  /* emphasis colored rows */
+
+  .romo-grid-table .romo-row.romo-base    { @include bg-base(!important);    }
+  .romo-grid-table .romo-row.romo-alt     { @include bg-alt(!important);     }
+  .romo-grid-table .romo-row.romo-muted   { @include bg-muted(!important);   }
+  .romo-grid-table .romo-row.romo-warning { @include bg-warning(!important); }
+  .romo-grid-table .romo-row.romo-danger  { @include bg-danger(!important);  }
+  .romo-grid-table .romo-row.romo-info    { @include bg-info(!important);    }
+  .romo-grid-table .romo-row.romo-success { @include bg-success(!important); }
+  .romo-grid-table .romo-row.romo-inverse { @include bg-inverse(!important); }
+
+  .romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-base:hover,
+  .romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-base:not(:first-child):hover    { @include bg-base-hover(!important);    }
+  .romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-alt:hover,
+  .romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-alt:not(:first-child):hover     { @include bg-alt-hover(!important);     }
+  .romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-muted:hover,
+  .romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-muted:not(:first-child):hover   { @include bg-muted-hover(!important);   }
+  .romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-warning:hover,
+  .romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-warning:not(:first-child):hover { @include bg-warning-hover(!important); }
+  .romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-danger:hover,
+  .romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-danger:not(:first-child):hover  { @include bg-danger-hover(!important);  }
+  .romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-info:hover,
+  .romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-info:not(:first-child):hover    { @include bg-info-hover(!important);    }
+  .romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-success:hover,
+  .romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-success:not(:first-child):hover { @include bg-success-hover(!important); }
+  .romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-inverse:hover,
+  .romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-inverse:not(:first-child):hover { @include bg-inverse-hover(!important); }
+
+  /* explicit colored rows */
+
+  .romo-grid-table .romo-row.romo-dark-red      { @include bg-dark-red(!important);      }
+  .romo-grid-table .romo-row.romo-red           { @include bg-red(!important);           }
+  .romo-grid-table .romo-row.romo-light-red     { @include bg-light-red(!important);     }
+  .romo-grid-table .romo-row.romo-pastel-red    { @include bg-pastel-red(!important);    }
+  .romo-grid-table .romo-row.romo-dark-orange   { @include bg-dark-orange(!important);   }
+  .romo-grid-table .romo-row.romo-orange        { @include bg-orange(!important);        }
+  .romo-grid-table .romo-row.romo-yellow        { @include bg-yellow(!important);        }
+  .romo-grid-table .romo-row.romo-pastel-yellow { @include bg-pastel-yellow(!important); }
+  .romo-grid-table .romo-row.romo-purple        { @include bg-purple(!important);        }
+  .romo-grid-table .romo-row.romo-light-purple  { @include bg-light-purple(!important);  }
+  .romo-grid-table .romo-row.romo-dark-pink     { @include bg-dark-pink(!important);     }
+  .romo-grid-table .romo-row.romo-hot-pink      { @include bg-hot-pink(!important);      }
+  .romo-grid-table .romo-row.romo-pink          { @include bg-pink(!important);          }
+  .romo-grid-table .romo-row.romo-dark-green    { @include bg-dark-green(!important);    }
+  .romo-grid-table .romo-row.romo-green         { @include bg-green(!important);         }
+  .romo-grid-table .romo-row.romo-light-green   { @include bg-light-green(!important);   }
+  .romo-grid-table .romo-row.romo-pastel-green  { @include bg-pastel-green(!important);  }
+  .romo-grid-table .romo-row.romo-navy          { @include bg-navy(!important);          }
+  .romo-grid-table .romo-row.romo-dark-blue     { @include bg-dark-blue(!important);     }
+  .romo-grid-table .romo-row.romo-blue          { @include bg-blue(!important);          }
+  .romo-grid-table .romo-row.romo-light-blue    { @include bg-light-blue(!important);    }
+  .romo-grid-table .romo-row.romo-pastel-blue   { @include bg-pastel-blue(!important);   }
+
+  .romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-dark-red:hover,
+  .romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-dark-red:not(:first-child):hover      { @include bg-dark-red-hover(!important);      }
+  .romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-red:hover,
+  .romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-red:not(:first-child):hover           { @include bg-red-hover(!important);           }
+  .romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-light-red:hover,
+  .romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-light-red:not(:first-child):hover     { @include bg-light-red-hover(!important);     }
+  .romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-pastel-red:hover,
+  .romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-pastel-red:not(:first-child):hover    { @include bg-pastel-red-hover(!important);    }
+  .romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-dark-orange:hover,
+  .romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-dark-orange:not(:first-child):hover   { @include bg-dark-orange-hover(!important);   }
+  .romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-orange:hover,
+  .romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-orange:not(:first-child):hover        { @include bg-orange-hover(!important);        }
+  .romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-yellow:hover,
+  .romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-yellow:not(:first-child):hover        { @include bg-yellow-hover(!important);        }
+  .romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-pastel-yellow:hover,
+  .romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-pastel-yellow:not(:first-child):hover { @include bg-pastel-yellow-hover(!important); }
+  .romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-purple:hover,
+  .romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-purple:not(:first-child):hover        { @include bg-purple-hover(!important);        }
+  .romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-light-purple:hover,
+  .romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-light-purple:not(:first-child):hover  { @include bg-light-purple-hover(!important);  }
+  .romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-dark-pink:hover,
+  .romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-dark-pink:not(:first-child):hover     { @include bg-dark-pink-hover(!important);     }
+  .romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-hot-pink:hover,
+  .romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-hot-pink:not(:first-child):hover      { @include bg-hot-pink-hover(!important);      }
+  .romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-pink:hover,
+  .romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-pink:not(:first-child):hover          { @include bg-pink-hover(!important);          }
+  .romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-dark-green:hover,
+  .romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-dark-green:not(:first-child):hover    { @include bg-dark-green-hover(!important);    }
+  .romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-green:hover,
+  .romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-green:not(:first-child):hover         { @include bg-green-hover(!important);         }
+  .romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-light-green:hover,
+  .romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-light-green:not(:first-child):hover   { @include bg-light-green-hover(!important);   }
+  .romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-pastel-green:hover,
+  .romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-pastel-green:not(:first-child):hover  { @include bg-pastel-green-hover(!important);  }
+  .romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-navy:hover,
+  .romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-navy:not(:first-child):hover          { @include bg-navy-hover(!important);          }
+  .romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-dark-blue:hover,
+  .romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-dark-blue:not(:first-child):hover     { @include bg-dark-blue-hover(!important);     }
+  .romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-blue:hover,
+  .romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-blue:not(:first-child):hover          { @include bg-blue-hover(!important);          }
+  .romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-light-blue:hover,
+  .romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-light-blue:not(:first-child):hover    { @include bg-light-blue-hover(!important);    }
+  .romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-pastel-blue:hover,
+  .romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-pastel-blue:not(:first-child):hover   { @include bg-pastel-blue-hover(!important);   }
+
+  /* emphasis colored borders */
+
+  .romo-grid-table-border-muted   { @include border-muted;   }
+  .romo-grid-table-border-warning { @include border-warning; }
+  .romo-grid-table-border-danger  { @include border-danger;  }
+  .romo-grid-table-border-info    { @include border-info;    }
+  .romo-grid-table-border-success { @include border-success; }
+  .romo-grid-table-border-inverse { @include border-inverse; }
+  .romo-grid-table-border-alt     { @include border-alt;     }
+
+  .romo-grid-table-border-muted   > .romo-row { @include border-muted;   }
+  .romo-grid-table-border-warning > .romo-row { @include border-warning; }
+  .romo-grid-table-border-danger  > .romo-row { @include border-danger;  }
+  .romo-grid-table-border-info    > .romo-row { @include border-info;    }
+  .romo-grid-table-border-success > .romo-row { @include border-success; }
+  .romo-grid-table-border-inverse > .romo-row { @include border-inverse; }
+  .romo-grid-table-border-alt     > .romo-row { @include border-alt;     }
+
+  .romo-grid-table-border-muted   > .romo-row > .romo-span { @include border-muted;   }
+  .romo-grid-table-border-warning > .romo-row > .romo-span { @include border-warning; }
+  .romo-grid-table-border-danger  > .romo-row > .romo-span { @include border-danger;  }
+  .romo-grid-table-border-info    > .romo-row > .romo-span { @include border-info;    }
+  .romo-grid-table-border-success > .romo-row > .romo-span { @include border-success; }
+  .romo-grid-table-border-inverse > .romo-row > .romo-span { @include border-inverse; }
+  .romo-grid-table-border-alt     > .romo-row > .romo-span { @include border-alt;     }
+
+  /* explicit colored borders */
+
+  .romo-grid-table-border-dark-red      { @include border-dark-red;      }
+  .romo-grid-table-border-red           { @include border-red;           }
+  .romo-grid-table-border-light-red     { @include border-light-red;     }
+  .romo-grid-table-border-pastel-red    { @include border-pastel-red;    }
+  .romo-grid-table-border-dark-orange   { @include border-dark-orange;   }
+  .romo-grid-table-border-orange        { @include border-orange;        }
+  .romo-grid-table-border-yellow        { @include border-yellow;        }
+  .romo-grid-table-border-pastel-yellow { @include border-pastel-yellow; }
+  .romo-grid-table-border-purple        { @include border-purple;        }
+  .romo-grid-table-border-light-purple  { @include border-light-purple;  }
+  .romo-grid-table-border-dark-pink     { @include border-dark-pink;     }
+  .romo-grid-table-border-hot-pink      { @include border-hot-pink;      }
+  .romo-grid-table-border-pink          { @include border-pink;          }
+  .romo-grid-table-border-dark-green    { @include border-dark-green;    }
+  .romo-grid-table-border-green         { @include border-green;         }
+  .romo-grid-table-border-light-green   { @include border-light-green;   }
+  .romo-grid-table-border-pastel-green  { @include border-pastel-green;  }
+  .romo-grid-table-border-navy          { @include border-navy;          }
+  .romo-grid-table-border-dark-blue     { @include border-dark-blue;     }
+  .romo-grid-table-border-blue          { @include border-blue;          }
+  .romo-grid-table-border-light-blue    { @include border-light-blue;    }
+  .romo-grid-table-border-pastel-blue   { @include border-pastel-blue;   }
+
+  .romo-grid-table-border-dark-red      > .romo-row { @include border-dark-red;      }
+  .romo-grid-table-border-red           > .romo-row { @include border-red;           }
+  .romo-grid-table-border-light-red     > .romo-row { @include border-light-red;     }
+  .romo-grid-table-border-pastel-red    > .romo-row { @include border-pastel-red;    }
+  .romo-grid-table-border-dark-orange   > .romo-row { @include border-dark-orange;   }
+  .romo-grid-table-border-orange        > .romo-row { @include border-orange;        }
+  .romo-grid-table-border-yellow        > .romo-row { @include border-yellow;        }
+  .romo-grid-table-border-pastel-yellow > .romo-row { @include border-pastel-yellow; }
+  .romo-grid-table-border-purple        > .romo-row { @include border-purple;        }
+  .romo-grid-table-border-light-purple  > .romo-row { @include border-light-purple;  }
+  .romo-grid-table-border-dark-pink     > .romo-row { @include border-dark-pink;     }
+  .romo-grid-table-border-hot-pink      > .romo-row { @include border-hot-pink;      }
+  .romo-grid-table-border-pink          > .romo-row { @include border-pink;          }
+  .romo-grid-table-border-dark-green    > .romo-row { @include border-dark-green;    }
+  .romo-grid-table-border-green         > .romo-row { @include border-green;         }
+  .romo-grid-table-border-light-green   > .romo-row { @include border-light-green;   }
+  .romo-grid-table-border-pastel-green  > .romo-row { @include border-pastel-green;  }
+  .romo-grid-table-border-navy          > .romo-row { @include border-navy;          }
+  .romo-grid-table-border-dark-blue     > .romo-row { @include border-dark-blue;     }
+  .romo-grid-table-border-blue          > .romo-row { @include border-blue;          }
+  .romo-grid-table-border-light-blue    > .romo-row { @include border-light-blue;    }
+  .romo-grid-table-border-pastel-blue   > .romo-row { @include border-pastel-blue;   }
+
+  .romo-grid-table-border-dark-red      > .romo-row > .romo-span { @include border-dark-red;      }
+  .romo-grid-table-border-red           > .romo-row > .romo-span { @include border-red;           }
+  .romo-grid-table-border-light-red     > .romo-row > .romo-span { @include border-light-red;     }
+  .romo-grid-table-border-pastel-red    > .romo-row > .romo-span { @include border-pastel-red;    }
+  .romo-grid-table-border-dark-orange   > .romo-row > .romo-span { @include border-dark-orange;   }
+  .romo-grid-table-border-orange        > .romo-row > .romo-span { @include border-orange;        }
+  .romo-grid-table-border-yellow        > .romo-row > .romo-span { @include border-yellow;        }
+  .romo-grid-table-border-pastel-yellow > .romo-row > .romo-span { @include border-pastel-yellow; }
+  .romo-grid-table-border-purple        > .romo-row > .romo-span { @include border-purple;        }
+  .romo-grid-table-border-light-purple  > .romo-row > .romo-span { @include border-light-purple;  }
+  .romo-grid-table-border-dark-pink     > .romo-row > .romo-span { @include border-dark-pink;     }
+  .romo-grid-table-border-hot-pink      > .romo-row > .romo-span { @include border-hot-pink;      }
+  .romo-grid-table-border-pink          > .romo-row > .romo-span { @include border-pink;          }
+  .romo-grid-table-border-dark-green    > .romo-row > .romo-span { @include border-dark-green;    }
+  .romo-grid-table-border-green         > .romo-row > .romo-span { @include border-green;         }
+  .romo-grid-table-border-light-green   > .romo-row > .romo-span { @include border-light-green;   }
+  .romo-grid-table-border-pastel-green  > .romo-row > .romo-span { @include border-pastel-green;  }
+  .romo-grid-table-border-navy          > .romo-row > .romo-span { @include border-navy;          }
+  .romo-grid-table-border-dark-blue     > .romo-row > .romo-span { @include border-dark-blue;     }
+  .romo-grid-table-border-blue          > .romo-row > .romo-span { @include border-blue;          }
+  .romo-grid-table-border-light-blue    > .romo-row > .romo-span { @include border-light-blue;    }
+  .romo-grid-table-border-pastel-blue   > .romo-row > .romo-span { @include border-pastel-blue;   }
+
 }
-
-ul.romo-grid-table,
-ol.romo-grid-table { @include list-unstyled(!important); }
-
-.romo-grid-table > .romo-row { @include border1-bottom; }
-
-.romo-grid-table.romo-grid-table-header > .romo-row:first-child > .romo-span { @include font-weight(bold); }
-.romo-grid-table.romo-grid-table-header > .romo-row:first-child > .romo-span { @include align-bottom; }
-
-.romo-grid-table > .romo-row > .romo-span {
-  @include rm-pad;
-  @include rm-push;
-  @include align-left;
-  @include align-middle;
-}
-
-.romo-grid-table-alt { @include bg-alt; }
-
-.romo-grid-table-striped:not(.romo-grid-table-header) > .romo-row:nth-child(odd) { @include bg-striped; }
-.romo-grid-table-striped:not(.romo-grid-table-header).romo-grid-table-striped-alt > .romo-row:nth-child(odd) { @include bg-base; }
-.romo-grid-table-striped.romo-grid-table-header > .romo-row:nth-child(even) { @include bg-striped; }
-.romo-grid-table-striped.romo-grid-table-header.romo-grid-table-striped-alt > .romo-row:nth-child(even) { @include bg-base; }
-.romo-grid-table-striped.romo-grid-table-striped-alt { @include bg-striped; }
-
-.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row:hover,
-.romo-grid-table-hover:not(.romo-grid-table-header).romo-grid-table-alt > .romo-row:hover,
-.romo-grid-table-hover:not(.romo-grid-table-header).romo-grid-table-striped > .romo-row:hover,
-.romo-grid-table-hover:not(.romo-grid-table-header).romo-grid-table-striped-alt > .romo-row:hover { @include bg-hover; }
-.romo-grid-table-hover.romo-grid-table-header > .romo-row:not(:first-child):hover,
-.romo-grid-table-hover.romo-grid-table-header.romo-grid-table-alt > .romo-row:not(:first-child):hover { @include bg-hover; }
-
-.romo-grid-table-border,
-.romo-grid-table-border1     { @include border1;            }
-.romo-grid-table-border0     { @include border0;            }
-.romo-grid-table-border2     { @include border2;            }
-.romo-grid-table-border-none { @include border-style(none); }
-
-.romo-grid-table.romo-grid-table-border      > .romo-row,
-.romo-grid-table.romo-grid-table-border1     > .romo-row { @include border1-bottom;     }
-.romo-grid-table.romo-grid-table-border0     > .romo-row { @include border0-bottom;     }
-.romo-grid-table.romo-grid-table-border2     > .romo-row { @include border2-bottom;     }
-.romo-grid-table.romo-grid-table-border-none > .romo-row { @include border-style(none); }
-
-.romo-grid-table.romo-grid-table-border      > .romo-row > .romo-span,
-.romo-grid-table.romo-grid-table-border1     > .romo-row > .romo-span { @include border1-right;      white-space: nowrap; overflow: hidden; }
-.romo-grid-table.romo-grid-table-border0     > .romo-row > .romo-span { @include border0-right;      white-space: nowrap; overflow: hidden; }
-.romo-grid-table.romo-grid-table-border2     > .romo-row > .romo-span { @include border2-right;      white-space: nowrap; overflow: hidden; }
-.romo-grid-table.romo-grid-table-border-none > .romo-row > .romo-span { @include border-style(none); white-space: nowrap; overflow: hidden; }
-
-.romo-grid-table[class*="romo-grid-table-border"] > .romo-row > .romo-span:last-child { @include rm-border-right; }
-.romo-grid-table[class*="romo-grid-table-border"] > .romo-row:last-child { @include rm-border-bottom; }
-
-.romo-grid-table.romo-grid-table-pad    > .romo-row > .romo-span,
-.romo-grid-table.romo-grid-table-pad1   > .romo-row > .romo-span { @include pad1;   }
-.romo-grid-table.romo-grid-table-pad0   > .romo-row > .romo-span { @include pad0;   }
-.romo-grid-table.romo-grid-table-pad2   > .romo-row > .romo-span { @include pad2;   }
-.romo-grid-table.romo-grid-table-rm-pad > .romo-row > .romo-span { @include rm-pad; }
-
-.romo-grid-table.romo-table-pad-top    > .romo-row > .romo-span,
-.romo-grid-table.romo-table-pad1-top   > .romo-row > .romo-span { @include pad1-top;   }
-.romo-grid-table.romo-table-pad0-top   > .romo-row > .romo-span { @include pad0-top;   }
-.romo-grid-table.romo-table-pad2-top   > .romo-row > .romo-span { @include pad2-top;   }
-.romo-grid-table.romo-table-rm-pad-top > .romo-row > .romo-span { @include rm-pad-top; }
-
-.romo-grid-table.romo-table-pad-right    > .romo-row > .romo-span,
-.romo-grid-table.romo-table-pad1-right   > .romo-row > .romo-span { @include pad1-right;   }
-.romo-grid-table.romo-table-pad0-right   > .romo-row > .romo-span { @include pad0-right;   }
-.romo-grid-table.romo-table-pad2-right   > .romo-row > .romo-span { @include pad2-right;   }
-.romo-grid-table.romo-table-rm-pad-right > .romo-row > .romo-span { @include rm-pad-right; }
-
-.romo-grid-table.romo-table-pad-bottom    > .romo-row > .romo-span,
-.romo-grid-table.romo-table-pad1-bottom   > .romo-row > .romo-span { @include pad1-bottom;   }
-.romo-grid-table.romo-table-pad0-bottom   > .romo-row > .romo-span { @include pad0-bottom;   }
-.romo-grid-table.romo-table-pad2-bottom   > .romo-row > .romo-span { @include pad2-bottom;   }
-.romo-grid-table.romo-table-rm-pad-bottom > .romo-row > .romo-span { @include rm-pad-bottom; }
-
-.romo-grid-table.romo-table-pad-left    > .romo-row > .romo-span,
-.romo-grid-table.romo-table-pad1-left   > .romo-row > .romo-span { @include pad1-left;   }
-.romo-grid-table.romo-table-pad0-left   > .romo-row > .romo-span { @include pad0-left;   }
-.romo-grid-table.romo-table-pad2-left   > .romo-row > .romo-span { @include pad2-left;   }
-.romo-grid-table.romo-table-rm-pad-left > .romo-row > .romo-span { @include rm-pad-left; }
-
-/* emphasis colored rows */
-
-.romo-grid-table .romo-row.romo-base    { @include bg-base(!important);    }
-.romo-grid-table .romo-row.romo-alt     { @include bg-alt(!important);     }
-.romo-grid-table .romo-row.romo-muted   { @include bg-muted(!important);   }
-.romo-grid-table .romo-row.romo-warning { @include bg-warning(!important); }
-.romo-grid-table .romo-row.romo-danger  { @include bg-danger(!important);  }
-.romo-grid-table .romo-row.romo-info    { @include bg-info(!important);    }
-.romo-grid-table .romo-row.romo-success { @include bg-success(!important); }
-.romo-grid-table .romo-row.romo-inverse { @include bg-inverse(!important); }
-
-.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-base:hover,
-.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-base:not(:first-child):hover    { @include bg-base-hover(!important);    }
-.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-alt:hover,
-.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-alt:not(:first-child):hover     { @include bg-alt-hover(!important);     }
-.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-muted:hover,
-.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-muted:not(:first-child):hover   { @include bg-muted-hover(!important);   }
-.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-warning:hover,
-.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-warning:not(:first-child):hover { @include bg-warning-hover(!important); }
-.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-danger:hover,
-.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-danger:not(:first-child):hover  { @include bg-danger-hover(!important);  }
-.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-info:hover,
-.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-info:not(:first-child):hover    { @include bg-info-hover(!important);    }
-.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-success:hover,
-.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-success:not(:first-child):hover { @include bg-success-hover(!important); }
-.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-inverse:hover,
-.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-inverse:not(:first-child):hover { @include bg-inverse-hover(!important); }
-
-/* explicit colored rows */
-
-.romo-grid-table .romo-row.romo-dark-red      { @include bg-dark-red(!important);      }
-.romo-grid-table .romo-row.romo-red           { @include bg-red(!important);           }
-.romo-grid-table .romo-row.romo-light-red     { @include bg-light-red(!important);     }
-.romo-grid-table .romo-row.romo-pastel-red    { @include bg-pastel-red(!important);    }
-.romo-grid-table .romo-row.romo-dark-orange   { @include bg-dark-orange(!important);   }
-.romo-grid-table .romo-row.romo-orange        { @include bg-orange(!important);        }
-.romo-grid-table .romo-row.romo-yellow        { @include bg-yellow(!important);        }
-.romo-grid-table .romo-row.romo-pastel-yellow { @include bg-pastel-yellow(!important); }
-.romo-grid-table .romo-row.romo-purple        { @include bg-purple(!important);        }
-.romo-grid-table .romo-row.romo-light-purple  { @include bg-light-purple(!important);  }
-.romo-grid-table .romo-row.romo-dark-pink     { @include bg-dark-pink(!important);     }
-.romo-grid-table .romo-row.romo-hot-pink      { @include bg-hot-pink(!important);      }
-.romo-grid-table .romo-row.romo-pink          { @include bg-pink(!important);          }
-.romo-grid-table .romo-row.romo-dark-green    { @include bg-dark-green(!important);    }
-.romo-grid-table .romo-row.romo-green         { @include bg-green(!important);         }
-.romo-grid-table .romo-row.romo-light-green   { @include bg-light-green(!important);   }
-.romo-grid-table .romo-row.romo-pastel-green  { @include bg-pastel-green(!important);  }
-.romo-grid-table .romo-row.romo-navy          { @include bg-navy(!important);          }
-.romo-grid-table .romo-row.romo-dark-blue     { @include bg-dark-blue(!important);     }
-.romo-grid-table .romo-row.romo-blue          { @include bg-blue(!important);          }
-.romo-grid-table .romo-row.romo-light-blue    { @include bg-light-blue(!important);    }
-.romo-grid-table .romo-row.romo-pastel-blue   { @include bg-pastel-blue(!important);   }
-
-.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-dark-red:hover,
-.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-dark-red:not(:first-child):hover      { @include bg-dark-red-hover(!important);      }
-.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-red:hover,
-.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-red:not(:first-child):hover           { @include bg-red-hover(!important);           }
-.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-light-red:hover,
-.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-light-red:not(:first-child):hover     { @include bg-light-red-hover(!important);     }
-.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-pastel-red:hover,
-.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-pastel-red:not(:first-child):hover    { @include bg-pastel-red-hover(!important);    }
-.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-dark-orange:hover,
-.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-dark-orange:not(:first-child):hover   { @include bg-dark-orange-hover(!important);   }
-.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-orange:hover,
-.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-orange:not(:first-child):hover        { @include bg-orange-hover(!important);        }
-.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-yellow:hover,
-.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-yellow:not(:first-child):hover        { @include bg-yellow-hover(!important);        }
-.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-pastel-yellow:hover,
-.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-pastel-yellow:not(:first-child):hover { @include bg-pastel-yellow-hover(!important); }
-.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-purple:hover,
-.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-purple:not(:first-child):hover        { @include bg-purple-hover(!important);        }
-.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-light-purple:hover,
-.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-light-purple:not(:first-child):hover  { @include bg-light-purple-hover(!important);  }
-.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-dark-pink:hover,
-.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-dark-pink:not(:first-child):hover     { @include bg-dark-pink-hover(!important);     }
-.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-hot-pink:hover,
-.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-hot-pink:not(:first-child):hover      { @include bg-hot-pink-hover(!important);      }
-.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-pink:hover,
-.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-pink:not(:first-child):hover          { @include bg-pink-hover(!important);          }
-.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-dark-green:hover,
-.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-dark-green:not(:first-child):hover    { @include bg-dark-green-hover(!important);    }
-.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-green:hover,
-.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-green:not(:first-child):hover         { @include bg-green-hover(!important);         }
-.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-light-green:hover,
-.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-light-green:not(:first-child):hover   { @include bg-light-green-hover(!important);   }
-.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-pastel-green:hover,
-.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-pastel-green:not(:first-child):hover  { @include bg-pastel-green-hover(!important);  }
-.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-navy:hover,
-.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-navy:not(:first-child):hover          { @include bg-navy-hover(!important);          }
-.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-dark-blue:hover,
-.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-dark-blue:not(:first-child):hover     { @include bg-dark-blue-hover(!important);     }
-.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-blue:hover,
-.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-blue:not(:first-child):hover          { @include bg-blue-hover(!important);          }
-.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-light-blue:hover,
-.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-light-blue:not(:first-child):hover    { @include bg-light-blue-hover(!important);    }
-.romo-grid-table-hover:not(.romo-grid-table-header) > .romo-row.romo-pastel-blue:hover,
-.romo-grid-table-hover.romo-grid-table-header > .romo-row.romo-pastel-blue:not(:first-child):hover   { @include bg-pastel-blue-hover(!important);   }
-
-/* emphasis colored borders */
-
-.romo-grid-table-border-muted   { @include border-muted;   }
-.romo-grid-table-border-warning { @include border-warning; }
-.romo-grid-table-border-danger  { @include border-danger;  }
-.romo-grid-table-border-info    { @include border-info;    }
-.romo-grid-table-border-success { @include border-success; }
-.romo-grid-table-border-inverse { @include border-inverse; }
-.romo-grid-table-border-alt     { @include border-alt;     }
-
-.romo-grid-table-border-muted   > .romo-row { @include border-muted;   }
-.romo-grid-table-border-warning > .romo-row { @include border-warning; }
-.romo-grid-table-border-danger  > .romo-row { @include border-danger;  }
-.romo-grid-table-border-info    > .romo-row { @include border-info;    }
-.romo-grid-table-border-success > .romo-row { @include border-success; }
-.romo-grid-table-border-inverse > .romo-row { @include border-inverse; }
-.romo-grid-table-border-alt     > .romo-row { @include border-alt;     }
-
-.romo-grid-table-border-muted   > .romo-row > .romo-span { @include border-muted;   }
-.romo-grid-table-border-warning > .romo-row > .romo-span { @include border-warning; }
-.romo-grid-table-border-danger  > .romo-row > .romo-span { @include border-danger;  }
-.romo-grid-table-border-info    > .romo-row > .romo-span { @include border-info;    }
-.romo-grid-table-border-success > .romo-row > .romo-span { @include border-success; }
-.romo-grid-table-border-inverse > .romo-row > .romo-span { @include border-inverse; }
-.romo-grid-table-border-alt     > .romo-row > .romo-span { @include border-alt;     }
-
-/* explicit colored borders */
-
-.romo-grid-table-border-dark-red      { @include border-dark-red;      }
-.romo-grid-table-border-red           { @include border-red;           }
-.romo-grid-table-border-light-red     { @include border-light-red;     }
-.romo-grid-table-border-pastel-red    { @include border-pastel-red;    }
-.romo-grid-table-border-dark-orange   { @include border-dark-orange;   }
-.romo-grid-table-border-orange        { @include border-orange;        }
-.romo-grid-table-border-yellow        { @include border-yellow;        }
-.romo-grid-table-border-pastel-yellow { @include border-pastel-yellow; }
-.romo-grid-table-border-purple        { @include border-purple;        }
-.romo-grid-table-border-light-purple  { @include border-light-purple;  }
-.romo-grid-table-border-dark-pink     { @include border-dark-pink;     }
-.romo-grid-table-border-hot-pink      { @include border-hot-pink;      }
-.romo-grid-table-border-pink          { @include border-pink;          }
-.romo-grid-table-border-dark-green    { @include border-dark-green;    }
-.romo-grid-table-border-green         { @include border-green;         }
-.romo-grid-table-border-light-green   { @include border-light-green;   }
-.romo-grid-table-border-pastel-green  { @include border-pastel-green;  }
-.romo-grid-table-border-navy          { @include border-navy;          }
-.romo-grid-table-border-dark-blue     { @include border-dark-blue;     }
-.romo-grid-table-border-blue          { @include border-blue;          }
-.romo-grid-table-border-light-blue    { @include border-light-blue;    }
-.romo-grid-table-border-pastel-blue   { @include border-pastel-blue;   }
-
-.romo-grid-table-border-dark-red      > .romo-row { @include border-dark-red;      }
-.romo-grid-table-border-red           > .romo-row { @include border-red;           }
-.romo-grid-table-border-light-red     > .romo-row { @include border-light-red;     }
-.romo-grid-table-border-pastel-red    > .romo-row { @include border-pastel-red;    }
-.romo-grid-table-border-dark-orange   > .romo-row { @include border-dark-orange;   }
-.romo-grid-table-border-orange        > .romo-row { @include border-orange;        }
-.romo-grid-table-border-yellow        > .romo-row { @include border-yellow;        }
-.romo-grid-table-border-pastel-yellow > .romo-row { @include border-pastel-yellow; }
-.romo-grid-table-border-purple        > .romo-row { @include border-purple;        }
-.romo-grid-table-border-light-purple  > .romo-row { @include border-light-purple;  }
-.romo-grid-table-border-dark-pink     > .romo-row { @include border-dark-pink;     }
-.romo-grid-table-border-hot-pink      > .romo-row { @include border-hot-pink;      }
-.romo-grid-table-border-pink          > .romo-row { @include border-pink;          }
-.romo-grid-table-border-dark-green    > .romo-row { @include border-dark-green;    }
-.romo-grid-table-border-green         > .romo-row { @include border-green;         }
-.romo-grid-table-border-light-green   > .romo-row { @include border-light-green;   }
-.romo-grid-table-border-pastel-green  > .romo-row { @include border-pastel-green;  }
-.romo-grid-table-border-navy          > .romo-row { @include border-navy;          }
-.romo-grid-table-border-dark-blue     > .romo-row { @include border-dark-blue;     }
-.romo-grid-table-border-blue          > .romo-row { @include border-blue;          }
-.romo-grid-table-border-light-blue    > .romo-row { @include border-light-blue;    }
-.romo-grid-table-border-pastel-blue   > .romo-row { @include border-pastel-blue;   }
-
-.romo-grid-table-border-dark-red      > .romo-row > .romo-span { @include border-dark-red;      }
-.romo-grid-table-border-red           > .romo-row > .romo-span { @include border-red;           }
-.romo-grid-table-border-light-red     > .romo-row > .romo-span { @include border-light-red;     }
-.romo-grid-table-border-pastel-red    > .romo-row > .romo-span { @include border-pastel-red;    }
-.romo-grid-table-border-dark-orange   > .romo-row > .romo-span { @include border-dark-orange;   }
-.romo-grid-table-border-orange        > .romo-row > .romo-span { @include border-orange;        }
-.romo-grid-table-border-yellow        > .romo-row > .romo-span { @include border-yellow;        }
-.romo-grid-table-border-pastel-yellow > .romo-row > .romo-span { @include border-pastel-yellow; }
-.romo-grid-table-border-purple        > .romo-row > .romo-span { @include border-purple;        }
-.romo-grid-table-border-light-purple  > .romo-row > .romo-span { @include border-light-purple;  }
-.romo-grid-table-border-dark-pink     > .romo-row > .romo-span { @include border-dark-pink;     }
-.romo-grid-table-border-hot-pink      > .romo-row > .romo-span { @include border-hot-pink;      }
-.romo-grid-table-border-pink          > .romo-row > .romo-span { @include border-pink;          }
-.romo-grid-table-border-dark-green    > .romo-row > .romo-span { @include border-dark-green;    }
-.romo-grid-table-border-green         > .romo-row > .romo-span { @include border-green;         }
-.romo-grid-table-border-light-green   > .romo-row > .romo-span { @include border-light-green;   }
-.romo-grid-table-border-pastel-green  > .romo-row > .romo-span { @include border-pastel-green;  }
-.romo-grid-table-border-navy          > .romo-row > .romo-span { @include border-navy;          }
-.romo-grid-table-border-dark-blue     > .romo-row > .romo-span { @include border-dark-blue;     }
-.romo-grid-table-border-blue          > .romo-row > .romo-span { @include border-blue;          }
-.romo-grid-table-border-light-blue    > .romo-row > .romo-span { @include border-light-blue;    }
-.romo-grid-table-border-pastel-blue   > .romo-row > .romo-span { @include border-pastel-blue;   }

--- a/assets/css/romo/indicator_text_input.scss
+++ b/assets/css/romo/indicator_text_input.scss
@@ -1,18 +1,22 @@
 @import 'css/romo/vars';
 @import 'css/romo/mixins';
 
-.romo-indicator-text-input-wrapper {
-  position: relative;
-}
+.romo {
 
-.romo-indicator-text-input-indicator {
-  display: inline-block;
-  position: absolute;
-  top: 0px;
-  vertical-align: middle;
-  cursor: pointer;
-}
-.romo-indicator-text-input-indicator.disabled {
-  cursor: $notAllowedCursor;
-  color: $disabledColor;
+  .romo-indicator-text-input-wrapper {
+    position: relative;
+  }
+
+  .romo-indicator-text-input-indicator {
+    display: inline-block;
+    position: absolute;
+    top: 0px;
+    vertical-align: middle;
+    cursor: pointer;
+  }
+  .romo-indicator-text-input-indicator.disabled {
+    cursor: $notAllowedCursor;
+    color: $disabledColor;
+  }
+
 }

--- a/assets/css/romo/labels.scss
+++ b/assets/css/romo/labels.scss
@@ -1,67 +1,71 @@
 @import 'css/romo/vars';
 @import 'css/romo/mixins';
 
-.romo-label {
-  display:          inline-block;
-  font-size:        $baseFontSize;
-  line-height:      $baseLineHeight;
-  background-color: $btnAltBgHover;
-  color:            $btnAltColor;
+.romo {
 
-  @include label-pad($baseLineHeight);
-  @include rm-push;
-  @include align-center;
-  @include align-middle;
+  .romo-label {
+    display:          inline-block;
+    font-size:        $baseFontSize;
+    line-height:      $baseLineHeight;
+    background-color: $btnAltBgHover;
+    color:            $btnAltColor;
+
+    @include label-pad($baseLineHeight);
+    @include rm-push;
+    @include align-center;
+    @include align-middle;
+  }
+
+  .romo-label.romo-label-small,
+  .romo-label.romo-label0 { @include font-size0; @include font-weight0; @include line-height0; @include label-pad0; }
+  .romo-label,
+  .romo-label.romo-label1 { @include font-size1; @include font-weight1; @include line-height1; @include label-pad1; }
+  .romo-label.romo-label-large,
+  .romo-label.romo-label2 { @include font-size2; @include font-weight2; @include line-height2; @include label-pad2; }
+  .romo-label.romo-label3 { @include font-size3; @include font-weight3; @include line-height3; @include label-pad3; }
+
+  .romo-label-inline-small,
+  .romo-label-inline0 { @include label-inline0; }
+  .romo-label-inline,
+  .romo-label-inline1 { @include label-inline1; }
+  .romo-label-inline-large,
+  .romo-label-inline2 { @include label-inline2; }
+  .romo-label-inline3 { @include label-inline3; }
+
+  .romo-label-block { display: block; width: 100%; }
+
+  /* emphasis colored labels */
+
+  .romo-label.romo-label-alt     { background-color: $btnBg;        color: $btnColor;        }
+  .romo-label.romo-label-inverse { background-color: $btnInverseBg; color: $btnInverseColor; }
+  .romo-label.romo-label-warning { background-color: $btnWarningBg; color: $btnWarningColor; }
+  .romo-label.romo-label-danger  { background-color: $btnDangerBg;  color: $btnDangerColor;  }
+  .romo-label.romo-label-info    { background-color: $btnInfoBg;    color: $btnInfoColor;    }
+  .romo-label.romo-label-success { background-color: $btnSuccessBg; color: $btnSuccessColor; }
+
+  /* explicit colored labels */
+
+  .romo-label.romo-label-dark-red      { background-color: $btnDarkRedBg;      color: $btnDarkRedColor;      }
+  .romo-label.romo-label-red           { background-color: $btnRedBg;          color: $btnRedColor;          }
+  .romo-label.romo-label-light-red     { background-color: $btnLightRedBg;     color: $btnLightRedColor;     }
+  .romo-label.romo-label-pastel-red    { background-color: $btnPastelRedBg;    color: $btnPastelRedColor;    }
+  .romo-label.romo-label-dark-orange   { background-color: $btnDarkOrangeBg;   color: $btnDarkOrangeColor;   }
+  .romo-label.romo-label-orange        { background-color: $btnOrangeBg;       color: $btnOrangeColor;       }
+  .romo-label.romo-label-yellow        { background-color: $btnYellowBg;       color: $btnYellowColor;       }
+  .romo-label.romo-label-pastel-yellow { background-color: $btnPastelYellowBg; color: $btnPastelYellowColor; }
+  .romo-label.romo-label-purple        { background-color: $btnPurpleBg;       color: $btnPurpleColor;       }
+  .romo-label.romo-label-light-purple  { background-color: $btnLightPurpleBg;  color: $btnLightPurpleColor;  }
+  .romo-label.romo-label-dark-pink     { background-color: $btnDarkPinkBg;     color: $btnDarkPinkColor;     }
+  .romo-label.romo-label-hot-pink      { background-color: $btnHotPinkBg;      color: $btnHotPinkColor;      }
+  .romo-label.romo-label-pink          { background-color: $btnPinkBg;         color: $btnPinkColor;         }
+  .romo-label.romo-label-dark-green    { background-color: $btnDarkGreenBg;    color: $btnDarkGreenColor;    }
+  .romo-label.romo-label-green         { background-color: $btnGreenBg;        color: $btnGreenColor;        }
+  .romo-label.romo-label-light-green   { background-color: $btnLightGreenBg;   color: $btnLightGreenColor;   }
+  .romo-label.romo-label-pastel-green  { background-color: $btnPastelGreenBg;  color: $btnPastelGreenColor;  }
+  .romo-label.romo-label-navy          { background-color: $btnNavyBg;         color: $btnNavyColor;         }
+  .romo-label.romo-label-dark-blue     { background-color: $btnDarkBlueBg;     color: $btnDarkBlueColor;     }
+  .romo-label.romo-label-blue          { background-color: $btnBlueBg;         color: $btnBlueColor;         }
+  .romo-label.romo-label-light-blue    { background-color: $btnLightBlueBg;    color: $btnLightBlueColor;    }
+  .romo-label.romo-label-pastel-blue   { background-color: $btnPastelBlueBg;   color: $btnPastelBlueColor;   }
+
 }
-
-.romo-label.romo-label-small,
-.romo-label.romo-label0 { @include font-size0; @include font-weight0; @include line-height0; @include label-pad0; }
-.romo-label,
-.romo-label.romo-label1 { @include font-size1; @include font-weight1; @include line-height1; @include label-pad1; }
-.romo-label.romo-label-large,
-.romo-label.romo-label2 { @include font-size2; @include font-weight2; @include line-height2; @include label-pad2; }
-.romo-label.romo-label3 { @include font-size3; @include font-weight3; @include line-height3; @include label-pad3; }
-
-.romo-label-inline-small,
-.romo-label-inline0 { @include label-inline0; }
-.romo-label-inline,
-.romo-label-inline1 { @include label-inline1; }
-.romo-label-inline-large,
-.romo-label-inline2 { @include label-inline2; }
-.romo-label-inline3 { @include label-inline3; }
-
-.romo-label-block { display: block; width: 100%; }
-
-/* emphasis colored labels */
-
-.romo-label.romo-label-alt     { background-color: $btnBg;        color: $btnColor;        }
-.romo-label.romo-label-inverse { background-color: $btnInverseBg; color: $btnInverseColor; }
-.romo-label.romo-label-warning { background-color: $btnWarningBg; color: $btnWarningColor; }
-.romo-label.romo-label-danger  { background-color: $btnDangerBg;  color: $btnDangerColor;  }
-.romo-label.romo-label-info    { background-color: $btnInfoBg;    color: $btnInfoColor;    }
-.romo-label.romo-label-success { background-color: $btnSuccessBg; color: $btnSuccessColor; }
-
-/* explicit colored labels */
-
-.romo-label.romo-label-dark-red      { background-color: $btnDarkRedBg;      color: $btnDarkRedColor;      }
-.romo-label.romo-label-red           { background-color: $btnRedBg;          color: $btnRedColor;          }
-.romo-label.romo-label-light-red     { background-color: $btnLightRedBg;     color: $btnLightRedColor;     }
-.romo-label.romo-label-pastel-red    { background-color: $btnPastelRedBg;    color: $btnPastelRedColor;    }
-.romo-label.romo-label-dark-orange   { background-color: $btnDarkOrangeBg;   color: $btnDarkOrangeColor;   }
-.romo-label.romo-label-orange        { background-color: $btnOrangeBg;       color: $btnOrangeColor;       }
-.romo-label.romo-label-yellow        { background-color: $btnYellowBg;       color: $btnYellowColor;       }
-.romo-label.romo-label-pastel-yellow { background-color: $btnPastelYellowBg; color: $btnPastelYellowColor; }
-.romo-label.romo-label-purple        { background-color: $btnPurpleBg;       color: $btnPurpleColor;       }
-.romo-label.romo-label-light-purple  { background-color: $btnLightPurpleBg;  color: $btnLightPurpleColor;  }
-.romo-label.romo-label-dark-pink     { background-color: $btnDarkPinkBg;     color: $btnDarkPinkColor;     }
-.romo-label.romo-label-hot-pink      { background-color: $btnHotPinkBg;      color: $btnHotPinkColor;      }
-.romo-label.romo-label-pink          { background-color: $btnPinkBg;         color: $btnPinkColor;         }
-.romo-label.romo-label-dark-green    { background-color: $btnDarkGreenBg;    color: $btnDarkGreenColor;    }
-.romo-label.romo-label-green         { background-color: $btnGreenBg;        color: $btnGreenColor;        }
-.romo-label.romo-label-light-green   { background-color: $btnLightGreenBg;   color: $btnLightGreenColor;   }
-.romo-label.romo-label-pastel-green  { background-color: $btnPastelGreenBg;  color: $btnPastelGreenColor;  }
-.romo-label.romo-label-navy          { background-color: $btnNavyBg;         color: $btnNavyColor;         }
-.romo-label.romo-label-dark-blue     { background-color: $btnDarkBlueBg;     color: $btnDarkBlueColor;     }
-.romo-label.romo-label-blue          { background-color: $btnBlueBg;         color: $btnBlueColor;         }
-.romo-label.romo-label-light-blue    { background-color: $btnLightBlueBg;    color: $btnLightBlueColor;    }
-.romo-label.romo-label-pastel-blue   { background-color: $btnPastelBlueBg;   color: $btnPastelBlueColor;   }

--- a/assets/css/romo/lists.scss
+++ b/assets/css/romo/lists.scss
@@ -1,37 +1,41 @@
 @import 'css/romo/vars';
 @import 'css/romo/mixins';
 
-/* style helpers */
+.romo {
 
-ul.romo-list-unstyled,
-ol.romo-list-unstyled { @include list-unstyled(!important); }
+  /* style helpers */
 
-ul.romo-list-styled,
-ol.romo-list-styled { @include list-styled(!important); }
+  ul.romo-list-unstyled,
+  ol.romo-list-unstyled { @include list-unstyled(!important); }
 
-ul.romo-list-inline,
-ol.romo-list-inline { @include list-unstyled(!important); @include display-inline-flex; }
-ul.romo-list-inline > li,
-ol.romo-list-inline > li { display: inline-block; }
+  ul.romo-list-styled,
+  ol.romo-list-styled { @include list-styled(!important); }
 
-/* spacing helpers */
+  ul.romo-list-inline,
+  ol.romo-list-inline { @include list-unstyled(!important); @include display-inline-flex; }
+  ul.romo-list-inline > li,
+  ol.romo-list-inline > li { display: inline-block; }
 
-.romo-list-inline.romo-list-pad  > li,
-.romo-list-inline.romo-list-pad1 > li { @include pad1-right; }
-.romo-list-inline.romo-list-pad0 > li { @include pad0-right; }
-.romo-list-inline.romo-list-pad2 > li { @include pad2-right; }
+  /* spacing helpers */
 
-.romo-list-inline.romo-list-pad  > li:last-child,
-.romo-list-inline.romo-list-pad1 > li:last-child,
-.romo-list-inline.romo-list-pad0 > li:last-child,
-.romo-list-inline.romo-list-pad2 > li:last-child { @include rm-pad-right; }
+  .romo-list-inline.romo-list-pad  > li,
+  .romo-list-inline.romo-list-pad1 > li { @include pad1-right; }
+  .romo-list-inline.romo-list-pad0 > li { @include pad0-right; }
+  .romo-list-inline.romo-list-pad2 > li { @include pad2-right; }
 
-.romo-list-inline.romo-list-push  > li,
-.romo-list-inline.romo-list-push1 > li { @include push1-right; }
-.romo-list-inline.romo-list-push0 > li { @include push0-right; }
-.romo-list-inline.romo-list-push2 > li { @include push2-right; }
+  .romo-list-inline.romo-list-pad  > li:last-child,
+  .romo-list-inline.romo-list-pad1 > li:last-child,
+  .romo-list-inline.romo-list-pad0 > li:last-child,
+  .romo-list-inline.romo-list-pad2 > li:last-child { @include rm-pad-right; }
 
-.romo-list-inline.romo-list-push  > li:last-child,
-.romo-list-inline.romo-list-push1 > li:last-child,
-.romo-list-inline.romo-list-push0 > li:last-child,
-.romo-list-inline.romo-list-push2 > li:last-child { @include rm-push-right; }
+  .romo-list-inline.romo-list-push  > li,
+  .romo-list-inline.romo-list-push1 > li { @include push1-right; }
+  .romo-list-inline.romo-list-push0 > li { @include push0-right; }
+  .romo-list-inline.romo-list-push2 > li { @include push2-right; }
+
+  .romo-list-inline.romo-list-push  > li:last-child,
+  .romo-list-inline.romo-list-push1 > li:last-child,
+  .romo-list-inline.romo-list-push0 > li:last-child,
+  .romo-list-inline.romo-list-push2 > li:last-child { @include rm-push-right; }
+
+}

--- a/assets/css/romo/modal.scss
+++ b/assets/css/romo/modal.scss
@@ -1,32 +1,36 @@
 @import 'css/romo/vars';
 @import 'css/romo/mixins';
 
-.romo-modal,
-[data-romo-modal-close="true"] {
-  cursor: pointer;
-}
+.romo {
 
-.romo-modal-grab {
-  @include cursor-grab;
-}
+  .romo-modal,
+  [data-romo-modal-close="true"] {
+    cursor: pointer;
+  }
 
-.romo-modal-grabbing {
-  @include cursor-grabbing;
-}
+  .romo-modal-grab {
+    @include cursor-grab;
+  }
 
-.romo-modal-popup {
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  float: left;
-  @include border0;
-  @include box-shadow(0 5px 10px rgba(0, 0, 0, 0.2));
+  .romo-modal-grabbing {
+    @include cursor-grabbing;
+  }
 
-  background-color: $baseBgColor;
-  border-color: $baseBorderColor;
-  border-color: rgba(0, 0, 0, 0.2);
-}
+  .romo-modal-popup {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    float: left;
+    @include border0;
+    @include box-shadow(0 5px 10px rgba(0, 0, 0, 0.2));
 
-.romo-modal-popup:not([class*="romo-modal-open"]) {
-  display: none;
+    background-color: $baseBgColor;
+    border-color: $baseBorderColor;
+    border-color: rgba(0, 0, 0, 0.2);
+  }
+
+  .romo-modal-popup:not([class*="romo-modal-open"]) {
+    display: none;
+  }
+
 }

--- a/assets/css/romo/normalize.scss
+++ b/assets/css/romo/normalize.scss
@@ -1,425 +1,429 @@
 /*! normalize.css v3.0.1 | MIT License | git.io/normalize */
+/* with tweaks to put all overrides under `.romo` */
 
-/**
- * 1. Set default font family to sans-serif.
- * 2. Prevent iOS text size adjust after orientation change, without disabling
- *    user zoom.
- */
+.romo {
 
-html {
+  /**
+   * Set default font family to sans-serif.
+   */
+
   font-family: sans-serif; /* 1 */
+
+  /**
+   * Prevent iOS text size adjust after orientation change, without disabling user zoom.
+   */
+
   -ms-text-size-adjust: 100%; /* 2 */
   -webkit-text-size-adjust: 100%; /* 2 */
-}
 
-/**
- * Remove default margin.
- */
+  /**
+   * Remove default margin.
+   */
 
-body {
   margin: 0;
-}
-
-/* HTML5 display definitions
-   ========================================================================== */
-
-/**
- * Correct `block` display not defined for any HTML5 element in IE 8/9.
- * Correct `block` display not defined for `details` or `summary` in IE 10/11 and Firefox.
- * Correct `block` display not defined for `main` in IE 11.
- */
-
-article,
-aside,
-details,
-figcaption,
-figure,
-footer,
-header,
-hgroup,
-main,
-nav,
-section,
-summary {
-  display: block;
-}
-
-/**
- * 1. Correct `inline-block` display not defined in IE 8/9.
- * 2. Normalize vertical alignment of `progress` in Chrome, Firefox, and Opera.
- */
-
-audio,
-canvas,
-progress,
-video {
-  display: inline-block; /* 1 */
-  vertical-align: baseline; /* 2 */
-}
-
-/**
- * Prevent modern browsers from displaying `audio` without controls.
- * Remove excess height in iOS 5 devices.
- */
-
-audio:not([controls]) {
-  display: none;
-  height: 0;
-}
-
-/**
- * Address `[hidden]` styling not present in IE 8/9/10.
- * Hide the `template` element in IE 8/9/11, Safari, and Firefox < 22.
- */
-
-[hidden],
-template {
-  display: none;
-}
-
-/* Links
-   ========================================================================== */
-
-/**
- * Remove the gray background color from active links in IE 10.
- */
-
-a {
-  background: transparent;
-}
-
-/**
- * Improve readability when focused and also mouse hovered in all browsers.
- */
-
-a:active,
-a:hover {
-  outline: 0;
-}
-
-/* Text-level semantics
-   ========================================================================== */
-
-/**
- * Address styling not present in IE 8/9/10/11, Safari, and Chrome.
- */
-
-abbr[title] {
-  border-bottom: 1px dotted;
-}
-
-/**
- * Address style set to `bolder` in Firefox 4+, Safari, and Chrome.
- */
-
-b,
-strong {
-  font-weight: bold;
-}
-
-/**
- * Address styling not present in Safari and Chrome.
- */
-
-dfn {
-  font-style: italic;
-}
-
-/**
- * Address variable `h1` font-size and margin within `section` and `article`
- * contexts in Firefox 4+, Safari, and Chrome.
- */
-
-h1 {
-  font-size: 2em;
-  margin: 0.67em 0;
-}
-
-/**
- * Address styling not present in IE 8/9.
- */
-
-mark {
-  background: #ff0;
-  color: #000;
-}
-
-/**
- * Address inconsistent and variable font size in all browsers.
- */
-
-small {
-  font-size: 80%;
-}
-
-/**
- * Prevent `sub` and `sup` affecting `line-height` in all browsers.
- */
-
-sub,
-sup {
-  font-size: 75%;
-  line-height: 0;
-  position: relative;
-  vertical-align: baseline;
-}
-
-sup {
-  top: -0.5em;
-}
-
-sub {
-  bottom: -0.25em;
-}
-
-/* Embedded content
-   ========================================================================== */
-
-/**
- * Remove border when inside `a` element in IE 8/9/10.
- */
-
-img {
-  border: 0;
-}
-
-/**
- * Correct overflow not hidden in IE 9/10/11.
- */
-
-svg:not(:root) {
-  overflow: hidden;
-}
-
-/* Grouping content
-   ========================================================================== */
-
-/**
- * Address margin not present in IE 8/9 and Safari.
- */
-
-figure {
-  margin: 1em 40px;
-}
-
-/**
- * Address differences between Firefox and other browsers.
- */
-
-hr {
-  -moz-box-sizing: content-box;
-  box-sizing: content-box;
-  height: 0;
-}
-
-/**
- * Contain overflow in all browsers.
- */
-
-pre {
-  overflow: auto;
-}
-
-/**
- * Address odd `em`-unit font size rendering in all browsers.
- */
-
-code,
-kbd,
-pre,
-samp {
-  font-family: monospace, monospace;
-  font-size: 1em;
-}
-
-/* Forms
-   ========================================================================== */
-
-/**
- * Known limitation: by default, Chrome and Safari on OS X allow very limited
- * styling of `select`, unless a `border` property is set.
- */
-
-/**
- * 1. Correct color not being inherited.
- *    Known issue: affects color of disabled elements.
- * 2. Correct font properties not being inherited.
- * 3. Address margins set differently in Firefox 4+, Safari, and Chrome.
- */
-
-button,
-input,
-optgroup,
-select,
-textarea {
-  color: inherit; /* 1 */
-  font: inherit; /* 2 */
-  margin: 0; /* 3 */
-}
-
-/**
- * Address `overflow` set to `hidden` in IE 8/9/10/11.
- */
-
-button {
-  overflow: visible;
-}
-
-/**
- * Address inconsistent `text-transform` inheritance for `button` and `select`.
- * All other form control elements do not inherit `text-transform` values.
- * Correct `button` style inheritance in Firefox, IE 8/9/10/11, and Opera.
- * Correct `select` style inheritance in Firefox.
- */
-
-button,
-select {
-  text-transform: none;
-}
-
-/**
- * 1. Avoid the WebKit bug in Android 4.0.* where (2) destroys native `audio`
- *    and `video` controls.
- * 2. Correct inability to style clickable `input` types in iOS.
- * 3. Improve usability and consistency of cursor style between image-type
- *    `input` and others.
- */
-
-button,
-html input[type="button"], /* 1 */
-input[type="reset"],
-input[type="submit"] {
-  -webkit-appearance: button; /* 2 */
-  cursor: pointer; /* 3 */
-}
-
-/**
- * Re-set default cursor for disabled elements.
- */
-
-button[disabled],
-html input[disabled] {
-  cursor: default;
-}
-
-/**
- * Remove inner padding and border in Firefox 4+.
- */
-
-button::-moz-focus-inner,
-input::-moz-focus-inner {
-  border: 0;
-  padding: 0;
-}
-
-/**
- * Address Firefox 4+ setting `line-height` on `input` using `!important` in
- * the UA stylesheet.
- */
-
-input {
-  line-height: normal;
-}
-
-/**
- * It's recommended that you don't attempt to style these elements.
- * Firefox's implementation doesn't respect box-sizing, padding, or width.
- *
- * 1. Address box sizing set to `content-box` in IE 8/9/10.
- * 2. Remove excess padding in IE 8/9/10.
- */
-
-input[type="checkbox"],
-input[type="radio"] {
-  box-sizing: border-box; /* 1 */
-  padding: 0; /* 2 */
-}
-
-/**
- * Fix the cursor style for Chrome's increment/decrement buttons. For certain
- * `font-size` values of the `input`, it causes the cursor style of the
- * decrement button to change from `default` to `text`.
- */
-
-input[type="number"]::-webkit-inner-spin-button,
-input[type="number"]::-webkit-outer-spin-button {
-  height: auto;
-}
-
-/**
- * 1. Address `appearance` set to `searchfield` in Safari and Chrome.
- * 2. Address `box-sizing` set to `border-box` in Safari and Chrome
- *    (include `-moz` to future-proof).
- */
-
-input[type="search"] {
-  -webkit-appearance: textfield; /* 1 */
-  -moz-box-sizing: content-box;
-  -webkit-box-sizing: content-box; /* 2 */
-  box-sizing: content-box;
-}
-
-/**
- * Remove inner padding and search cancel button in Safari and Chrome on OS X.
- * Safari (but not Chrome) clips the cancel button when the search input has
- * padding (and `textfield` appearance).
- */
-
-input[type="search"]::-webkit-search-cancel-button,
-input[type="search"]::-webkit-search-decoration {
-  -webkit-appearance: none;
-}
-
-/**
- * Define consistent border, margin, and padding.
- */
-
-fieldset {
-  border: 1px solid #c0c0c0;
-  margin: 0 2px;
-  padding: 0.35em 0.625em 0.75em;
-}
-
-/**
- * 1. Correct `color` not being inherited in IE 8/9/10/11.
- * 2. Remove padding so people aren't caught out if they zero out fieldsets.
- */
-
-legend {
-  border: 0; /* 1 */
-  padding: 0; /* 2 */
-}
-
-/**
- * Remove default vertical scrollbar in IE 8/9/10/11.
- */
-
-textarea {
-  overflow: auto;
-}
-
-/**
- * Don't inherit the `font-weight` (applied by a rule above).
- * NOTE: the default cannot safely be changed in Chrome and Safari on OS X.
- */
-
-optgroup {
-  font-weight: bold;
-}
-
-/* Tables
-   ========================================================================== */
-
-/**
- * Remove most spacing between table cells.
- */
-
-table {
-  border-collapse: collapse;
-  border-spacing: 0;
-}
-
-td,
-th {
-  padding: 0;
+
+  /* HTML5 display definitions
+     ========================================================================== */
+
+  /**
+   * Correct `block` display not defined for any HTML5 element in IE 8/9.
+   * Correct `block` display not defined for `details` or `summary` in IE 10/11 and Firefox.
+   * Correct `block` display not defined for `main` in IE 11.
+   */
+
+  article,
+  aside,
+  details,
+  figcaption,
+  figure,
+  footer,
+  header,
+  hgroup,
+  main,
+  nav,
+  section,
+  summary {
+    display: block;
+  }
+
+  /**
+   * 1. Correct `inline-block` display not defined in IE 8/9.
+   * 2. Normalize vertical alignment of `progress` in Chrome, Firefox, and Opera.
+   */
+
+  audio,
+  canvas,
+  progress,
+  video {
+    display: inline-block; /* 1 */
+    vertical-align: baseline; /* 2 */
+  }
+
+  /**
+   * Prevent modern browsers from displaying `audio` without controls.
+   * Remove excess height in iOS 5 devices.
+   */
+
+  audio:not([controls]) {
+    display: none;
+    height: 0;
+  }
+
+  /**
+   * Address `[hidden]` styling not present in IE 8/9/10.
+   * Hide the `template` element in IE 8/9/11, Safari, and Firefox < 22.
+   */
+
+  [hidden],
+  template {
+    display: none;
+  }
+
+  /* Links
+     ========================================================================== */
+
+  /**
+   * Remove the gray background color from active links in IE 10.
+   */
+
+  a {
+    background: transparent;
+  }
+
+  /**
+   * Improve readability when focused and also mouse hovered in all browsers.
+   */
+
+  a:active,
+  a:hover {
+    outline: 0;
+  }
+
+  /* Text-level semantics
+     ========================================================================== */
+
+  /**
+   * Address styling not present in IE 8/9/10/11, Safari, and Chrome.
+   */
+
+  abbr[title] {
+    border-bottom: 1px dotted;
+  }
+
+  /**
+   * Address style set to `bolder` in Firefox 4+, Safari, and Chrome.
+   */
+
+  b,
+  strong {
+    font-weight: bold;
+  }
+
+  /**
+   * Address styling not present in Safari and Chrome.
+   */
+
+  dfn {
+    font-style: italic;
+  }
+
+  /**
+   * Address variable `h1` font-size and margin within `section` and `article`
+   * contexts in Firefox 4+, Safari, and Chrome.
+   */
+
+  h1 {
+    font-size: 2em;
+    margin: 0.67em 0;
+  }
+
+  /**
+   * Address styling not present in IE 8/9.
+   */
+
+  mark {
+    background: #ff0;
+    color: #000;
+  }
+
+  /**
+   * Address inconsistent and variable font size in all browsers.
+   */
+
+  small {
+    font-size: 80%;
+  }
+
+  /**
+   * Prevent `sub` and `sup` affecting `line-height` in all browsers.
+   */
+
+  sub,
+  sup {
+    font-size: 75%;
+    line-height: 0;
+    position: relative;
+    vertical-align: baseline;
+  }
+
+  sup {
+    top: -0.5em;
+  }
+
+  sub {
+    bottom: -0.25em;
+  }
+
+  /* Embedded content
+     ========================================================================== */
+
+  /**
+   * Remove border when inside `a` element in IE 8/9/10.
+   */
+
+  img {
+    border: 0;
+  }
+
+  /**
+   * Correct overflow not hidden in IE 9/10/11.
+   */
+
+  svg:not(:root) {
+    overflow: hidden;
+  }
+
+  /* Grouping content
+     ========================================================================== */
+
+  /**
+   * Address margin not present in IE 8/9 and Safari.
+   */
+
+  figure {
+    margin: 1em 40px;
+  }
+
+  /**
+   * Address differences between Firefox and other browsers.
+   */
+
+  hr {
+    -moz-box-sizing: content-box;
+    box-sizing: content-box;
+    height: 0;
+  }
+
+  /**
+   * Contain overflow in all browsers.
+   */
+
+  pre {
+    overflow: auto;
+  }
+
+  /**
+   * Address odd `em`-unit font size rendering in all browsers.
+   */
+
+  code,
+  kbd,
+  pre,
+  samp {
+    font-family: monospace, monospace;
+    font-size: 1em;
+  }
+
+  /* Forms
+     ========================================================================== */
+
+  /**
+   * Known limitation: by default, Chrome and Safari on OS X allow very limited
+   * styling of `select`, unless a `border` property is set.
+   */
+
+  /**
+   * 1. Correct color not being inherited.
+   *    Known issue: affects color of disabled elements.
+   * 2. Correct font properties not being inherited.
+   * 3. Address margins set differently in Firefox 4+, Safari, and Chrome.
+   */
+
+  button,
+  input,
+  optgroup,
+  select,
+  textarea {
+    color: inherit; /* 1 */
+    font: inherit; /* 2 */
+    margin: 0; /* 3 */
+  }
+
+  /**
+   * Address `overflow` set to `hidden` in IE 8/9/10/11.
+   */
+
+  button {
+    overflow: visible;
+  }
+
+  /**
+   * Address inconsistent `text-transform` inheritance for `button` and `select`.
+   * All other form control elements do not inherit `text-transform` values.
+   * Correct `button` style inheritance in Firefox, IE 8/9/10/11, and Opera.
+   * Correct `select` style inheritance in Firefox.
+   */
+
+  button,
+  select {
+    text-transform: none;
+  }
+
+  /**
+   * 1. Avoid the WebKit bug in Android 4.0.* where (2) destroys native `audio`
+   *    and `video` controls.
+   * 2. Correct inability to style clickable `input` types in iOS.
+   * 3. Improve usability and consistency of cursor style between image-type
+   *    `input` and others.
+   */
+
+  button,
+  html input[type="button"], /* 1 */
+  input[type="reset"],
+  input[type="submit"] {
+    -webkit-appearance: button; /* 2 */
+    cursor: pointer; /* 3 */
+  }
+
+  /**
+   * Re-set default cursor for disabled elements.
+   */
+
+  button[disabled],
+  html input[disabled] {
+    cursor: default;
+  }
+
+  /**
+   * Remove inner padding and border in Firefox 4+.
+   */
+
+  button::-moz-focus-inner,
+  input::-moz-focus-inner {
+    border: 0;
+    padding: 0;
+  }
+
+  /**
+   * Address Firefox 4+ setting `line-height` on `input` using `!important` in
+   * the UA stylesheet.
+   */
+
+  input {
+    line-height: normal;
+  }
+
+  /**
+   * It's recommended that you don't attempt to style these elements.
+   * Firefox's implementation doesn't respect box-sizing, padding, or width.
+   *
+   * 1. Address box sizing set to `content-box` in IE 8/9/10.
+   * 2. Remove excess padding in IE 8/9/10.
+   */
+
+  input[type="checkbox"],
+  input[type="radio"] {
+    box-sizing: border-box; /* 1 */
+    padding: 0; /* 2 */
+  }
+
+  /**
+   * Fix the cursor style for Chrome's increment/decrement buttons. For certain
+   * `font-size` values of the `input`, it causes the cursor style of the
+   * decrement button to change from `default` to `text`.
+   */
+
+  input[type="number"]::-webkit-inner-spin-button,
+  input[type="number"]::-webkit-outer-spin-button {
+    height: auto;
+  }
+
+  /**
+   * 1. Address `appearance` set to `searchfield` in Safari and Chrome.
+   * 2. Address `box-sizing` set to `border-box` in Safari and Chrome
+   *    (include `-moz` to future-proof).
+   */
+
+  input[type="search"] {
+    -webkit-appearance: textfield; /* 1 */
+    -moz-box-sizing: content-box;
+    -webkit-box-sizing: content-box; /* 2 */
+    box-sizing: content-box;
+  }
+
+  /**
+   * Remove inner padding and search cancel button in Safari and Chrome on OS X.
+   * Safari (but not Chrome) clips the cancel button when the search input has
+   * padding (and `textfield` appearance).
+   */
+
+  input[type="search"]::-webkit-search-cancel-button,
+  input[type="search"]::-webkit-search-decoration {
+    -webkit-appearance: none;
+  }
+
+  /**
+   * Define consistent border, margin, and padding.
+   */
+
+  fieldset {
+    border: 1px solid #c0c0c0;
+    margin: 0 2px;
+    padding: 0.35em 0.625em 0.75em;
+  }
+
+  /**
+   * 1. Correct `color` not being inherited in IE 8/9/10/11.
+   * 2. Remove padding so people aren't caught out if they zero out fieldsets.
+   */
+
+  legend {
+    border: 0; /* 1 */
+    padding: 0; /* 2 */
+  }
+
+  /**
+   * Remove default vertical scrollbar in IE 8/9/10/11.
+   */
+
+  textarea {
+    overflow: auto;
+  }
+
+  /**
+   * Don't inherit the `font-weight` (applied by a rule above).
+   * NOTE: the default cannot safely be changed in Chrome and Safari on OS X.
+   */
+
+  optgroup {
+    font-weight: bold;
+  }
+
+  /* Tables
+     ========================================================================== */
+
+  /**
+   * Remove most spacing between table cells.
+   */
+
+  table {
+    border-collapse: collapse;
+    border-spacing: 0;
+  }
+
+  td,
+  th {
+    padding: 0;
+  }
+
 }

--- a/assets/css/romo/select.scss
+++ b/assets/css/romo/select.scss
@@ -1,97 +1,101 @@
 @import 'css/romo/vars';
 @import 'css/romo/mixins';
 
-.romo-select-dropdown-options-parent {
-  display: none;
-}
+.romo {
 
-.romo-select-wrapper {
-  display: inline-block;
-  text-align: left;
-  text-shadow: 0 1px 1px rgba(255, 255, 255, 0.75);
-  cursor: pointer;
-  @include user-select(none);
-  position: relative;
-}
+  .romo-select-dropdown-options-parent {
+    display: none;
+  }
 
-.romo-select {
-  min-width: 50px;
-  font-weight: normal;
-  text-align: left;
-  padding-left: 6px;
-  padding-right: 6px;
-}
+  .romo-select-wrapper {
+    display: inline-block;
+    text-align: left;
+    text-shadow: 0 1px 1px rgba(255, 255, 255, 0.75);
+    cursor: pointer;
+    @include user-select(none);
+    position: relative;
+  }
 
-.romo-select:focus,
-.romo-select.romo-select-focus { @include input-focus; }
+  .romo-select {
+    min-width: 50px;
+    font-weight: normal;
+    text-align: left;
+    padding-left: 6px;
+    padding-right: 6px;
+  }
 
-.romo-select:active,
-.romo-select.active {
-  background-image: none;
-  outline: 0;
-  @include box-shadow((inset 0 2px 4px rgba(0,0,0,.15), 0 1px 2px rgba(0,0,0,.05)));
-}
+  .romo-select:focus,
+  .romo-select.romo-select-focus { @include input-focus; }
 
-.romo-select-text {
-  white-space: nowrap;
-  overflow: hidden;
-  display: inline-block;
-  width: 100%;
-}
-.romo-select-caret {
-  display: inline-block;
-  position: absolute;
-  vertical-align: middle;
-  cursor: pointer;
-}
+  .romo-select:active,
+  .romo-select.active {
+    background-image: none;
+    outline: 0;
+    @include box-shadow((inset 0 2px 4px rgba(0,0,0,.15), 0 1px 2px rgba(0,0,0,.05)));
+  }
 
-.romo-select-dropdown-option-filter-wrapper {
-  @include border1-bottom();
-  padding: 4px 0;
-  margin: 0 4px;
-}
+  .romo-select-text {
+    white-space: nowrap;
+    overflow: hidden;
+    display: inline-block;
+    width: 100%;
+  }
+  .romo-select-caret {
+    display: inline-block;
+    position: absolute;
+    vertical-align: middle;
+    cursor: pointer;
+  }
 
-.romo-select-option-list {
-  cursor: pointer;
-  font-weight: normal;
-  padding: 4px 0;
-  @include user-select(none);
+  .romo-select-dropdown-option-filter-wrapper {
+    @include border1-bottom();
+    padding: 4px 0;
+    margin: 0 4px;
+  }
 
-  background-color: $inputBgColor;
-  color: $inputColor;
-}
+  .romo-select-option-list {
+    cursor: pointer;
+    font-weight: normal;
+    padding: 4px 0;
+    @include user-select(none);
 
-.romo-select-option-list UL {
-  list-style: none outside none;
-  margin: 0;
-  padding: 0;
-  white-space: nowrap;
-  overflow: hidden;
-}
+    background-color: $inputBgColor;
+    color: $inputColor;
+  }
 
-.romo-select-option-list UL.romo-select-optgroup LI {
-  padding-left: $spacingSize1;
-}
+  .romo-select-option-list UL {
+    list-style: none outside none;
+    margin: 0;
+    padding: 0;
+    white-space: nowrap;
+    overflow: hidden;
+  }
 
-.romo-select-option-list LI {
-  @include select-option;
-}
+  .romo-select-option-list UL.romo-select-optgroup LI {
+    padding-left: $spacingSize1;
+  }
 
-.romo-select-option-list LI[data-romo-select-item="optgroup"] {
-  @include select-optgroup;
-}
+  .romo-select-option-list LI {
+    @include select-option;
+  }
 
-.romo-select-option-list LI.romo-select-highlight {
-  background-color: $inputHighlightBgColor;
-  color: $inputBgColor;
-}
+  .romo-select-option-list LI[data-romo-select-item="optgroup"] {
+    @include select-optgroup;
+  }
 
-.romo-select-option-list LI.disabled {
-  cursor: $notAllowedCursor;
-}
+  .romo-select-option-list LI.romo-select-highlight {
+    background-color: $inputHighlightBgColor;
+    color: $inputBgColor;
+  }
 
-.romo-select-option-list LI.disabled,
-.romo-select-option-list LI.disabled.romo-select-highlight {
-  background-color: $inputBgColor;
-  color: $disabledColor;
+  .romo-select-option-list LI.disabled {
+    cursor: $notAllowedCursor;
+  }
+
+  .romo-select-option-list LI.disabled,
+  .romo-select-option-list LI.disabled.romo-select-highlight {
+    background-color: $inputBgColor;
+    color: $disabledColor;
+  }
+
 }

--- a/assets/css/romo/sortable.scss
+++ b/assets/css/romo/sortable.scss
@@ -1,14 +1,18 @@
 @import 'css/romo/mixins';
 
-[data-romo-sortable-item="true"] {
-  @include user-select(text);
-}
+.romo {
 
-.romo-sortable-grab {
-  @include cursor-grab;
-  @include user-select(none);
-}
+  [data-romo-sortable-item="true"] {
+    @include user-select(text);
+  }
 
-.romo-sortable-grabbing {
-  @include cursor-grabbing;
+  .romo-sortable-grab {
+    @include cursor-grab;
+    @include user-select(none);
+  }
+
+  .romo-sortable-grabbing {
+    @include cursor-grabbing;
+  }
+
 }

--- a/assets/css/romo/table.scss
+++ b/assets/css/romo/table.scss
@@ -1,211 +1,215 @@
 @import 'css/romo/vars';
 @import 'css/romo/mixins';
 
-.romo-table       { width: 100%; }
-.romo-table-fixed { table-layout: fixed; }
+.romo {
 
-.romo-table th,
-.romo-table td {
-  @include rm-pad;
-  @include align-left;
-  @include align-middle;
-  @include border1-bottom;
+  .romo-table       { width: 100%; }
+  .romo-table-fixed { table-layout: fixed; }
+
+  .romo-table th,
+  .romo-table td {
+    @include rm-pad;
+    @include align-left;
+    @include align-middle;
+    @include border1-bottom;
+  }
+
+  .romo-table th { @include font-weight(bold); }
+  .romo-table thead th { @include align-bottom; }
+
+  .romo-table-alt { @include bg-alt; }
+
+  .romo-table-striped tbody > tr:nth-child(odd) { @include bg-striped; }
+  .romo-table-striped.romo-table-striped-alt tbody > tr:nth-child(odd) { @include bg-base; }
+  .romo-table-striped.romo-table-striped-alt { @include bg-striped; }
+
+  .romo-table-hover tbody tr:hover,
+  .romo-table-hover.romo-table-alt tbody tr:hover,
+  .romo-table-hover.romo-table-striped tbody tr:hover,
+  .romo-table-hover.romo-table-striped-alt tbody tr:hover { @include bg-hover; }
+
+  .romo-table-border,
+  .romo-table-border0,
+  .romo-table-border1,
+  .romo-table-border2,
+  .romo-table-border-none { border-collapse: collapse; *border-collapse: collapse; }
+
+  .romo-table-border,
+  .romo-table-border1     { @include border1-top; @include border1-left; }
+  .romo-table-border0     { @include border0-top; @include border0-left; }
+  .romo-table-border2     { @include border2-top; @include border2-left; }
+  .romo-table-border-none { @include border-style(none); }
+
+  .romo-table-border      th, .romo-table-border      td,
+  .romo-table-border1     th, .romo-table-border1     td { @include border1-bottom; @include border1-right; }
+  .romo-table-border0     th, .romo-table-border0     td { @include border0-bottom; @include border0-right; }
+  .romo-table-border2     th, .romo-table-border2     td { @include border2-bottom; @include border2-right; }
+  .romo-table-border-none th, .romo-table-border-none td { @include border-style(none); }
+
+  .romo-table-pad    th, .romo-table-pad    td,
+  .romo-table-pad1   th, .romo-table-pad1   td { @include pad1;   }
+  .romo-table-pad0   th, .romo-table-pad0   td { @include pad0;   }
+  .romo-table-pad2   th, .romo-table-pad2   td { @include pad2;   }
+  .romo-table-rm-pad th, .romo-table-rm-pad td { @include rm-pad; }
+
+  .romo-table-pad-top    th, .romo-table-pad-top    td,
+  .romo-table-pad1-top   th, .romo-table-pad1-top   td { @include pad1-top;   }
+  .romo-table-pad0-top   th, .romo-table-pad0-top   td { @include pad0-top;   }
+  .romo-table-pad2-top   th, .romo-table-pad2-top   td { @include pad2-top;   }
+  .romo-table-rm-pad-top th, .romo-table-rm-pad-top td { @include rm-pad-top; }
+
+  .romo-table-pad-right    th, .romo-table-pad-right    td,
+  .romo-table-pad1-right   th, .romo-table-pad1-right   td { @include pad1-right;   }
+  .romo-table-pad0-right   th, .romo-table-pad0-right   td { @include pad0-right;   }
+  .romo-table-pad2-right   th, .romo-table-pad2-right   td { @include pad2-right;   }
+  .romo-table-rm-pad-right th, .romo-table-rm-pad-right td { @include rm-pad-right; }
+
+  .romo-table-pad-bottom    th, .romo-table-pad-bottom    td,
+  .romo-table-pad1-bottom   th, .romo-table-pad1-bottom   td { @include pad1-bottom;   }
+  .romo-table-pad0-bottom   th, .romo-table-pad0-bottom   td { @include pad0-bottom;   }
+  .romo-table-pad2-bottom   th, .romo-table-pad2-bottom   td { @include pad2-bottom;   }
+  .romo-table-rm-pad-bottom th, .romo-table-rm-pad-bottom td { @include rm-pad-bottom; }
+
+  .romo-table-pad-left    th, .romo-table-pad-left    td,
+  .romo-table-pad1-left   th, .romo-table-pad1-left   td { @include pad1-left;   }
+  .romo-table-pad0-left   th, .romo-table-pad0-left   td { @include pad0-left;   }
+  .romo-table-pad2-left   th, .romo-table-pad2-left   td { @include pad2-left;   }
+  .romo-table-rm-pad-left th, .romo-table-rm-pad-left td { @include rm-pad-left; }
+
+  /* emphasis colored rows */
+
+  .romo-table tr.romo-base    { @include bg-base(!important);    }
+  .romo-table tr.romo-alt     { @include bg-alt(!important);     }
+  .romo-table tr.romo-muted   { @include bg-muted(!important);   }
+  .romo-table tr.romo-warning { @include bg-warning(!important); }
+  .romo-table tr.romo-danger  { @include bg-danger(!important);  }
+  .romo-table tr.romo-info    { @include bg-info(!important);    }
+  .romo-table tr.romo-success { @include bg-success(!important); }
+  .romo-table tr.romo-inverse { @include bg-inverse(!important); }
+
+  .romo-table-hover tbody tr.romo-base:hover    { @include bg-base-hover(!important);    }
+  .romo-table-hover tbody tr.romo-alt:hover     { @include bg-alt-hover(!important);     }
+  .romo-table-hover tbody tr.romo-muted:hover   { @include bg-muted-hover(!important);   }
+  .romo-table-hover tbody tr.romo-warning:hover { @include bg-warning-hover(!important); }
+  .romo-table-hover tbody tr.romo-danger:hover  { @include bg-danger-hover(!important);  }
+  .romo-table-hover tbody tr.romo-info:hover    { @include bg-info-hover(!important);    }
+  .romo-table-hover tbody tr.romo-success:hover { @include bg-success-hover(!important); }
+  .romo-table-hover tbody tr.romo-inverse:hover { @include bg-inverse-hover(!important); }
+
+  /* explicit colored rows */
+
+  .romo-table tr.romo-dark-red      { @include bg-dark-red(!important);      }
+  .romo-table tr.romo-red           { @include bg-red(!important);           }
+  .romo-table tr.romo-light-red     { @include bg-light-red(!important);     }
+  .romo-table tr.romo-pastel-red    { @include bg-pastel-red(!important);    }
+  .romo-table tr.romo-dark-orange   { @include bg-dark-orange(!important);   }
+  .romo-table tr.romo-orange        { @include bg-orange(!important);        }
+  .romo-table tr.romo-yellow        { @include bg-yellow(!important);        }
+  .romo-table tr.romo-pastel-yellow { @include bg-pastel-yellow(!important); }
+  .romo-table tr.romo-purple        { @include bg-purple(!important);        }
+  .romo-table tr.romo-light-purple  { @include bg-light-purple(!important);  }
+  .romo-table tr.romo-dark-pink     { @include bg-dark-pink(!important);     }
+  .romo-table tr.romo-hot-pink      { @include bg-hot-pink(!important);      }
+  .romo-table tr.romo-pink          { @include bg-pink(!important);          }
+  .romo-table tr.romo-dark-green    { @include bg-dark-green(!important);    }
+  .romo-table tr.romo-green         { @include bg-green(!important);         }
+  .romo-table tr.romo-light-green   { @include bg-light-green(!important);   }
+  .romo-table tr.romo-pastel-green  { @include bg-pastel-green(!important);  }
+  .romo-table tr.romo-navy          { @include bg-navy(!important);          }
+  .romo-table tr.romo-dark-blue     { @include bg-dark-blue(!important);     }
+  .romo-table tr.romo-blue          { @include bg-blue(!important);          }
+  .romo-table tr.romo-light-blue    { @include bg-light-blue(!important);    }
+  .romo-table tr.romo-pastel-blue   { @include bg-pastel-blue(!important);   }
+
+  .romo-table-hover tbody tr.romo-dark-red:hover      { @include bg-dark-red-hover(!important);      }
+  .romo-table-hover tbody tr.romo-red:hover           { @include bg-red-hover(!important);           }
+  .romo-table-hover tbody tr.romo-light-red:hover     { @include bg-light-red-hover(!important);     }
+  .romo-table-hover tbody tr.romo-pastel-red:hover    { @include bg-pastel-red-hover(!important);    }
+  .romo-table-hover tbody tr.romo-dark-orange:hover   { @include bg-dark-orange-hover(!important);   }
+  .romo-table-hover tbody tr.romo-orange:hover        { @include bg-orange-hover(!important);        }
+  .romo-table-hover tbody tr.romo-yellow:hover        { @include bg-yellow-hover(!important);        }
+  .romo-table-hover tbody tr.romo-pastel-yellow:hover { @include bg-pastel-yellow-hover(!important); }
+  .romo-table-hover tbody tr.romo-purple:hover        { @include bg-purple-hover(!important);        }
+  .romo-table-hover tbody tr.romo-light-purple:hover  { @include bg-light-purple-hover(!important);  }
+  .romo-table-hover tbody tr.romo-dark-pink:hover     { @include bg-dark-pink-hover(!important);     }
+  .romo-table-hover tbody tr.romo-hot-pink:hover      { @include bg-hot-pink-hover(!important);      }
+  .romo-table-hover tbody tr.romo-pink:hover          { @include bg-pink-hover(!important);          }
+  .romo-table-hover tbody tr.romo-dark-green:hover    { @include bg-dark-green-hover(!important);    }
+  .romo-table-hover tbody tr.romo-green:hover         { @include bg-green-hover(!important);         }
+  .romo-table-hover tbody tr.romo-light-green:hover   { @include bg-light-green-hover(!important);   }
+  .romo-table-hover tbody tr.romo-pastel-green:hover  { @include bg-pastel-green-hover(!important);  }
+  .romo-table-hover tbody tr.romo-navy:hover          { @include bg-navy-hover(!important);          }
+  .romo-table-hover tbody tr.romo-dark-blue:hover     { @include bg-dark-blue-hover(!important);     }
+  .romo-table-hover tbody tr.romo-blue:hover          { @include bg-blue-hover(!important);          }
+  .romo-table-hover tbody tr.romo-light-blue:hover    { @include bg-light-blue-hover(!important);    }
+  .romo-table-hover tbody tr.romo-pastel-blue:hover   { @include bg-pastel-blue-hover(!important);   }
+
+  /* emphasis colored borders */
+
+  .romo-table-border-base    { @include border-base;    }
+  .romo-table-border-alt     { @include border-alt;     }
+  .romo-table-border-muted   { @include border-muted;   }
+  .romo-table-border-warning { @include border-warning; }
+  .romo-table-border-danger  { @include border-danger;  }
+  .romo-table-border-info    { @include border-info;    }
+  .romo-table-border-success { @include border-success; }
+  .romo-table-border-inverse { @include border-inverse; }
+
+  .romo-table-border-base    th, .romo-table-border-base    td { @include border-base;    }
+  .romo-table-border-alt     th, .romo-table-border-alt     td { @include border-alt;     }
+  .romo-table-border-muted   th, .romo-table-border-muted   td { @include border-muted;   }
+  .romo-table-border-warning th, .romo-table-border-warning td { @include border-warning; }
+  .romo-table-border-danger  th, .romo-table-border-danger  td { @include border-danger;  }
+  .romo-table-border-info    th, .romo-table-border-info    td { @include border-info;    }
+  .romo-table-border-success th, .romo-table-border-success td { @include border-success; }
+  .romo-table-border-inverse th, .romo-table-border-inverse td { @include border-inverse; }
+
+  /* explicit colored borders */
+
+  .romo-table-border-dark-red      { @include border-dark-red;      }
+  .romo-table-border-red           { @include border-red;           }
+  .romo-table-border-light-red     { @include border-light-red;     }
+  .romo-table-border-pastel-red    { @include border-pastel-red;    }
+  .romo-table-border-dark-orange   { @include border-dark-orange;   }
+  .romo-table-border-orange        { @include border-orange;        }
+  .romo-table-border-yellow        { @include border-yellow;        }
+  .romo-table-border-pastel-yellow { @include border-pastel-yellow; }
+  .romo-table-border-purple        { @include border-purple;        }
+  .romo-table-border-light-purple  { @include border-light-purple;  }
+  .romo-table-border-dark-pink     { @include border-dark-pink;     }
+  .romo-table-border-hot-pink      { @include border-hot-pink;      }
+  .romo-table-border-pink          { @include border-pink;          }
+  .romo-table-border-dark-green    { @include border-dark-green;    }
+  .romo-table-border-green         { @include border-green;         }
+  .romo-table-border-light-green   { @include border-light-green;   }
+  .romo-table-border-pastel-green  { @include border-pastel-green;  }
+  .romo-table-border-navy          { @include border-navy;          }
+  .romo-table-border-dark-blue     { @include border-dark-blue;     }
+  .romo-table-border-blue          { @include border-blue;          }
+  .romo-table-border-light-blue    { @include border-light-blue;    }
+  .romo-table-border-pastel-blue   { @include border-pastel-blue;   }
+
+  .romo-table-border-dark-red      th, .romo-table-border-dark-red      td { @include border-dark-red;      }
+  .romo-table-border-red           th, .romo-table-border-red           td { @include border-red;           }
+  .romo-table-border-light-red     th, .romo-table-border-light-red     td { @include border-light-red;     }
+  .romo-table-border-pastel-red    th, .romo-table-border-pastel-red    td { @include border-pastel-red;    }
+  .romo-table-border-dark-orange   th, .romo-table-border-dark-orange   td { @include border-dark-orange;   }
+  .romo-table-border-orange        th, .romo-table-border-orange        td { @include border-orange;        }
+  .romo-table-border-yellow        th, .romo-table-border-yellow        td { @include border-yellow;        }
+  .romo-table-border-pastel-yellow th, .romo-table-border-pastel-yellow td { @include border-pastel-yellow; }
+  .romo-table-border-purple        th, .romo-table-border-purple        td { @include border-purple;        }
+  .romo-table-border-light-purple  th, .romo-table-border-light-purple  td { @include border-light-purple;  }
+  .romo-table-border-dark-pink     th, .romo-table-border-dark-pink     td { @include border-dark-pink;     }
+  .romo-table-border-hot-pink      th, .romo-table-border-hot-pink      td { @include border-hot-pink;      }
+  .romo-table-border-pink          th, .romo-table-border-pink          td { @include border-pink;          }
+  .romo-table-border-dark-green    th, .romo-table-border-dark-green    td { @include border-dark-green;    }
+  .romo-table-border-green         th, .romo-table-border-green         td { @include border-green;         }
+  .romo-table-border-light-green   th, .romo-table-border-light-green   td { @include border-light-green;   }
+  .romo-table-border-pastel-green  th, .romo-table-border-pastel-green  td { @include border-pastel-green;  }
+  .romo-table-border-navy          th, .romo-table-border-navy          td { @include border-navy;          }
+  .romo-table-border-dark-blue     th, .romo-table-border-dark-blue     td { @include border-dark-blue;     }
+  .romo-table-border-blue          th, .romo-table-border-blue          td { @include border-blue;          }
+  .romo-table-border-light-blue    th, .romo-table-border-light-blue    td { @include border-light-blue;    }
+  .romo-table-border-pastel-blue   th, .romo-table-border-pastel-blue   td { @include border-pastel-blue;   }
+
 }
-
-.romo-table th { @include font-weight(bold); }
-.romo-table thead th { @include align-bottom; }
-
-.romo-table-alt { @include bg-alt; }
-
-.romo-table-striped tbody > tr:nth-child(odd) { @include bg-striped; }
-.romo-table-striped.romo-table-striped-alt tbody > tr:nth-child(odd) { @include bg-base; }
-.romo-table-striped.romo-table-striped-alt { @include bg-striped; }
-
-.romo-table-hover tbody tr:hover,
-.romo-table-hover.romo-table-alt tbody tr:hover,
-.romo-table-hover.romo-table-striped tbody tr:hover,
-.romo-table-hover.romo-table-striped-alt tbody tr:hover { @include bg-hover; }
-
-.romo-table-border,
-.romo-table-border0,
-.romo-table-border1,
-.romo-table-border2,
-.romo-table-border-none { border-collapse: collapse; *border-collapse: collapse; }
-
-.romo-table-border,
-.romo-table-border1     { @include border1-top; @include border1-left; }
-.romo-table-border0     { @include border0-top; @include border0-left; }
-.romo-table-border2     { @include border2-top; @include border2-left; }
-.romo-table-border-none { @include border-style(none); }
-
-.romo-table-border      th, .romo-table-border      td,
-.romo-table-border1     th, .romo-table-border1     td { @include border1-bottom; @include border1-right; }
-.romo-table-border0     th, .romo-table-border0     td { @include border0-bottom; @include border0-right; }
-.romo-table-border2     th, .romo-table-border2     td { @include border2-bottom; @include border2-right; }
-.romo-table-border-none th, .romo-table-border-none td { @include border-style(none); }
-
-.romo-table-pad    th, .romo-table-pad    td,
-.romo-table-pad1   th, .romo-table-pad1   td { @include pad1;   }
-.romo-table-pad0   th, .romo-table-pad0   td { @include pad0;   }
-.romo-table-pad2   th, .romo-table-pad2   td { @include pad2;   }
-.romo-table-rm-pad th, .romo-table-rm-pad td { @include rm-pad; }
-
-.romo-table-pad-top    th, .romo-table-pad-top    td,
-.romo-table-pad1-top   th, .romo-table-pad1-top   td { @include pad1-top;   }
-.romo-table-pad0-top   th, .romo-table-pad0-top   td { @include pad0-top;   }
-.romo-table-pad2-top   th, .romo-table-pad2-top   td { @include pad2-top;   }
-.romo-table-rm-pad-top th, .romo-table-rm-pad-top td { @include rm-pad-top; }
-
-.romo-table-pad-right    th, .romo-table-pad-right    td,
-.romo-table-pad1-right   th, .romo-table-pad1-right   td { @include pad1-right;   }
-.romo-table-pad0-right   th, .romo-table-pad0-right   td { @include pad0-right;   }
-.romo-table-pad2-right   th, .romo-table-pad2-right   td { @include pad2-right;   }
-.romo-table-rm-pad-right th, .romo-table-rm-pad-right td { @include rm-pad-right; }
-
-.romo-table-pad-bottom    th, .romo-table-pad-bottom    td,
-.romo-table-pad1-bottom   th, .romo-table-pad1-bottom   td { @include pad1-bottom;   }
-.romo-table-pad0-bottom   th, .romo-table-pad0-bottom   td { @include pad0-bottom;   }
-.romo-table-pad2-bottom   th, .romo-table-pad2-bottom   td { @include pad2-bottom;   }
-.romo-table-rm-pad-bottom th, .romo-table-rm-pad-bottom td { @include rm-pad-bottom; }
-
-.romo-table-pad-left    th, .romo-table-pad-left    td,
-.romo-table-pad1-left   th, .romo-table-pad1-left   td { @include pad1-left;   }
-.romo-table-pad0-left   th, .romo-table-pad0-left   td { @include pad0-left;   }
-.romo-table-pad2-left   th, .romo-table-pad2-left   td { @include pad2-left;   }
-.romo-table-rm-pad-left th, .romo-table-rm-pad-left td { @include rm-pad-left; }
-
-/* emphasis colored rows */
-
-.romo-table tr.romo-base    { @include bg-base(!important);    }
-.romo-table tr.romo-alt     { @include bg-alt(!important);     }
-.romo-table tr.romo-muted   { @include bg-muted(!important);   }
-.romo-table tr.romo-warning { @include bg-warning(!important); }
-.romo-table tr.romo-danger  { @include bg-danger(!important);  }
-.romo-table tr.romo-info    { @include bg-info(!important);    }
-.romo-table tr.romo-success { @include bg-success(!important); }
-.romo-table tr.romo-inverse { @include bg-inverse(!important); }
-
-.romo-table-hover tbody tr.romo-base:hover    { @include bg-base-hover(!important);    }
-.romo-table-hover tbody tr.romo-alt:hover     { @include bg-alt-hover(!important);     }
-.romo-table-hover tbody tr.romo-muted:hover   { @include bg-muted-hover(!important);   }
-.romo-table-hover tbody tr.romo-warning:hover { @include bg-warning-hover(!important); }
-.romo-table-hover tbody tr.romo-danger:hover  { @include bg-danger-hover(!important);  }
-.romo-table-hover tbody tr.romo-info:hover    { @include bg-info-hover(!important);    }
-.romo-table-hover tbody tr.romo-success:hover { @include bg-success-hover(!important); }
-.romo-table-hover tbody tr.romo-inverse:hover { @include bg-inverse-hover(!important); }
-
-/* explicit colored rows */
-
-.romo-table tr.romo-dark-red      { @include bg-dark-red(!important);      }
-.romo-table tr.romo-red           { @include bg-red(!important);           }
-.romo-table tr.romo-light-red     { @include bg-light-red(!important);     }
-.romo-table tr.romo-pastel-red    { @include bg-pastel-red(!important);    }
-.romo-table tr.romo-dark-orange   { @include bg-dark-orange(!important);   }
-.romo-table tr.romo-orange        { @include bg-orange(!important);        }
-.romo-table tr.romo-yellow        { @include bg-yellow(!important);        }
-.romo-table tr.romo-pastel-yellow { @include bg-pastel-yellow(!important); }
-.romo-table tr.romo-purple        { @include bg-purple(!important);        }
-.romo-table tr.romo-light-purple  { @include bg-light-purple(!important);  }
-.romo-table tr.romo-dark-pink     { @include bg-dark-pink(!important);     }
-.romo-table tr.romo-hot-pink      { @include bg-hot-pink(!important);      }
-.romo-table tr.romo-pink          { @include bg-pink(!important);          }
-.romo-table tr.romo-dark-green    { @include bg-dark-green(!important);    }
-.romo-table tr.romo-green         { @include bg-green(!important);         }
-.romo-table tr.romo-light-green   { @include bg-light-green(!important);   }
-.romo-table tr.romo-pastel-green  { @include bg-pastel-green(!important);  }
-.romo-table tr.romo-navy          { @include bg-navy(!important);          }
-.romo-table tr.romo-dark-blue     { @include bg-dark-blue(!important);     }
-.romo-table tr.romo-blue          { @include bg-blue(!important);          }
-.romo-table tr.romo-light-blue    { @include bg-light-blue(!important);    }
-.romo-table tr.romo-pastel-blue   { @include bg-pastel-blue(!important);   }
-
-.romo-table-hover tbody tr.romo-dark-red:hover      { @include bg-dark-red-hover(!important);      }
-.romo-table-hover tbody tr.romo-red:hover           { @include bg-red-hover(!important);           }
-.romo-table-hover tbody tr.romo-light-red:hover     { @include bg-light-red-hover(!important);     }
-.romo-table-hover tbody tr.romo-pastel-red:hover    { @include bg-pastel-red-hover(!important);    }
-.romo-table-hover tbody tr.romo-dark-orange:hover   { @include bg-dark-orange-hover(!important);   }
-.romo-table-hover tbody tr.romo-orange:hover        { @include bg-orange-hover(!important);        }
-.romo-table-hover tbody tr.romo-yellow:hover        { @include bg-yellow-hover(!important);        }
-.romo-table-hover tbody tr.romo-pastel-yellow:hover { @include bg-pastel-yellow-hover(!important); }
-.romo-table-hover tbody tr.romo-purple:hover        { @include bg-purple-hover(!important);        }
-.romo-table-hover tbody tr.romo-light-purple:hover  { @include bg-light-purple-hover(!important);  }
-.romo-table-hover tbody tr.romo-dark-pink:hover     { @include bg-dark-pink-hover(!important);     }
-.romo-table-hover tbody tr.romo-hot-pink:hover      { @include bg-hot-pink-hover(!important);      }
-.romo-table-hover tbody tr.romo-pink:hover          { @include bg-pink-hover(!important);          }
-.romo-table-hover tbody tr.romo-dark-green:hover    { @include bg-dark-green-hover(!important);    }
-.romo-table-hover tbody tr.romo-green:hover         { @include bg-green-hover(!important);         }
-.romo-table-hover tbody tr.romo-light-green:hover   { @include bg-light-green-hover(!important);   }
-.romo-table-hover tbody tr.romo-pastel-green:hover  { @include bg-pastel-green-hover(!important);  }
-.romo-table-hover tbody tr.romo-navy:hover          { @include bg-navy-hover(!important);          }
-.romo-table-hover tbody tr.romo-dark-blue:hover     { @include bg-dark-blue-hover(!important);     }
-.romo-table-hover tbody tr.romo-blue:hover          { @include bg-blue-hover(!important);          }
-.romo-table-hover tbody tr.romo-light-blue:hover    { @include bg-light-blue-hover(!important);    }
-.romo-table-hover tbody tr.romo-pastel-blue:hover   { @include bg-pastel-blue-hover(!important);   }
-
-/* emphasis colored borders */
-
-.romo-table-border-base    { @include border-base;    }
-.romo-table-border-alt     { @include border-alt;     }
-.romo-table-border-muted   { @include border-muted;   }
-.romo-table-border-warning { @include border-warning; }
-.romo-table-border-danger  { @include border-danger;  }
-.romo-table-border-info    { @include border-info;    }
-.romo-table-border-success { @include border-success; }
-.romo-table-border-inverse { @include border-inverse; }
-
-.romo-table-border-base    th, .romo-table-border-base    td { @include border-base;    }
-.romo-table-border-alt     th, .romo-table-border-alt     td { @include border-alt;     }
-.romo-table-border-muted   th, .romo-table-border-muted   td { @include border-muted;   }
-.romo-table-border-warning th, .romo-table-border-warning td { @include border-warning; }
-.romo-table-border-danger  th, .romo-table-border-danger  td { @include border-danger;  }
-.romo-table-border-info    th, .romo-table-border-info    td { @include border-info;    }
-.romo-table-border-success th, .romo-table-border-success td { @include border-success; }
-.romo-table-border-inverse th, .romo-table-border-inverse td { @include border-inverse; }
-
-/* explicit colored borders */
-
-.romo-table-border-dark-red      { @include border-dark-red;      }
-.romo-table-border-red           { @include border-red;           }
-.romo-table-border-light-red     { @include border-light-red;     }
-.romo-table-border-pastel-red    { @include border-pastel-red;    }
-.romo-table-border-dark-orange   { @include border-dark-orange;   }
-.romo-table-border-orange        { @include border-orange;        }
-.romo-table-border-yellow        { @include border-yellow;        }
-.romo-table-border-pastel-yellow { @include border-pastel-yellow; }
-.romo-table-border-purple        { @include border-purple;        }
-.romo-table-border-light-purple  { @include border-light-purple;  }
-.romo-table-border-dark-pink     { @include border-dark-pink;     }
-.romo-table-border-hot-pink      { @include border-hot-pink;      }
-.romo-table-border-pink          { @include border-pink;          }
-.romo-table-border-dark-green    { @include border-dark-green;    }
-.romo-table-border-green         { @include border-green;         }
-.romo-table-border-light-green   { @include border-light-green;   }
-.romo-table-border-pastel-green  { @include border-pastel-green;  }
-.romo-table-border-navy          { @include border-navy;          }
-.romo-table-border-dark-blue     { @include border-dark-blue;     }
-.romo-table-border-blue          { @include border-blue;          }
-.romo-table-border-light-blue    { @include border-light-blue;    }
-.romo-table-border-pastel-blue   { @include border-pastel-blue;   }
-
-.romo-table-border-dark-red      th, .romo-table-border-dark-red      td { @include border-dark-red;      }
-.romo-table-border-red           th, .romo-table-border-red           td { @include border-red;           }
-.romo-table-border-light-red     th, .romo-table-border-light-red     td { @include border-light-red;     }
-.romo-table-border-pastel-red    th, .romo-table-border-pastel-red    td { @include border-pastel-red;    }
-.romo-table-border-dark-orange   th, .romo-table-border-dark-orange   td { @include border-dark-orange;   }
-.romo-table-border-orange        th, .romo-table-border-orange        td { @include border-orange;        }
-.romo-table-border-yellow        th, .romo-table-border-yellow        td { @include border-yellow;        }
-.romo-table-border-pastel-yellow th, .romo-table-border-pastel-yellow td { @include border-pastel-yellow; }
-.romo-table-border-purple        th, .romo-table-border-purple        td { @include border-purple;        }
-.romo-table-border-light-purple  th, .romo-table-border-light-purple  td { @include border-light-purple;  }
-.romo-table-border-dark-pink     th, .romo-table-border-dark-pink     td { @include border-dark-pink;     }
-.romo-table-border-hot-pink      th, .romo-table-border-hot-pink      td { @include border-hot-pink;      }
-.romo-table-border-pink          th, .romo-table-border-pink          td { @include border-pink;          }
-.romo-table-border-dark-green    th, .romo-table-border-dark-green    td { @include border-dark-green;    }
-.romo-table-border-green         th, .romo-table-border-green         td { @include border-green;         }
-.romo-table-border-light-green   th, .romo-table-border-light-green   td { @include border-light-green;   }
-.romo-table-border-pastel-green  th, .romo-table-border-pastel-green  td { @include border-pastel-green;  }
-.romo-table-border-navy          th, .romo-table-border-navy          td { @include border-navy;          }
-.romo-table-border-dark-blue     th, .romo-table-border-dark-blue     td { @include border-dark-blue;     }
-.romo-table-border-blue          th, .romo-table-border-blue          td { @include border-blue;          }
-.romo-table-border-light-blue    th, .romo-table-border-light-blue    td { @include border-light-blue;    }
-.romo-table-border-pastel-blue   th, .romo-table-border-pastel-blue   td { @include border-pastel-blue;   }

--- a/assets/css/romo/tabs.scss
+++ b/assets/css/romo/tabs.scss
@@ -1,71 +1,75 @@
 @import 'css/romo/vars';
 @import 'css/romo/mixins';
 
-/* tabs */
+.romo {
 
-.romo-tabs {
-  display: block;
-  @include list-unstyled;
-  @include clearfix;
+  /* tabs */
 
-  border-bottom: $tabDividerSize solid $tabBgColorActive;
-}
+  .romo-tabs {
+    display: block;
+    @include list-unstyled;
+    @include clearfix;
 
-.romo-tabs > li {
-  float: left;
-  @include rm-push;
-  @include rm-pad;
-}
-
-.romo-tabs-pull-left  > li { float: left; }
-.romo-tabs-pull-right > li { float: right; }
-
-.romo-tabs > li > a {
-  display: block;
-  cursor: pointer;
-
-  @include border1;
-  background-color: $tabBgColor;
-  border-color: $tabBgColor;
-  color: $tabColor;
-
-  &:hover,
-  &:focus {
-    outline: 0;
-    text-decoration: none;
-    background-color: $tabBgColorHover;
-    border-color: $tabBgColorHover;
+    border-bottom: $tabDividerSize solid $tabBgColorActive;
   }
-}
 
-.romo-tabs > li.active > a {
-  background-color: $tabBgColorActive;
-  border-color: $tabBgColorActive;
-  color: $tabColorActive;
-}
+  .romo-tabs > li {
+    float: left;
+    @include rm-push;
+    @include rm-pad;
+  }
 
-.romo-tabs > li.disabled a,
-.romo-tabs > li:disabled a {
-  color: $tabColorDisabled;
-  cursor: $notAllowedCursor;
+  .romo-tabs-pull-left  > li { float: left; }
+  .romo-tabs-pull-right > li { float: right; }
 
-  &:hover,
-  &:focus {
+  .romo-tabs > li > a {
+    display: block;
+    cursor: pointer;
+
+    @include border1;
     background-color: $tabBgColor;
-    border-color: $tabBgColorHover;
+    border-color: $tabBgColor;
+    color: $tabColor;
+
+    &:hover,
+    &:focus {
+      outline: 0;
+      text-decoration: none;
+      background-color: $tabBgColorHover;
+      border-color: $tabBgColorHover;
+    }
   }
+
+  .romo-tabs > li.active > a {
+    background-color: $tabBgColorActive;
+    border-color: $tabBgColorActive;
+    color: $tabColorActive;
+  }
+
+  .romo-tabs > li.disabled a,
+  .romo-tabs > li:disabled a {
+    color: $tabColorDisabled;
+    cursor: $notAllowedCursor;
+
+    &:hover,
+    &:focus {
+      background-color: $tabBgColor;
+      border-color: $tabBgColorHover;
+    }
+  }
+
+  .romo-tabs.romo-tabs-small > li > a,
+  .romo-tabs.romo-tabs0 > li > a { @include font-size0; @include font-weight0; @include line-height0; @include button-pad0; }
+  .romo-tabs > li > a,
+  .romo-tabs.romo-tabs1 > li > a { @include font-size1; @include font-weight1; @include line-height1; @include button-pad1; }
+  .romo-tabs.romo-tabs-large > li > a,
+  .romo-tabs.romo-tabs2 > li > a { @include font-size2; @include font-weight2; @include line-height2; @include button-pad2; }
+  .romo-tabs.romo-tabs3 > li > a { @include font-size3; @include font-weight3; @include line-height3; @include button-pad3; }
+
+  .romo-tabs.romo-tabs-stacked { @include rm-border; }
+  .romo-tabs.romo-tabs-stacked > li { float: none; }
+  .romo-tabs.romo-tabs-stacked > li > a { @include border1; border-color: $baseBorderColor; }
+  .romo-tabs.romo-tabs-stacked > li.active > a { border-color: $tabBgColorActive; }
+  .romo-tabs.romo-tabs-stacked > li:not(:last-child) > a { @include rm-border-bottom; }
+
 }
-
-.romo-tabs.romo-tabs-small > li > a,
-.romo-tabs.romo-tabs0 > li > a { @include font-size0; @include font-weight0; @include line-height0; @include button-pad0; }
-.romo-tabs > li > a,
-.romo-tabs.romo-tabs1 > li > a { @include font-size1; @include font-weight1; @include line-height1; @include button-pad1; }
-.romo-tabs.romo-tabs-large > li > a,
-.romo-tabs.romo-tabs2 > li > a { @include font-size2; @include font-weight2; @include line-height2; @include button-pad2; }
-.romo-tabs.romo-tabs3 > li > a { @include font-size3; @include font-weight3; @include line-height3; @include button-pad3; }
-
-.romo-tabs.romo-tabs-stacked { @include rm-border; }
-.romo-tabs.romo-tabs-stacked > li { float: none; }
-.romo-tabs.romo-tabs-stacked > li > a { @include border1; border-color: $baseBorderColor; }
-.romo-tabs.romo-tabs-stacked > li.active > a { border-color: $tabBgColorActive; }
-.romo-tabs.romo-tabs-stacked > li:not(:last-child) > a { @include rm-border-bottom; }

--- a/assets/css/romo/tooltip.scss
+++ b/assets/css/romo/tooltip.scss
@@ -1,89 +1,93 @@
 @import 'css/romo/vars';
 @import 'css/romo/mixins';
 
-.romo-tooltip {
-  cursor: pointer;
-}
+.romo {
 
-.romo-tooltip-popup {
-  position: absolute;
-  float: left;
-  @include border1-radius;
+  .romo-tooltip {
+    cursor: pointer;
+  }
 
-  white-space: normal;
-  text-align: center;
+  .romo-tooltip-popup {
+    position: absolute;
+    float: left;
+    @include border1-radius;
 
-  font-size: 11px;
-  line-height: 1.4;
-  font-weight: 300;
-}
+    white-space: normal;
+    text-align: center;
 
-.romo-tooltip-popup:not([class*="romo-tooltip-open"]) {
-  display: none;
-}
+    font-size: 11px;
+    line-height: 1.4;
+    font-weight: 300;
+  }
 
-.romo-tooltip-arrow {
-  position: absolute;
-  width: 0;
-  height: 0;
-  border-color: transparent;
-  border-style: solid;
-}
+  .romo-tooltip-popup:not([class*="romo-tooltip-open"]) {
+    display: none;
+  }
 
-.romo-tooltip-popup[data-romo-tooltip-arrow-position="top"] .romo-tooltip-arrow {
-  border-width: 6px 6px 0;
-  bottom: -6px;
-  left: 50%;
-  margin-left: -6px;
-}
+  .romo-tooltip-arrow {
+    position: absolute;
+    width: 0;
+    height: 0;
+    border-color: transparent;
+    border-style: solid;
+  }
 
-.romo-tooltip-popup[data-romo-tooltip-arrow-position="right"] .romo-tooltip-arrow {
-  border-width: 6px 6px 6px 0;
-  left: -6px;
-  top: 50%;
-  margin-top: -6px;
-}
+  .romo-tooltip-popup[data-romo-tooltip-arrow-position="top"] .romo-tooltip-arrow {
+    border-width: 6px 6px 0;
+    bottom: -6px;
+    left: 50%;
+    margin-left: -6px;
+  }
 
-.romo-tooltip-popup[data-romo-tooltip-arrow-position="bottom"] .romo-tooltip-arrow {
-  border-width: 0 6px 6px;
-  top: -6px;
-  left: 50%;
-  margin-left: -6px;
-}
+  .romo-tooltip-popup[data-romo-tooltip-arrow-position="right"] .romo-tooltip-arrow {
+    border-width: 6px 6px 6px 0;
+    left: -6px;
+    top: 50%;
+    margin-top: -6px;
+  }
 
-.romo-tooltip-popup[data-romo-tooltip-arrow-position="left"] .romo-tooltip-arrow {
-  border-width: 6px 0 6px 6px;
-  right: -6px;
-  top: 50%;
-  margin-top: -6px;
-}
+  .romo-tooltip-popup[data-romo-tooltip-arrow-position="bottom"] .romo-tooltip-arrow {
+    border-width: 0 6px 6px;
+    top: -6px;
+    left: 50%;
+    margin-left: -6px;
+  }
 
-.romo-tooltip-popup[data-romo-tooltip-alignment="left"]   { @include align-left; }
-.romo-tooltip-popup[data-romo-tooltip-alignment="center"] { @include align-center; }
-.romo-tooltip-popup[data-romo-tooltip-alignment="right"]  { @include align-right; }
+  .romo-tooltip-popup[data-romo-tooltip-arrow-position="left"] .romo-tooltip-arrow {
+    border-width: 6px 0 6px 6px;
+    right: -6px;
+    top: 50%;
+    margin-top: -6px;
+  }
 
-.romo-tooltip-body {
-  padding: 6px 8px;
-  overflow: hidden;
-}
+  .romo-tooltip-popup[data-romo-tooltip-alignment="left"]   { @include align-left; }
+  .romo-tooltip-popup[data-romo-tooltip-alignment="center"] { @include align-center; }
+  .romo-tooltip-popup[data-romo-tooltip-alignment="right"]  { @include align-right; }
+
+  .romo-tooltip-body {
+    padding: 6px 8px;
+    overflow: hidden;
+  }
 
 
-/* theme */
+  /* theme */
 
-.romo-tooltip-popup {
-  background-color: $tooltipBgColor;
-  color: $tooltipColor;
-}
+  .romo-tooltip-popup {
+    background-color: $tooltipBgColor;
+    color: $tooltipColor;
+  }
 
-.romo-tooltip-popup[data-romo-tooltip-arrow-position="top"] .romo-tooltip-arrow {
-  border-top-color: $tooltipBgColor;
-}
-.romo-tooltip-popup[data-romo-tooltip-arrow-position="right"] .romo-tooltip-arrow {
-  border-right-color: $tooltipBgColor;
-}
-.romo-tooltip-popup[data-romo-tooltip-arrow-position="bottom"] .romo-tooltip-arrow {
-  border-bottom-color: $tooltipBgColor;
-}
-.romo-tooltip-popup[data-romo-tooltip-arrow-position="left"] .romo-tooltip-arrow {
-  border-left-color: $tooltipBgColor;
+  .romo-tooltip-popup[data-romo-tooltip-arrow-position="top"] .romo-tooltip-arrow {
+    border-top-color: $tooltipBgColor;
+  }
+  .romo-tooltip-popup[data-romo-tooltip-arrow-position="right"] .romo-tooltip-arrow {
+    border-right-color: $tooltipBgColor;
+  }
+  .romo-tooltip-popup[data-romo-tooltip-arrow-position="bottom"] .romo-tooltip-arrow {
+    border-bottom-color: $tooltipBgColor;
+  }
+  .romo-tooltip-popup[data-romo-tooltip-arrow-position="left"] .romo-tooltip-arrow {
+    border-left-color: $tooltipBgColor;
+  }
+
 }

--- a/assets/css/romo/z_index.scss
+++ b/assets/css/romo/z_index.scss
@@ -1,26 +1,30 @@
 @import 'css/romo/vars';
 @import 'css/romo/mixins';
 
-.romo-tooltip-popup {
-  z-index: $tooltipZIndex;
-}
-.romo-tooltip-popup * {
-  z-index: inherit;
-}
+.romo {
 
-.romo-dropdown-popup {
-  z-index: $dropdownZIndex;
-}
-.romo-dropdown-popup * {
-  z-index: inherit;
-}
+  .romo-tooltip-popup {
+    z-index: $tooltipZIndex;
+  }
+  .romo-tooltip-popup * {
+    z-index: inherit;
+  }
 
-// 1300 is reserved for app specific things like nav bars, etc
-// modals should appear on top of everything though
+  .romo-dropdown-popup {
+    z-index: $dropdownZIndex;
+  }
+  .romo-dropdown-popup * {
+    z-index: inherit;
+  }
 
-.romo-modal-popup {
-  z-index: $modalZIndex;
-}
-.romo-modal-popup * {
-  z-index: inherit;
+  // 1300 is reserved for app specific things like nav bars, etc
+  // modals should appear on top of everything though
+
+  .romo-modal-popup {
+    z-index: $modalZIndex;
+  }
+  .romo-modal-popup * {
+    z-index: inherit;
+  }
+
 }


### PR DESCRIPTION
This allows bringing in Romo CSS alongside legacy/other CSS and
ensures Romo won't conflict with those styles.  For Romo to work
or take effect, it now has to have a parent elem with the "romo"
style class.

For most only-Romo uses, just add the "romo" class to the BODY
elem and you are good to go.  For legacy uses that want to blend
in Romo alongside some other CSS, contain your Romo markup in a
DIV (or whatever) elem with the "romo" class.

Because this causes legacy uses to break, this will need to be
deployed in a breaking change version release.

@jcredding ready for review.