### PR TITLE
add `romo-flex-align-*` style classes

### DIFF
--- a/assets/css/romo/base.scss
+++ b/assets/css/romo/base.scss
@@ -228,6 +228,38 @@ body.romo {
   .romo-align-middle { @include align-middle(!important); }
   .romo-align-bottom { @include align-bottom(!important); }
 
+  .romo-flex-align-left   {
+    @include display-flex;
+    @include flex-direction(column);
+    @include flex-align-items(flex-start)
+  }
+  .romo-flex-align-center {
+    @include display-flex;
+    @include flex-direction(column);
+    @include flex-align-items(center)
+  }
+  .romo-flex-align-right  {
+    @include display-flex;
+    @include flex-direction(column);
+    @include flex-align-items(flex-end)
+  }
+
+  .romo-flex-align-top    {
+    @include display-flex;
+    @include flex-direction(column);
+    @include flex-justify-content(flex-start);
+  }
+  .romo-flex-align-middle {
+    @include display-flex;
+    @include flex-direction(column);
+    @include flex-justify-content(center);
+  }
+  .romo-flex-align-bottom {
+    @include display-flex;
+    @include flex-direction(column);
+    @include flex-justify-content(flex-end);
+  }
+
   /* Scaffolding */
   /* ----------- */
 


### PR DESCRIPTION
This is the next chapter in the ever unfolding saga that is 
vertical alignment in CSS.  Flexbox makes it a lot easier but the
API is involved and hard to commit to memory.  These styles classes
mimic the normal alignment style classes but use flex to implement
the behavior so the results are more predictable.

Note: these should just *replace* the normal alignment classes.
Flex is heavier and should only be used when necessary.  For
typical, boring, horizontal alignment, the normal classes should
be preferred.

![imagesd1si](https://user-images.githubusercontent.com/82110/28078913-01cddfd0-662c-11e7-97b8-78a6df235ad7.jpg)

@jcredding ready for review.