### PR TITLE
break out OptionListDropdown component from SelectDropdown

### DIFF
--- a/assets/css/romo/_mixins.scss
+++ b/assets/css/romo/_mixins.scss
@@ -360,7 +360,7 @@
   @include box-shadow((inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(82, 168, 236, 0.6)));
 }
 
-@mixin select-optgroup {
+@mixin input-option-list-optgroup {
   font-size: $fontSize0;
   line-height: $lineHeight0;
 
@@ -368,7 +368,7 @@
   color: $inputBgColor;
 }
 
-@mixin select-option {
+@mixin input-option-list-option {
   font-size: $baseFontSize;
   line-height: $baseLineHeight;
   padding: 0 $spacingSize0;

--- a/assets/css/romo/forms.scss
+++ b/assets/css/romo/forms.scss
@@ -29,7 +29,7 @@
   .romo-form input,
   .romo-form select,
   .romo-form textarea,
-  input.romo-select-dropdown-option-filter {
+  input.romo-option-list-dropdown-filter {
     font-size: 100%;
     @include rm-push;
     @include align-middle;
@@ -46,7 +46,7 @@
   }
 
   .romo-form input,
-  input.romo-select-dropdown-option-filter {
+  input.romo-option-list-dropdown-filter {
     *overflow: visible;
     line-height: normal;
   }
@@ -69,16 +69,16 @@
   .romo-form input[readonly],
   .romo-form select[readonly],
   .romo-form textarea[readonly],
-  input.romo-select-dropdown-option-filter[disabled],
-  input.romo-select-dropdown-option-filter[readonly] { cursor: $notAllowedCursor; }
+  input.romo-option-list-dropdown-filter[disabled],
+  input.romo-option-list-dropdown-filter[readonly] { cursor: $notAllowedCursor; }
 
   .romo-form select {
     font-weight: normal;
     background-color: $inputBgColor;
     @include border1;
   }
-  .romo-form select optgroup { @include select-optgroup; }
-  .romo-form select option { @include select-option; }
+  .romo-form select optgroup { @include input-option-list-optgroup; }
+  .romo-form select option   { @include input-option-list-option; }
 
   .romo-form textarea,
   .romo-form input[type="text"],
@@ -95,7 +95,7 @@
   .romo-form input[type="search"],
   .romo-form input[type="tel"],
   .romo-form input[type="color"],
-  input.romo-select-dropdown-option-filter {
+  input.romo-option-list-dropdown-filter {
     font-weight: normal;
     background-color: $inputBgColor;
     @include border1;
@@ -119,7 +119,7 @@
   .romo-form input[type="search"]::placeholder,
   .romo-form input[type="tel"]::placeholder,
   .romo-form input[type="color"]::placeholder,
-  input.romo-select-dropdown-option-filter::placeholder {
+  input.romo-option-list-dropdown-filter::placeholder {
     @include input-placeholder;
   }
   .romo-form textarea::-webkit-input-placeholder,                     /* Chrome/Opera/Safari */
@@ -137,7 +137,7 @@
   .romo-form input[type="search"]::-webkit-input-placeholder,
   .romo-form input[type="tel"]::-webkit-input-placeholder,
   .romo-form input[type="color"]::-webkit-input-placeholder,
-  input.romo-select-dropdown-option-filter::-webkit-input-placeholder {
+  input.romo-option-list-dropdown-filter::-webkit-input-placeholder {
     @include input-placeholder;
   }
   .romo-form textarea::-moz-placeholder,                              /* Firefox 19+ */
@@ -155,7 +155,7 @@
   .romo-form input[type="search"]::-moz-placeholder,
   .romo-form input[type="tel"]::-moz-placeholder,
   .romo-form input[type="color"]::-moz-placeholder,
-  input.romo-select-dropdown-option-filter::-moz-placeholder {
+  input.romo-option-list-dropdown-filter::-moz-placeholder {
     @include input-placeholder;
   }
   .romo-form textarea:-moz-placeholder,                               /* Firefox 18- */
@@ -173,7 +173,7 @@
   .romo-form input[type="search"]:-moz-placeholder,
   .romo-form input[type="tel"]:-moz-placeholder,
   .romo-form input[type="color"]:-moz-placeholder,
-  input.romo-select-dropdown-option-filter:-moz-placeholder {
+  input.romo-option-list-dropdown-filter:-moz-placeholder {
     @include input-placeholder;
   }
   .romo-form textarea:-ms-input-placeholder,                          /* IE 10+ */
@@ -191,7 +191,7 @@
   .romo-form input[type="search"]:-ms-input-placeholder,
   .romo-form input[type="tel"]:-ms-input-placeholder,
   .romo-form input[type="color"]:-ms-input-placeholder,
-  input.romo-select-dropdown-option-filter:-ms-input-placeholder {
+  input.romo-option-list-dropdown-filter:-ms-input-placeholder {
     @include input-placeholder;
   }
 
@@ -211,7 +211,7 @@
   .romo-form input[type="search"]:focus,
   .romo-form input[type="tel"]:focus,
   .romo-form input[type="color"]:focus,
-  input.romo-select-dropdown-option-filter:focus {
+  input.romo-option-list-dropdown-filter:focus {
     @include input-focus;
   }
 
@@ -221,8 +221,8 @@
   .romo-form input[readonly],
   .romo-form select[readonly],
   .romo-form textarea[readonly],
-  input.romo-select-dropdown-option-filter[disabled],
-  input.romo-select-dropdown-option-filter[readonly] { background-color: $inputDisabledColor; }
+  input.romo-option-list-dropdown-filter[disabled],
+  input.romo-option-list-dropdown-filter[readonly] { background-color: $inputDisabledColor; }
 
   .romo-form input[type="radio"][disabled],
   .romo-form input[type="checkbox"][disabled],
@@ -244,13 +244,13 @@
   .romo-form input[type="search"],
   .romo-form input[type="tel"],
   .romo-form input[type="color"],
-  input.romo-select-dropdown-option-filter {
+  input.romo-option-list-dropdown-filter {
     height: $inputHeight;
     line-height: $baseLineHeight;
     @include align-middle;
   }
 
-  input.romo-select-dropdown-option-filter {
+  input.romo-option-list-dropdown-filter {
     height: $inputFilterHeight;
   }
 
@@ -269,15 +269,21 @@
   .romo-form input[type="search"],
   .romo-form input[type="tel"],
   .romo-form input[type="color"],
-  input.romo-select-dropdown-option-filter {
+  input.romo-option-list-dropdown-filter {
     display: inline-block;
     padding: 4px 6px;
     color: $inputColor;
   }
 
-  input.romo-select-dropdown-option-filter {
+  input.romo-option-list-dropdown-filter {
     display: block;
     width: 100%;
+  }
+
+  .romo-option-list-dropdown-filter-wrapper {
+    @include border1-bottom();
+    padding: 4px 0;
+    margin: 0 4px;
   }
 
   .romo-form textarea,
@@ -310,6 +316,53 @@
   .romo-form .romo-input-help {
     line-height: $inputHeight;
     @include align-middle;
+  }
+
+  /* input option list (used by selects vie option list dropdown) */
+
+  .romo-input-option-list {
+    cursor: pointer;
+    font-weight: normal;
+    padding: 4px 0;
+    @include user-select(none);
+
+    background-color: $inputBgColor;
+    color: $inputColor;
+  }
+
+  .romo-input-option-list UL {
+    list-style: none outside none;
+    margin: 0;
+    padding: 0;
+    white-space: nowrap;
+    overflow: hidden;
+  }
+
+  .romo-input-option-list UL.romo-option-list-optgroup LI {
+    padding-left: $spacingSize1;
+  }
+
+  .romo-input-option-list LI {
+    @include input-option-list-option;
+  }
+
+  .romo-input-option-list LI[data-romo-option-list-item="optgroup"] {
+    @include input-option-list-optgroup;
+  }
+
+  .romo-input-option-list LI.romo-option-list-dropdown-highlight {
+    background-color: $inputHighlightBgColor;
+    color: $inputBgColor;
+  }
+
+  .romo-input-option-list LI.disabled {
+    cursor: $notAllowedCursor;
+  }
+
+  .romo-input-option-list LI.disabled,
+  .romo-input-option-list LI.disabled.romo-option-list-dropdown-highlight {
+    background-color: $inputBgColor;
+    color: $disabledColor;
   }
 
 }

--- a/assets/css/romo/select.scss
+++ b/assets/css/romo/select.scss
@@ -40,62 +40,12 @@
     display: inline-block;
     width: 100%;
   }
+
   .romo-select-caret {
     display: inline-block;
     position: absolute;
     vertical-align: middle;
     cursor: pointer;
-  }
-
-  .romo-select-dropdown-option-filter-wrapper {
-    @include border1-bottom();
-    padding: 4px 0;
-    margin: 0 4px;
-  }
-
-  .romo-select-option-list {
-    cursor: pointer;
-    font-weight: normal;
-    padding: 4px 0;
-    @include user-select(none);
-
-    background-color: $inputBgColor;
-    color: $inputColor;
-  }
-
-  .romo-select-option-list UL {
-    list-style: none outside none;
-    margin: 0;
-    padding: 0;
-    white-space: nowrap;
-    overflow: hidden;
-  }
-
-  .romo-select-option-list UL.romo-select-optgroup LI {
-    padding-left: $spacingSize1;
-  }
-
-  .romo-select-option-list LI {
-    @include select-option;
-  }
-
-  .romo-select-option-list LI[data-romo-select-item="optgroup"] {
-    @include select-optgroup;
-  }
-
-  .romo-select-option-list LI.romo-select-highlight {
-    background-color: $inputHighlightBgColor;
-    color: $inputBgColor;
-  }
-
-  .romo-select-option-list LI.disabled {
-    cursor: $notAllowedCursor;
-  }
-
-  .romo-select-option-list LI.disabled,
-  .romo-select-option-list LI.disabled.romo-select-highlight {
-    background-color: $inputBgColor;
-    color: $disabledColor;
   }
 
 }

--- a/assets/js/romo/option_list_dropdown.js
+++ b/assets/js/romo/option_list_dropdown.js
@@ -1,0 +1,486 @@
+$.fn.romoOptionListDropdown = function() {
+  return $.map(this, function(element) {
+    return new RomoOptionListDropdown(element);
+  });
+}
+
+var RomoOptionListDropdown = function(element) {
+  this.elem      = $(element);
+  this.prevValue = '';
+
+  var selCustomization = this.elem.data('romo-option-list-dropdown-item-selector-customization') || '';
+  this.itemSelector    = 'LI[data-romo-option-list-dropdown-item="opt"]:not(.disabled)'+selCustomization;
+  this.focusStyleClass = this.elem.data('romo-option-list-focus-style-class');
+
+  this.doInit();
+  this._bindElem();
+
+  this.elem.trigger('romoOptionListDropdown:ready', [this]);
+}
+
+RomoOptionListDropdown.prototype.bodyElem = function() {
+  return this.romoDropdown.bodyElem;
+}
+
+RomoOptionListDropdown.prototype.popupElem = function() {
+  return this.romoDropdown.popupElem;
+}
+
+RomoOptionListDropdown.prototype.selectedItemElem = function() {
+  return this.romoDropdown.bodyElem.find('LI.selected');
+}
+
+RomoOptionListDropdown.prototype.optItemElems = function() {
+  return this.romoDropdown.bodyElem.find('LI[data-romo-option-list-dropdown-item="opt"]');
+}
+
+RomoOptionListDropdown.prototype.optgroupItemElems = function() {
+  return this.romoDropdown.bodyElem.find('LI[data-romo-option-list-dropdown-item="optgroup"]');
+}
+
+RomoOptionListDropdown.prototype.doInit = function() {
+  // override as needed
+}
+
+RomoOptionListDropdown.prototype.doSetNewValue = function(newValue) {
+  this.selectedItemElem().removeClass('selected');
+  this.romoDropdown.bodyElem.find('LI[data-romo-option-list-dropdown-option-value="'+newValue+'"]').addClass('selected');
+
+  this.prevValue = newValue;
+}
+
+/*
+Options are specified as a list of items.  Each 'option' item object
+has either display text or html, a value, and can optionally be
+selected or disabled.  Each 'optgroup' item object has a label and
+a list of items.
+
+Example:
+[ { 'type': 'option',   'displayText': 'A', 'value': 'a' },
+  { 'type': 'option',   'displayText': 'B', 'value': 'b', 'selected': true },
+  { 'type': 'option',   'displayText': 'C', 'value': 'c', 'disabled': true },
+  { 'type': 'optgroup', 'label': 'Numbers', 'items': [
+    { 'type': 'option',   'displayHtml': '<span>1</span>', 'value': '1' },
+    { 'type': 'option',   'displayHtml': '<span>2</span>', 'value': '2' },
+    { 'type': 'option',   'displayHtml': '<span>3</span>', 'value': '3' }
+  ] },
+  { 'type': 'optgroup', 'label': 'Symbols', 'items': [
+    { 'type': 'option',   'displayHtml': '<span>!</span>', 'value': 'exclamation' },
+    { 'type': 'option',   'displayHtml': '<span>@</span>', 'value': 'at', 'disabled': true },
+    { 'type': 'option',   'displayHtml': '<span>#</span>', 'value': 'pound' }
+  ] }
+]
+*/
+
+RomoOptionListDropdown.prototype.doSetListItems = function(itemsList) {
+  this.optionListContainer.html(this._buildListElem(itemsList));
+
+  this._updateOptionsListUI();
+
+  this.optionListContainer.find(this.itemSelector).on('mouseenter', $.proxy(this._onItemEnter, this));
+  this.optionListContainer.find(this.itemSelector).on('click',      $.proxy(this._onItemClick, this));
+}
+
+/* private */
+
+RomoOptionListDropdown.prototype._bindElem = function() {
+  this.elem.on('keydown',             $.proxy(this._onElemKeyDown, this));
+  this.elem.on('dropdown:popupOpen',  $.proxy(this._onPopupOpen,   this));
+  this.elem.on('dropdown:popupClose', $.proxy(this._onPopupClose,  this));
+
+  this.elem.on('dropdown:toggle', $.proxy(function(e, dropdown) {
+    this.elem.trigger('romoOptionListDropdown:dropdown:toggle', [dropdown, this]);
+  }, this));
+  this.elem.on('dropdown:popupOpen', $.proxy(function(e, dropdown) {
+    this.elem.trigger('romoOptionListDropdown:dropdown:popupOpen', [dropdown, this]);
+  }, this));
+  this.elem.on('dropdown:popupClose', $.proxy(function(e, dropdown) {
+    this.elem.trigger('romoOptionListDropdown:dropdown:popupClose', [dropdown, this]);
+  }, this));
+
+  this.elem.on('romoOptionListDropdown:triggerListOptionsUpdate', $.proxy(function(e, highlightOptionElem) {
+   this._updateOptionsListUI(highlightOptionElem);
+  }, this));
+
+  this.elem.on('romoOptionListDropdown:triggerToggle', $.proxy(function(e) {
+    this.elem.trigger('dropdown:triggerToggle', []);
+  }, this));
+  this.elem.on('romoOptionListDropdown:triggerPopupOpen', $.proxy(function(e) {
+    this.elem.trigger('dropdown:triggerPopupOpen', []);
+  }, this));
+  this.elem.on('romoOptionListDropdown:triggerPopupClose', $.proxy(function(e) {
+    this.elem.trigger('dropdown:triggerPopupClose', []);
+  }, this));
+
+  this.romoDropdown = this.elem.romoDropdown()[0];
+  this.romoDropdown.doSetPopupZIndex(this.elem);
+
+  this.romoDropdown.popupElem.on('keydown',   $.proxy(this._onElemKeyDown,    this));
+  this.romoDropdown.popupElem.on('mousedown', $.proxy(this._onPopupMouseDown, this));
+  this.romoDropdown.popupElem.on('mouseup',   $.proxy(this._onPopupMouseUp,   this));
+
+  this.romoDropdown.bodyElem.addClass('romo-input-option-list');
+  this.romoDropdown.bodyElem.html('');
+
+  if (this.elem.data('romo-option-list-dropdown-no-filter') !== true) {
+    this.optionFilter = this._buildOptionFilter();
+    var optionFilterWrapper = $('<div class="romo-option-list-dropdown-filter-wrapper"></div>');
+    optionFilterWrapper.append(this.optionFilter);
+    this.romoDropdown.popupElem.prepend(optionFilterWrapper);
+    this._bindDropdownOptionFilter();
+  }
+
+  this.romoDropdown.bodyElem.append($('<div class="romo-option-list-dropdown-container"></div>'));
+  this.optionListContainer = this.romoDropdown.bodyElem.find('.romo-option-list-dropdown-container');
+
+  this.doSetListItems([]);
+}
+
+RomoOptionListDropdown.prototype._buildListElem = function(itemsList, listClass) {
+  var listElem = $('<ul></ul>');
+
+  listElem.addClass(listClass);
+  $.each(itemsList, $.proxy(function(idx, item) {
+    if (item.type === 'option') {
+      listElem.append(this._buildListOptionElem(item));
+    } else if (item.type === 'optgroup') {
+      listElem.append(this._buildListOptGroupElem(item));
+      listElem.append(this._buildListElem(item.items, 'romo-option-list-optgroup'));
+    }
+  }, this));
+
+  return listElem;
+}
+
+RomoOptionListDropdown.prototype._buildListOptionElem = function(item) {
+  var itemElem = $('<li data-romo-option-list-dropdown-item="opt"></li>');
+  var value    = item.value || '';
+
+  itemElem.attr('data-romo-option-list-dropdown-option-value', value);
+  itemElem.html(item.displayHtml || item.displayText || '&nbsp;');
+  if (item.selected === true) {
+    itemElem.addClass('selected');
+    this.prevValue = value; // the last option marked selected is used
+  }
+  if (item.disabled === true) {
+    itemElem.addClass('disabled');
+  }
+
+  return itemElem;
+}
+
+RomoOptionListDropdown.prototype._buildListOptGroupElemItem = function(item) {
+  var itemElem = $('<li data-romo-option-list-dropdown-item="optgroup"></li>');
+
+  itemElem.text(item.label);
+
+  return itemElem;
+}
+
+RomoOptionListDropdown.prototype._buildOptionFilter = function() {
+  var filter = $('<input type="text" size="1" class="romo-option-list-dropdown-filter"></input>');
+
+  if (this.elem.data('romo-option-list-dropdown-filter-placeholder') !== undefined) {
+    filter.attr('placeholder', this.elem.data('romo-option-list-dropdown-filter-placeholder'));
+  }
+  filter.attr('data-romo-indicator-text-input-elem-display',       "block");
+  filter.attr('data-romo-indicator-text-input-indicator-position', "right");
+  if (this.elem.data('romo-option-list-dropdown-filter-indicator') !== undefined) {
+    filter.attr('data-romo-indicator-text-input-indicator', this.elem.data('romo-option-list-dropdown-filter-indicator'));
+  }
+  if (this.elem.data('romo-option-list-dropdown-filter-indicator-width-px') !== undefined) {
+    filter.attr('data-romo-indicator-text-input-indicator-width-px', this.elem.data('romo-option-list-dropdown-filter-indicator-width-px'));
+  }
+  filter.attr('data-romo-form-disable-enter-submit', "true");
+  filter.attr('data-romo-onkey-on', "keydown");
+
+  filter.attr('autocomplete', 'off');
+
+  return filter;
+}
+
+RomoOptionListDropdown.prototype._bindDropdownOptionFilter = function() {
+  this.optionFilter.romoIndicatorTextInput();
+  this.optionFilter.romoOnkey();
+
+  this.romoDropdown.elem.on('focus', $.proxy(function(e) {
+    if (this.blurTimeoutId !== undefined) {
+      clearTimeout(this.blurTimeoutId);
+    }
+    // remove any manual elem focus when elem is actually focused
+    this.optionFilterFocused = false;
+    this.romoDropdown.elem.removeClass(this.focusStyleClass);
+  }, this));
+  this.romoDropdown.elem.on('blur', $.proxy(function(e) {
+    if (this.blurTimeoutId !== undefined) {
+      clearTimeout(this.blurTimeoutId);
+    }
+    // close the dropdown when elem is blurred
+    // remove any manual focus as well
+    this.romoDropdown.elem.removeClass(this.focusStyleClass);
+    this.blurTimeoutId = setTimeout($.proxy(function() {
+      if (this.popupMouseDown !== true && this.optionFilterFocused !== true) {
+        this.romoDropdown.elem.trigger('dropdown:triggerPopupClose', []);
+      }
+    }, this), 10);
+  }, this));
+  this.optionFilter.on('focus', $.proxy(function(e) {
+    if (this.blurTimeoutId !== undefined) {
+      clearTimeout(this.blurTimeoutId);
+    }
+    // manually make the elem focused when its filter is focused
+    this.optionFilterFocused = true;
+    this.romoDropdown.elem.addClass(this.focusStyleClass);
+  }, this));
+  this.optionFilter.on('blur', $.proxy(function(e) {
+    // remove any manual elem focus when its filter is blurred
+    this.optionFilterFocused = false;
+    this.romoDropdown.elem.removeClass(this.focusStyleClass);
+  }, this));
+
+  this.romoDropdown.elem.on('dropdown:popupOpen', $.proxy(function(e, dropdown) {
+    this.optionFilter.trigger('indicatorTextInput:triggerPlaceIndicator');
+    this.optionFilter.focus();
+    this._filterOptionElems();
+  }, this));
+  this.romoDropdown.elem.on('dropdown:popupClose', $.proxy(function(e, dropdown) {
+    this.optionFilter.val('');
+  }, this));
+  this.romoDropdown.elem.on('dropdown:popupClosedByEsc', $.proxy(function(e, dropdown) {
+    this.romoDropdown.elem.focus();
+  }, this));
+  this.optionFilter.on('click', $.proxy(function(e) {
+    if (e !== undefined) {
+      e.stopPropagation();
+    }
+  }, this));
+  this.romoDropdown.popupElem.on('click', $.proxy(function(e) {
+    this.optionFilter.focus();
+  }, this));
+
+  this.onkeySearchTimeout = undefined;
+  this.onkeySearchDelay   = 100; // 0.1 secs, want it to be really responsive
+
+  this.optionFilter.on('onkey:trigger', $.proxy(function(e, triggerEvent, onkey) {
+    // TODO: incorp this timeout logic into the onkey component so don't have to repeat it
+    clearTimeout(this.onkeySearchTimeout);
+    this.onkeySearchTimeout = setTimeout($.proxy(function() {
+      if (Romo.nonInputTextKeyCodes().indexOf(triggerEvent.keyCode) === -1 /* Input Text */) {
+        this._filterOptionElems();
+      }
+    }, this), this.onkeySearchDelay);
+  }, this));
+}
+
+RomoOptionListDropdown.prototype._filterOptionElems = function() {
+  this.elem.trigger('romoOptionListDropdown:filterOptions', [this.optionFilter.val(), this]);
+}
+
+RomoOptionListDropdown.prototype._updateOptionsListUI = function(highlightOptionElem) {
+  this.romoDropdown.doPlacePopupElem();
+  if (highlightOptionElem !== undefined) {
+    this._highlightItem(highlightOptionElem);
+    this._scrollTopToItem(highlightOptionElem);
+  } else {
+    this._highlightItem(this.selectedItemElem());
+    this._scrollTopToItem(this.selectedItemElem());
+  }
+}
+
+RomoOptionListDropdown.prototype._selectHighlightedItem = function() {
+  var curr = this._getHighlightedItem();
+  if (curr.length !== 0) {
+    var prevValue = this.prevValue;
+    var newValue  = curr.data('romo-option-list-dropdown-option-value');
+
+    this.romoDropdown.doPopupClose();
+    this.elem.trigger('romoOptionListDropdown:itemSelected', [newValue, prevValue, this]);
+
+    if (newValue !== prevValue) {
+      this.doSetNewValue(newValue);
+      this.elem.trigger('romoOptionListDropdown:change', [newValue, prevValue, this]);
+    }
+  }
+}
+
+RomoOptionListDropdown.prototype._onPopupOpen = function(e) {
+  if (this.elem.hasClass('disabled') === false) {
+    this._highlightItem(this.selectedItemElem());
+    this._scrollTopToItem(this.selectedItemElem());
+  }
+  $('body').on('keydown', $.proxy(this._onPopupOpenBodyKeyDown, this));
+}
+
+RomoOptionListDropdown.prototype._onPopupClose = function(e) {
+  this._highlightItem($());
+  $('body').off('keydown', $.proxy(this._onPopupOpenBodyKeyDown, this));
+}
+
+RomoOptionListDropdown.prototype._onItemEnter = function(e) {
+  if (e !== undefined) {
+    e.preventDefault();
+    e.stopPropagation();
+  }
+  this._highlightItem($(e.target));
+}
+
+RomoOptionListDropdown.prototype._onItemClick = function(e) {
+  if (this.blurTimeoutId !== undefined) {
+    clearTimeout(this.blurTimeoutId);
+    this.blurTimeoutId = undefined;
+  }
+  if (e !== undefined) {
+    e.preventDefault();
+    e.stopPropagation();
+  }
+  this._selectHighlightedItem();
+}
+
+RomoOptionListDropdown.prototype._onPopupMouseDown = function(e) {
+  this.popupMouseDown = true;
+}
+
+RomoOptionListDropdown.prototype._onPopupMouseUp = function(e) {
+  this.popupMouseDown = false;
+}
+
+RomoOptionListDropdown.prototype._onPopupOpenBodyKeyDown = function(e) {
+  if (e !== undefined) {
+    e.stopPropagation();
+  }
+
+  var scroll = this.romoDropdown.bodyElem;
+
+  if (e.keyCode === 38 /* Up */) {
+    var prev = this._prevListItem();
+
+    this._highlightItem(prev);
+    if (scroll.offset().top > prev.offset().top) {
+      this._scrollTopToItem(prev);
+    } else if ((scroll.offset().top + scroll.height()) < prev.offset().top) {
+      this._scrollTopToItem(prev);
+    }
+
+    return false;
+  } else if(e.keyCode === 40 /* Down */) {
+    var next = this._nextListItem();
+
+    this._highlightItem(next);
+    if ((scroll.offset().top + scroll.height()) < next.offset().top + next.height()) {
+      this._scrollBottomToItem(next);
+    } else if (scroll.offset().top > next.offset().top) {
+      this._scrollTopToItem(next);
+    }
+
+    return false;
+  } else if (e.keyCode === 13 /* Enter */ ) {
+    this._selectHighlightedItem();
+    return false;
+  } else if (e.keyCode === 9 /* Tab */ ) {
+    e.preventDefault();
+    return false;
+  } else {
+    return true;
+  }
+}
+
+RomoOptionListDropdown.prototype._onElemKeyDown = function(e) {
+  if (this.elem.hasClass('disabled') === false) {
+    if (this.romoDropdown.popupElem.hasClass('romo-dropdown-open') === false) {
+      if (e.keyCode === 40 /* Down */  || e.keyCode === 38 /* Up */) {
+        this.romoDropdown.doPopupOpen();
+        return false;
+      } else if (this.optionFilter !== undefined &&
+                 Romo.nonInputTextKeyCodes().indexOf(e.keyCode) === -1 /* Input Text */)  {
+        if (e.metaKey === false) {
+          // don't prevent default on Cmd-* keys (preserve Cmd-R refresh, etc)
+          e.preventDefault();
+        }
+        e.stopPropagation();
+        this.optionFilter.val(e.key);
+        this.romoDropdown.doPopupOpen();
+        return true;
+      } else {
+        return true;
+      }
+    }
+  }
+  return true;
+}
+
+RomoOptionListDropdown.prototype._scrollTopToItem = function(item) {
+  if (item.size() > 0) {
+    var scroll = this.romoDropdown.bodyElem;
+    scroll.scrollTop(0);
+
+    var scrollOffsetTop = scroll.offset().top;
+    var selOffsetTop = item.offset().top;
+    var selOffset = item.height() / 2;
+
+    scroll.scrollTop(selOffsetTop - scrollOffsetTop - selOffset);
+  }
+}
+
+RomoOptionListDropdown.prototype._scrollBottomToItem = function(item) {
+  if (item.size() > 0) {
+    var scroll = this.romoDropdown.bodyElem;
+    scroll.scrollTop(0);
+
+    var scrollOffsetTop = scroll.offset().top;
+    var selOffsetTop = item.offset().top;
+    var selOffset = scroll[0].offsetHeight - item.height();
+
+    scroll.scrollTop(selOffsetTop - scrollOffsetTop - selOffset);
+  }
+}
+
+RomoOptionListDropdown.prototype._nextListItem = function() {
+  var curr = this._getHighlightedItem();
+  if (curr.length === 0) {
+    return curr;
+  }
+  var currList = curr.closest('UL');
+  var next     = Romo.selectNext(curr, this.itemSelector);
+
+  while (next.length === 0) {
+    currList = Romo.selectNext(currList, 'UL');
+    if (currList.length !== 0) {
+      next = currList.find(this.itemSelector).first();
+    } else {
+      next = this.romoDropdown.bodyElem.find(this.itemSelector).first();
+    }
+  }
+  return next;
+}
+
+RomoOptionListDropdown.prototype._prevListItem = function() {
+  var curr = this._getHighlightedItem();
+  if (curr.length === 0) {
+    return curr;
+  }
+  var currList = curr.closest('UL');
+  var prev     = Romo.selectPrev(curr, this.itemSelector);
+
+  while (prev.length === 0) {
+    currList = Romo.selectPrev(currList, 'UL');
+    if (currList.length !== 0) {
+      prev = currList.find(this.itemSelector).last();
+    } else {
+      prev = this.romoDropdown.bodyElem.find(this.itemSelector).last();
+    }
+  }
+  return prev;
+}
+
+RomoOptionListDropdown.prototype._highlightItem = function(item) {
+  this._getHighlightedItem().removeClass('romo-option-list-dropdown-highlight');
+  item.addClass('romo-option-list-dropdown-highlight');
+}
+
+RomoOptionListDropdown.prototype._getHighlightedItem = function() {
+  return this.romoDropdown.bodyElem.find('LI.romo-option-list-dropdown-highlight');
+}
+
+Romo.onInitUI(function(e) {
+  Romo.initUIElems(e, '[data-romo-option-list-dropdown-auto="true"]').romoOptionListDropdown();
+});

--- a/assets/js/romo/select.js
+++ b/assets/js/romo/select.js
@@ -77,7 +77,7 @@ RomoSelect.prototype.doBindSelectDropdown = function() {
 }
 
 RomoSelect.prototype.doRefreshUI = function() {
-  var text = this.romoSelectDropdown.selectedListing().text() || '&nbsp;';
+  var text = this.romoSelectDropdown.selectedItemElem().text() || '&nbsp;';
   this.romoSelectDropdown.elem.find('.romo-select-text').html(text);
 }
 

--- a/assets/js/romo/select_dropdown.js
+++ b/assets/js/romo/select_dropdown.js
@@ -5,20 +5,17 @@ $.fn.romoSelectDropdown = function(optionElemsParent) {
 }
 
 var RomoSelectDropdown = function(element, optionElemsParent) {
-  this.elem      = $(element);
-  this.prevValue = '';
+  this.elem = $(element);
 
   this.filterHiddenClass = 'romo-select-filter-hidden';
-  this.itemSelector      = 'LI[data-romo-select-item="opt"]:not(.disabled):not(.'+this.filterHiddenClass+')';
 
-  var optsParent    = (optionElemsParent || this.elem.find('.romo-select-dropdown-options-parent'));
-  this.optionElems  = optsParent.children();
-  this.optionList   = this._buildOptionList(this.optionElems);
-  this.optionFilter = undefined;
+  var optsParent   = (optionElemsParent || this.elem.find('.romo-select-dropdown-options-parent'));
+  this.optionElems = optsParent.children();
 
   this.doInit();
-  this.doBindDropdown();
+  this._bindElem();
 
+  // TODO: move to select
   if (this.elem.attr('id') !== undefined) {
     $('label[for="'+this.elem.attr('id')+'"]').on('click', $.proxy(function(e) {
       this.elem.focus();
@@ -28,8 +25,24 @@ var RomoSelectDropdown = function(element, optionElemsParent) {
   this.elem.trigger('selectDropdown:ready', [this]);
 }
 
-RomoSelectDropdown.prototype.selectedListing = function() {
-  return this.romoDropdown.bodyElem.find('LI.selected');
+RomoSelectDropdown.prototype.bodyElem = function() {
+  return this.romoOptionListDropdown.bodyElem();
+}
+
+RomoSelectDropdown.prototype.popupElem = function() {
+  return this.romoOptionListDropdown.popupElem();
+}
+
+RomoSelectDropdown.prototype.selectedItemElem = function() {
+  return this.romoOptionListDropdown.selectedItemElem();
+}
+
+RomoSelectDropdown.prototype.optItemElems = function() {
+  return this.romoOptionListDropdown.optItemElems();
+}
+
+RomoSelectDropdown.prototype.optgroupItemElems = function() {
+  return this.romoOptionListDropdown.optgroupItemElems();
 }
 
 RomoSelectDropdown.prototype.doInit = function() {
@@ -37,417 +50,119 @@ RomoSelectDropdown.prototype.doInit = function() {
 }
 
 RomoSelectDropdown.prototype.doSetNewValue = function(newValue) {
-  this.selectedListing().removeClass('selected');
-  this.romoDropdown.bodyElem.find('LI[data-romo-select-option-value="'+newValue+'"]').addClass('selected');
-
-  this.prevValue = newValue;
+  this.romoOptionListDropdown.doSetNewValue(newValue);
 }
 
-RomoSelectDropdown.prototype.doBindDropdown = function() {
-  this.romoDropdown = this.elem.romoDropdown()[0];
-  this.romoDropdown.doSetPopupZIndex(this.elem);
-  this.romoDropdown.bodyElem.addClass('romo-select-option-list');
+/* private */
 
-  this.romoDropdown.elem.on('dropdown:popupOpen', $.proxy(this.onPopupOpen, this));
-  this.romoDropdown.elem.on('dropdown:popupClose', $.proxy(this.onPopupClose, this));
+RomoSelectDropdown.prototype._bindElem = function() {
+  this.elem.attr('data-romo-option-list-dropdown-item-selector-customization', ':not(.'+this.filterHiddenClass+')');
+  this.elem.attr('data-romo-option-list-focus-style-class', 'romo-select-focus');
 
-  this.romoDropdown.elem.on('keydown', $.proxy(this.onElemKeyDown, this));
-  this.romoDropdown.popupElem.on('keydown', $.proxy(this.onElemKeyDown, this));
-
-  this.romoDropdown.elem.on('dropdown:toggle', $.proxy(function(e, dropdown) {
-    this.elem.trigger('selectDropdown:dropdown:toggle', [dropdown, this]);
-  }, this));
-  this.romoDropdown.elem.on('dropdown:popupOpen', $.proxy(function(e, dropdown) {
-    this.elem.trigger('selectDropdown:dropdown:popupOpen', [dropdown, this]);
-  }, this));
-  this.romoDropdown.elem.on('dropdown:popupClose', $.proxy(function(e, dropdown) {
-    this.elem.trigger('selectDropdown:dropdown:popupClose', [dropdown, this]);
-  }, this));
-
-  this.elem.on('selectDropdown:triggerToggle', $.proxy(function(e) {
-    this.romoDropdown.elem.trigger('dropdown:triggerToggle', []);
-  }, this));
-  this.elem.on('selectDropdown:triggerPopupOpen', $.proxy(function(e) {
-    this.romoDropdown.elem.trigger('dropdown:triggerPopupOpen', []);
-  }, this));
-  this.elem.on('selectDropdown:triggerPopupClose', $.proxy(function(e) {
-    this.romoDropdown.elem.trigger('dropdown:triggerPopupClose', []);
-  }, this));
-
-  this.romoDropdown.bodyElem.html('');
-
-  if (this.elem.data('romo-select-dropdown-no-filter') !== true) {
-    this.optionFilter = this._buildOptionFilter();
-    var optionFilterWrapper = $('<div class="romo-select-dropdown-option-filter-wrapper"></div>');
-    optionFilterWrapper.append(this.optionFilter);
-    this.romoDropdown.popupElem.prepend(optionFilterWrapper);
-    this.doBindDropdownOptionFilter();
+  if (this.elem.data('romo-select-dropdown-no-filter') !== undefined) {
+    this.elem.attr('data-romo-option-list-dropdown-no-filter', this.elem.data('romo-select-dropdown-no-filter'));
+  }
+  if (this.elem.data('romo-select-dropdown-filter-placeholder') !== undefined) {
+    this.elem.attr('data-romo-option-list-dropdown-filter-placeholder', this.elem.data('romo-select-dropdown-filter-placeholder'));
+  }
+  if (this.elem.data('romo-select-dropdown-filter-indicator') !== undefined) {
+    this.elem.attr('data-romo-option-list-dropdown-filter-indicator', this.elem.data('romo-select-dropdown-filter-indicator'));
+  }
+  if (this.elem.data('romo-select-dropdown-filter-indicator-width-px') !== undefined) {
+    this.elem.attr('data-romo-option-list-dropdown-filter-indicator-width-px', this.elem.data('romo-select-dropdown-filter-indicator-width-px'));
   }
 
-  this.romoDropdown.bodyElem.append(this.optionList);
-
-  this.romoDropdown.bodyElem.find(this.itemSelector).on('mouseenter', $.proxy(this.onItemEnter, this));
-  this.romoDropdown.bodyElem.find(this.itemSelector).on('click', $.proxy(this.onItemClick, this));
-
-  this.romoDropdown.popupElem.on('mousedown', $.proxy(this.onPopupMouseDown, this));
-  this.romoDropdown.popupElem.on('mouseup',   $.proxy(this.onPopupMouseUp, this));
-}
-
-RomoSelectDropdown.prototype.doBindDropdownOptionFilter = function() {
-  this.optionFilter.romoIndicatorTextInput();
-  this.optionFilter.romoOnkey();
-
-  this.romoDropdown.elem.on('focus', $.proxy(function(e) {
-    if (this.blurTimeoutId !== undefined) {
-      clearTimeout(this.blurTimeoutId);
-    }
-    // remove any manual elem focus when elem is actually focused
-    this.optionFilterFocused = false;
-    this.romoDropdown.elem.removeClass('romo-select-focus');
+  this.elem.on('romoOptionListDropdown:dropdown:toggle', $.proxy(function(e, dropdown) {
+    this.elem.trigger('selectDropdown:dropdown:toggle', [dropdown, this]);
   }, this));
-  this.romoDropdown.elem.on('blur', $.proxy(function(e) {
-    if (this.blurTimeoutId !== undefined) {
-      clearTimeout(this.blurTimeoutId);
-    }
-    // close the dropdown when elem is blurred
-    // remove any manual focus as well
-    this.romoDropdown.elem.removeClass('romo-select-focus');
-    this.blurTimeoutId = setTimeout($.proxy(function() {
-      if (this.popupMouseDown !== true && this.optionFilterFocused !== true) {
-        this.romoDropdown.elem.trigger('dropdown:triggerPopupClose', []);
-      }
-    }, this), 10);
+  this.elem.on('romoOptionListDropdown:dropdown:popupOpen', $.proxy(function(e, dropdown) {
+    this.elem.trigger('selectDropdown:dropdown:popupOpen', [dropdown, this]);
   }, this));
-  this.optionFilter.on('focus', $.proxy(function(e) {
-    if (this.blurTimeoutId !== undefined) {
-      clearTimeout(this.blurTimeoutId);
-    }
-    // manually make the elem focused when its filter is focused
-    this.optionFilterFocused = true;
-    this.romoDropdown.elem.addClass('romo-select-focus');
+  this.elem.on('romoOptionListDropdown:dropdown:popupClose', $.proxy(function(e, dropdown) {
+    this.elem.trigger('selectDropdown:dropdown:popupClose', [dropdown, this]);
   }, this));
-  this.optionFilter.on('blur', $.proxy(function(e) {
-    // remove any manual elem focus when its filter is blurred
-    this.optionFilterFocused = false;
-    this.romoDropdown.elem.removeClass('romo-select-focus');
+  this.elem.on('romoOptionListDropdown:itemSelected', $.proxy(function(e, newValue, prevValue, romoOptionListDropdown) {
+    this.elem.trigger('selectDropdown:itemSelected', [newValue, prevValue, this]);
+  }, this));
+  this.elem.on('romoOptionListDropdown:change', $.proxy(function(e, newValue, prevValue, romoOptionListDropdown) {
+    this.elem.trigger('selectDropdown:change', [newValue, prevValue, this]);
   }, this));
 
-  this.romoDropdown.elem.on('dropdown:popupOpen', $.proxy(function(e, dropdown) {
-    this.optionFilter.trigger('indicatorTextInput:triggerPlaceIndicator');
-    this.optionFilter.focus();
-    this.doFilterOptionElems();
+
+  this.elem.on('selectDropdown:triggerToggle', $.proxy(function(e) {
+    this.elem.trigger('romoOptionListDropdown:triggerToggle', []);
   }, this));
-  this.romoDropdown.elem.on('dropdown:popupClose', $.proxy(function(e, dropdown) {
-    this.optionFilter.val('');
+  this.elem.on('selectDropdown:triggerPopupOpen', $.proxy(function(e) {
+    this.elem.trigger('romoOptionListDropdown:triggerPopupOpen', []);
   }, this));
-  this.romoDropdown.elem.on('dropdown:popupClosedByEsc', $.proxy(function(e, dropdown) {
-    this.romoDropdown.elem.focus();
-  }, this));
-  this.optionFilter.on('click', $.proxy(function(e) {
-    if (e !== undefined) {
-      e.stopPropagation();
-    }
-  }, this));
-  this.romoDropdown.popupElem.on('click', $.proxy(function(e) {
-    this.optionFilter.focus();
+  this.elem.on('selectDropdown:triggerPopupClose', $.proxy(function(e) {
+    this.elem.trigger('romoOptionListDropdown:triggerPopupClose', []);
   }, this));
 
-  this.onkeySearchTimeout = undefined;
-  this.onkeySearchDelay   = 100; // 0.1 secs, want it to be really responsive
+  this.romoOptionListDropdown = this.elem.romoOptionListDropdown()[0];
 
-  this.optionFilter.on('onkey:trigger', $.proxy(function(e, triggerEvent, onkey) {
-    // TODO: incorp this timeout logic into the onkey component so don't have to repeat it
-    clearTimeout(this.onkeySearchTimeout);
-    this.onkeySearchTimeout = setTimeout($.proxy(function() {
-      if (Romo.nonInputTextKeyCodes().indexOf(triggerEvent.keyCode) === -1 /* Input Text */) {
-        this.doFilterOptionElems();
-      }
-    }, this), this.onkeySearchDelay);
-  }, this));
-}
-
-RomoSelectDropdown.prototype.doFilterOptionElems = function() {
-  var wbFilter = new RomoWordBoundaryFilter(
-    this.optionFilter.val(),
-    this.romoDropdown.bodyElem.find('LI[data-romo-select-item="opt"]'),
-    function(elem) {
+  this.elem.on('romoOptionListDropdown:filterOptions', $.proxy(function(e, filterValue, romoOptionListDropdown) {
+    var wbFilter = new RomoWordBoundaryFilter(filterValue, this.optItemElems(), function(elem) {
       // The romo word boundary filter by default considers a space, "-" and "_" as word boundaries.
       // We want to also consider other non-word characters (such as ":", "/", ".", "?", "=", "&")
       // as word boundaries as well.
       return elem[0].textContent.replace(/\W/g, ' ');
-    }
-  );
+    });
 
-  wbFilter.matchingElems.show();
-  wbFilter.notMatchingElems.hide();
-  wbFilter.matchingElems.removeClass(this.filterHiddenClass);
-  wbFilter.notMatchingElems.addClass(this.filterHiddenClass);
+    wbFilter.matchingElems.show();
+    wbFilter.notMatchingElems.hide();
+    wbFilter.matchingElems.removeClass(this.filterHiddenClass);
+    wbFilter.notMatchingElems.addClass(this.filterHiddenClass);
 
-  this.romoDropdown.doPlacePopupElem();
-  if (this.optionFilter.val() !== '') {
-    this._highlightItem(wbFilter.matchingElems.first());
-    this._scrollTopToItem(wbFilter.matchingElems.first());
-  } else {
-    this._highlightItem(this.selectedListing());
-    this._scrollTopToItem(this.selectedListing());
-  }
-}
-
-RomoSelectDropdown.prototype.doSelectHighlightedItem = function() {
-  var curr = this._getHighlightedItem();
-  if (curr.length !== 0) {
-    var prevValue = this.prevValue;
-    var newValue  = curr.data('romo-select-option-value');
-
-    this.romoDropdown.doPopupClose();
-    this.elem.trigger('selectDropdown:itemSelected', [newValue, prevValue, this]);
-
-    if (newValue !== prevValue) {
-      this.doSetNewValue(newValue);
-      this.elem.trigger('selectDropdown:change', [newValue, prevValue, this]);
-    }
-  }
-}
-
-RomoSelectDropdown.prototype.onPopupOpen = function(e) {
-  if (this.elem.hasClass('disabled') === false) {
-    this._highlightItem(this.selectedListing());
-    this._scrollTopToItem(this.selectedListing());
-  }
-  $('body').on('keydown', $.proxy(this.onPopupOpenBodyKeyDown, this));
-}
-
-RomoSelectDropdown.prototype.onPopupClose = function(e) {
-  this._highlightItem($());
-  $('body').off('keydown', $.proxy(this.onPopupOpenBodyKeyDown, this));
-}
-
-RomoSelectDropdown.prototype.onItemEnter = function(e) {
-  if (e !== undefined) {
-    e.preventDefault();
-    e.stopPropagation();
-  }
-  this._highlightItem($(e.target));
-}
-
-RomoSelectDropdown.prototype.onItemClick = function(e) {
-  if (this.blurTimeoutId !== undefined) {
-    clearTimeout(this.blurTimeoutId);
-    this.blurTimeoutId = undefined;
-  }
-  if (e !== undefined) {
-    e.preventDefault();
-    e.stopPropagation();
-  }
-  this.doSelectHighlightedItem();
-}
-
-RomoSelectDropdown.prototype.onPopupMouseDown = function(e) {
-  this.popupMouseDown = true;
-}
-
-RomoSelectDropdown.prototype.onPopupMouseUp = function(e) {
-  this.popupMouseDown = false;
-}
-
-RomoSelectDropdown.prototype.onPopupOpenBodyKeyDown = function(e) {
-  if (e !== undefined) {
-    e.stopPropagation();
-  }
-
-  var scroll = this.romoDropdown.bodyElem;
-
-  if (e.keyCode === 38 /* Up */) {
-    var prev = this._prevListItem();
-
-    this._highlightItem(prev);
-    if (scroll.offset().top > prev.offset().top) {
-      this._scrollTopToItem(prev);
-    } else if ((scroll.offset().top + scroll.height()) < prev.offset().top) {
-      this._scrollTopToItem(prev);
-    }
-
-    return false;
-  } else if(e.keyCode === 40 /* Down */) {
-    var next = this._nextListItem();
-
-    this._highlightItem(next);
-    if ((scroll.offset().top + scroll.height()) < next.offset().top + next.height()) {
-      this._scrollBottomToItem(next);
-    } else if (scroll.offset().top > next.offset().top) {
-      this._scrollTopToItem(next);
-    }
-
-    return false;
-  } else if (e.keyCode === 13 /* Enter */ ) {
-    this.doSelectHighlightedItem();
-    return false;
-  } else if (e.keyCode === 9 /* Tab */ ) {
-    e.preventDefault();
-    return false;
-  } else {
-    return true;
-  }
-}
-
-RomoSelectDropdown.prototype.onElemKeyDown = function(e) {
-  if (this.elem.hasClass('disabled') === false) {
-    if (this.romoDropdown.popupElem.hasClass('romo-dropdown-open') === false) {
-      if (e.keyCode === 40 /* Down */  || e.keyCode === 38 /* Up */) {
-        this.romoDropdown.doPopupOpen();
-        return false;
-      } else if (this.optionFilter !== undefined &&
-                 Romo.nonInputTextKeyCodes().indexOf(e.keyCode) === -1 /* Input Text */)  {
-        if (e.metaKey === false) {
-          // don't prevent default on Cmd-* keys (preserve Cmd-R refresh, etc)
-          e.preventDefault();
-        }
-        e.stopPropagation();
-        this.optionFilter.val(e.key);
-        this.romoDropdown.doPopupOpen();
-        return true;
-      } else {
-        return true;
-      }
-    }
-  }
-  return true;
-}
-
-RomoSelectDropdown.prototype._scrollTopToItem = function(item) {
-  if (item.size() > 0) {
-    var scroll = this.romoDropdown.bodyElem;
-    scroll.scrollTop(0);
-
-    var scrollOffsetTop = scroll.offset().top;
-    var selOffsetTop = item.offset().top;
-    var selOffset = item.height() / 2;
-
-    scroll.scrollTop(selOffsetTop - scrollOffsetTop - selOffset);
-  }
-}
-
-RomoSelectDropdown.prototype._scrollBottomToItem = function(item) {
-  if (item.size() > 0) {
-    var scroll = this.romoDropdown.bodyElem;
-    scroll.scrollTop(0);
-
-    var scrollOffsetTop = scroll.offset().top;
-    var selOffsetTop = item.offset().top;
-    var selOffset = scroll[0].offsetHeight - item.height();
-
-    scroll.scrollTop(selOffsetTop - scrollOffsetTop - selOffset);
-  }
-}
-
-RomoSelectDropdown.prototype._buildOptionList = function(optionElems, listClass) {
-  var list = $('<ul></ul>');
-  list.addClass(listClass);
-  $.each(optionElems, $.proxy(function(idx, elem) {
-    if (elem.tagName === "OPTION") {
-      list.append(this._buildOptionListItem(elem));
-    } else if (elem.tagName === "OPTGROUP") {
-      list.append(this._buildOptGroupListItem(elem));
-      list.append(this._buildOptionList($(elem).children(), 'romo-select-optgroup'));
+    if (filterValue !== '') {
+      this.elem.trigger('romoOptionListDropdown:triggerListOptionsUpdate', [wbFilter.matchingElems.first()]);
+    } else {
+      this.elem.trigger('romoOptionListDropdown:triggerListOptionsUpdate', [this.selectedItemElem()]);
     }
   }, this));
+
+  this.romoOptionListDropdown.doSetListItems(this._buildOptionList(this.optionElems));
+}
+
+RomoSelectDropdown.prototype._buildOptionList = function(optionElems) {
+  var list = [];
+
+  $.each(optionElems, $.proxy(function(idx, optionNode) {
+    if (optionNode.tagName === "OPTION") {
+      list.push(this._buildOptionItem($(optionNode)));
+    } else if (optionNode.tagName === "OPTGROUP") {
+      list.push(this._buildOptGroupItem($(optionNode)));
+    }
+  }, this));
+
   return list;
 }
 
-RomoSelectDropdown.prototype._buildOptionListItem = function(optionElem) {
-  var opt   = $(optionElem);
-  var item  = $('<li data-romo-select-item="opt"></li>');
-  var value = opt.attr('value') || '';
+RomoSelectDropdown.prototype._buildOptionItem = function(optionElem) {
+  var item = {}
 
-  item.attr('data-romo-select-option-value', value);
-  item.html(opt.text().trim() || '&nbsp;');
-  if (opt.prop('selected')) {
-    item.addClass('selected');
-    this.prevValue = value; // the last option marked selected is used
+  item['type']        = 'option';
+  item['value']       = (optionElem.attr('value') || '');
+  item['displayHtml'] = (optionElem.text().trim() || '&nbsp;');
+
+  if (optionElem.prop('selected')) {
+    item['selected'] = true;
   }
-  if (opt.attr('disabled') !== undefined) {
-    item.addClass('disabled');
+  if (optionElem.attr('disabled') !== undefined) {
+    item['disabled'] = true;
   }
 
   return item;
 }
 
-RomoSelectDropdown.prototype._buildOptGroupListItem = function(optGroupElem) {
-  var optgroup = $(optGroupElem);
-  var item = $('<li data-romo-select-item="optgroup"></li>');
+RomoSelectDropdown.prototype._buildOptGroupItem = function(optGroupElem) {
+  var item = {};
 
-  item.text(optgroup.attr('label'));
+  item['type']  = 'optgroup';
+  item['label'] = optGroupElem.attr('label');
+  item['items'] = this._buildOptionList(optGroupElem.children());
 
   return item;
-}
-
-RomoSelectDropdown.prototype._buildOptionFilter = function() {
-  var filter = $('<input type="text" size="1" class="romo-select-dropdown-option-filter"></input>');
-
-  if (this.elem.data('romo-select-dropdown-filter-placeholder') !== undefined) {
-    filter.attr('placeholder', this.elem.data('romo-select-dropdown-filter-placeholder'));
-  }
-  filter.attr('data-romo-indicator-text-input-elem-display', "block");
-  filter.attr('data-romo-indicator-text-input-indicator-position', "right");
-  if (this.elem.data('romo-select-dropdown-filter-indicator') !== undefined) {
-    filter.attr('data-romo-indicator-text-input-indicator', this.elem.data('romo-select-dropdown-filter-indicator'));
-  }
-  if (this.elem.data('romo-select-dropdown-filter-indicator-width-px') !== undefined) {
-    filter.attr('data-romo-indicator-text-input-indicator-width-px', this.elem.data('romo-select-dropdown-filter-indicator-width-px'));
-  }
-  filter.attr('data-romo-form-disable-enter-submit', "true");
-  filter.attr('data-romo-onkey-on', "keydown");
-
-  filter.attr('autocomplete', 'off');
-
-  return filter;
-}
-
-RomoSelectDropdown.prototype._nextListItem = function() {
-  var curr = this._getHighlightedItem();
-  if (curr.length === 0) {
-    return curr;
-  }
-  var currList = curr.closest('UL');
-  var next     = Romo.selectNext(curr, this.itemSelector);
-
-  while (next.length === 0) {
-    currList = Romo.selectNext(currList, 'UL');
-    if (currList.length !== 0) {
-      next = currList.find(this.itemSelector).first();
-    } else {
-      next = this.romoDropdown.bodyElem.find(this.itemSelector).first();
-    }
-  }
-  return next;
-}
-
-RomoSelectDropdown.prototype._prevListItem = function() {
-  var curr = this._getHighlightedItem();
-  if (curr.length === 0) {
-    return curr;
-  }
-  var currList = curr.closest('UL');
-  var prev     = Romo.selectPrev(curr, this.itemSelector);
-
-  while (prev.length === 0) {
-    currList = Romo.selectPrev(currList, 'UL');
-    if (currList.length !== 0) {
-      prev = currList.find(this.itemSelector).last();
-    } else {
-      prev = this.romoDropdown.bodyElem.find(this.itemSelector).last();
-    }
-  }
-  return prev;
-}
-
-RomoSelectDropdown.prototype._highlightItem = function(item) {
-  this._getHighlightedItem().removeClass('romo-select-highlight');
-  item.addClass('romo-select-highlight');
-}
-
-RomoSelectDropdown.prototype._getHighlightedItem = function() {
-  return this.romoDropdown.bodyElem.find('LI.romo-select-highlight');
 }
 
 Romo.onInitUI(function(e) {

--- a/lib/romo/dassets.rb
+++ b/lib/romo/dassets.rb
@@ -54,6 +54,7 @@ module Romo::Dassets
         'js/romo/dropdown_form.js',
         'js/romo/indicator_text_input.js',
         'js/romo/currency_text_input.js',
+        'js/romo/option_list_dropdown.js',
         'js/romo/select_dropdown.js',
         'js/romo/select.js',
         'js/romo/datepicker.js',

--- a/test/unit/dassets_tests.rb
+++ b/test/unit/dassets_tests.rb
@@ -56,6 +56,7 @@ module Romo::Dassets
         'js/romo/dropdown_form.js',
         'js/romo/indicator_text_input.js',
         'js/romo/currency_text_input.js',
+        'js/romo/option_list_dropdown.js',
         'js/romo/select_dropdown.js',
         'js/romo/select.js',
         'js/romo/datepicker.js',


### PR DESCRIPTION
This is a new component that contains all of the logic related to
a dropdown with a list of selectable options and a filter input
for selecting those options.  It also contains all of the dropdown
handling and navigating prev/next options.

This is prep for adding a new "picker" component.  This new
component will be very similar to the "select" component.  It too
will compose the OptionListDropdown as it will have a list of
selectable options in a dropdown.  The main difference is that
the selectable options won't be sourced from markup but instead
be fetched via RomoAjax as the user types in the filter input.
This component will be designed to work well with large sets of
options that are too cumbersome to render inline as markup.

The OptionListDropdown is designed to allow defining ad-hoc
options via the `doSetListItems` method.  It also triggers a
an event when the filter is typed that can implement custom
behavior.  The SelectDropdown listens for this event and does
its word boundary filter logic.  The picker will listen for this
event and use RomoAjax to fetch matching options and manually
rebuild the option list.

![gif](https://user-images.githubusercontent.com/82110/29196533-94ed5864-7dfa-11e7-8283-5e3329faac87.gif)

@jcredding ready for review.