### PR TITLE
add `romo-cursor-not-allowed` style class

### DIFF
--- a/assets/css/romo/base.scss
+++ b/assets/css/romo/base.scss
@@ -98,10 +98,11 @@ body.romo {
   .romo-link:hover,
   .romo-link-hover:hover { color: $linkColorHover !important;}
 
-  .romo-cursor-default { cursor: default; }
-  .romo-pointer        { cursor: pointer; }
-  .romo-grab           { @include cursor-grab; }
-  .romo-grabbing       { @include cursor-grabbing; }
+  .romo-cursor-default     { cursor: default; }
+  .romo-cursor-not-allowed { cursor: $notAllowedCursor; }
+  .romo-pointer            { cursor: pointer; }
+  .romo-grab               { @include cursor-grab; }
+  .romo-grabbing           { @include cursor-grabbing; }
 
   .romo-user-select-none{ @include user-select(none); }
 


### PR DESCRIPTION
We use this cursor a bunch within the internal styles but have no
way to specify it manually with a style class.  One of the apps
we work on needed this so I am adding it to the API.

@jcredding ready for review.