### PR TITLE
add placeholder styles for romo form placeholder inputs

### DIFF
--- a/assets/css/romo/_mixins.scss
+++ b/assets/css/romo/_mixins.scss
@@ -377,6 +377,11 @@
   color: $inputColor;
 }
 
+@mixin input-placeholder {
+  color: $mutedText;
+  font-style: italic;
+}
+
 /* Buttons */
 /* ------- */
 

--- a/assets/css/romo/forms.scss
+++ b/assets/css/romo/forms.scss
@@ -102,6 +102,99 @@
     @include box-shadow(inset 0 1px 1px rgba(0, 0, 0, 0.075));
   }
 
+  /* see https://css-tricks.com/almanac/selectors/p/placeholder/ */
+  /* https://developer.mozilla.org/en-US/docs/Web/CSS/::placeholder */
+  .romo-form textarea::placeholder,
+  .romo-form input[type="text"]::placeholder,
+  .romo-form input[type="password"]::placeholder,
+  .romo-form input[type="datetime"]::placeholder,
+  .romo-form input[type="datetime-local"]::placeholder,
+  .romo-form input[type="date"]::placeholder,
+  .romo-form input[type="month"]::placeholder,
+  .romo-form input[type="time"]::placeholder,
+  .romo-form input[type="week"]::placeholder,
+  .romo-form input[type="number"]::placeholder,
+  .romo-form input[type="email"]::placeholder,
+  .romo-form input[type="url"]::placeholder,
+  .romo-form input[type="search"]::placeholder,
+  .romo-form input[type="tel"]::placeholder,
+  .romo-form input[type="color"]::placeholder,
+  input.romo-select-dropdown-option-filter::placeholder {
+    @include input-placeholder;
+  }
+  .romo-form textarea::-webkit-input-placeholder,                     /* Chrome/Opera/Safari */
+  .romo-form input[type="text"]::-webkit-input-placeholder,
+  .romo-form input[type="password"]::-webkit-input-placeholder,
+  .romo-form input[type="datetime"]::-webkit-input-placeholder,
+  .romo-form input[type="datetime-local"]::-webkit-input-placeholder,
+  .romo-form input[type="date"]::-webkit-input-placeholder,
+  .romo-form input[type="month"]::-webkit-input-placeholder,
+  .romo-form input[type="time"]::-webkit-input-placeholder,
+  .romo-form input[type="week"]::-webkit-input-placeholder,
+  .romo-form input[type="number"]::-webkit-input-placeholder,
+  .romo-form input[type="email"]::-webkit-input-placeholder,
+  .romo-form input[type="url"]::-webkit-input-placeholder,
+  .romo-form input[type="search"]::-webkit-input-placeholder,
+  .romo-form input[type="tel"]::-webkit-input-placeholder,
+  .romo-form input[type="color"]::-webkit-input-placeholder,
+  input.romo-select-dropdown-option-filter::-webkit-input-placeholder {
+    @include input-placeholder;
+  }
+  .romo-form textarea::-moz-placeholder,                              /* Firefox 19+ */
+  .romo-form input[type="text"]::-moz-placeholder,
+  .romo-form input[type="password"]::-moz-placeholder,
+  .romo-form input[type="datetime"]::-moz-placeholder,
+  .romo-form input[type="datetime-local"]::-moz-placeholder,
+  .romo-form input[type="date"]::-moz-placeholder,
+  .romo-form input[type="month"]::-moz-placeholder,
+  .romo-form input[type="time"]::-moz-placeholder,
+  .romo-form input[type="week"]::-moz-placeholder,
+  .romo-form input[type="number"]::-moz-placeholder,
+  .romo-form input[type="email"]::-moz-placeholder,
+  .romo-form input[type="url"]::-moz-placeholder,
+  .romo-form input[type="search"]::-moz-placeholder,
+  .romo-form input[type="tel"]::-moz-placeholder,
+  .romo-form input[type="color"]::-moz-placeholder,
+  input.romo-select-dropdown-option-filter::-moz-placeholder {
+    @include input-placeholder;
+  }
+  .romo-form textarea:-moz-placeholder,                               /* Firefox 18- */
+  .romo-form input[type="text"]:-moz-placeholder,
+  .romo-form input[type="password"]:-moz-placeholder,
+  .romo-form input[type="datetime"]:-moz-placeholder,
+  .romo-form input[type="datetime-local"]:-moz-placeholder,
+  .romo-form input[type="date"]:-moz-placeholder,
+  .romo-form input[type="month"]:-moz-placeholder,
+  .romo-form input[type="time"]:-moz-placeholder,
+  .romo-form input[type="week"]:-moz-placeholder,
+  .romo-form input[type="number"]:-moz-placeholder,
+  .romo-form input[type="email"]:-moz-placeholder,
+  .romo-form input[type="url"]:-moz-placeholder,
+  .romo-form input[type="search"]:-moz-placeholder,
+  .romo-form input[type="tel"]:-moz-placeholder,
+  .romo-form input[type="color"]:-moz-placeholder,
+  input.romo-select-dropdown-option-filter:-moz-placeholder {
+    @include input-placeholder;
+  }
+  .romo-form textarea:-ms-input-placeholder,                          /* IE 10+ */
+  .romo-form input[type="text"]:-ms-input-placeholder,
+  .romo-form input[type="password"]:-ms-input-placeholder,
+  .romo-form input[type="datetime"]:-ms-input-placeholder,
+  .romo-form input[type="datetime-local"]:-ms-input-placeholder,
+  .romo-form input[type="date"]:-ms-input-placeholder,
+  .romo-form input[type="month"]:-ms-input-placeholder,
+  .romo-form input[type="time"]:-ms-input-placeholder,
+  .romo-form input[type="week"]:-ms-input-placeholder,
+  .romo-form input[type="number"]:-ms-input-placeholder,
+  .romo-form input[type="email"]:-ms-input-placeholder,
+  .romo-form input[type="url"]:-ms-input-placeholder,
+  .romo-form input[type="search"]:-ms-input-placeholder,
+  .romo-form input[type="tel"]:-ms-input-placeholder,
+  .romo-form input[type="color"]:-ms-input-placeholder,
+  input.romo-select-dropdown-option-filter:-ms-input-placeholder {
+    @include input-placeholder;
+  }
+
   .romo-form select:focus,
   .romo-form textarea:focus,
   .romo-form input[type="text"]:focus,


### PR DESCRIPTION
See https://developer.mozilla.org/en-US/docs/Web/CSS/::placeholder
and https://css-tricks.com/almanac/selectors/p/placeholder/. I
wanted some custom styles to make placeholders look obviously
different from the typed in input text.  I chose to use our muted
text color and italics.

Chrome:
![chrome](https://user-images.githubusercontent.com/82110/27458276-d133efbc-576d-11e7-9fce-241d368e1806.jpg)

Firefox:
![firefox](https://user-images.githubusercontent.com/82110/27458284-d6b67e8c-576d-11e7-8886-3fe7462d6cf6.jpg)

@jcredding ready for review.