### PR TITLE
add RomoAjax opt to disable the default invoke on

### DIFF
--- a/assets/js/romo/ajax.js
+++ b/assets/js/romo/ajax.js
@@ -8,7 +8,12 @@ var RomoAjax = function(element) {
   this.elem       = $(element);
   this.targetElem = $(this.elem.data('romo-ajax-target'));
 
-  this.invokeOn     = this.elem.data('romo-ajax-invoke-on')   || 'click';
+  this.defaultInvokeOn = 'click';
+  this.invokeOn        = this.elem.data('romo-ajax-invoke-on');
+  if (this.invokeOn === undefined && this.elem.data('romo-ajax-disable-default-invoke-on') !== true) {
+    this.invokeOn = this.defaultInvokeOn;
+  }
+
   this.callMethod   = this.elem.data('romo-ajax-call-method') || 'GET';
   this.urlAttr      = this.elem.data('romo-ajax-url-attr')    || 'href';
   this.callOnlyOnce = this.elem.data('romo-ajax-call-once') === true;
@@ -16,7 +21,9 @@ var RomoAjax = function(element) {
   this.invokeQueued  = false;
   this.invokeRunning = false;
 
-  this.elem.unbind(this.invokeOn);
+  if (this.invokeOn !== undefined) {
+    this.elem.unbind(this.invokeOn);
+  }
 
   this.doInit();
   this.doBindElem();
@@ -29,12 +36,16 @@ RomoAjax.prototype.doInit = function() {
 
 RomoAjax.prototype.doBindElem = function() {
   this.doUnbindElem();
-  this.elem.on(this.invokeOn, $.proxy(this.onInvoke, this));
+  if (this.invokeOn !== undefined) {
+    this.elem.on(this.invokeOn, $.proxy(this.onInvoke, this));
+  }
   this.elem.on('romoAjax:triggerInvoke', $.proxy(this.onInvoke, this));
 }
 
 RomoAjax.prototype.doUnbindElem = function() {
-  this.elem.off(this.invokeOn, $.proxy(this.onInvoke, this));
+  if (this.invokeOn !== undefined) {
+    this.elem.off(this.invokeOn, $.proxy(this.onInvoke, this));
+  }
   this.elem.off('romoAjax:triggerInvoke', $.proxy(this.onInvoke, this));
 }
 


### PR DESCRIPTION
The idea is that you should be able to use the RomoAjax component
and not have an invoke-on event.  You would do this when you just
want to invoke the component using the trigger event manually.

This prevents you from having to set some rando invoke-on value
like `data-romo-ajax-invoke-on="none"` or something.  Plus, this
turns off all invoke-on logic if no value is set.

This came up in one of our apps where we were manually triggering
the invoke on an interval.  We chose to bind RomoAjax to a visible
elem (b/c why not?) and we noticed that everytime you clicked this
random elem the ajax request would invoke which was not intended.

@jcredding ready for review.