### PR TITLE
update picker js to properly lookup display text when setting values

### DIFF
--- a/assets/js/romo/option_list_dropdown.js
+++ b/assets/js/romo/option_list_dropdown.js
@@ -31,11 +31,17 @@ RomoOptionListDropdown.prototype.selectedItemElem = function() {
 }
 
 RomoOptionListDropdown.prototype.selectedItemValue = function() {
-  return this.selectedItemElem().data('romo-option-list-dropdown-option-value');
+  // need to use `attr` so it will always read from the DOM
+  // using `data` works the first time but does some elem caching or something
+  // so it won't work subsequent times.
+  return this.elem.attr('data-romo-option-list-dropdown-selected-value');
 }
 
 RomoOptionListDropdown.prototype.selectedItemText = function() {
-  return this.selectedItemElem().data('romo-option-list-dropdown-option-display-text');
+  // need to use `attr` so it will always read from the DOM
+  // using `data` works the first time but does some elem caching or something
+  // so it won't work subsequent times.
+  return this.elem.attr('data-romo-option-list-dropdown-selected-text');
 }
 
 RomoOptionListDropdown.prototype.optItemElems = function() {
@@ -52,7 +58,20 @@ RomoOptionListDropdown.prototype.doInit = function() {
 
 RomoOptionListDropdown.prototype.doSetNewValue = function(newValue) {
   this.selectedItemElem().removeClass('selected');
-  this.romoDropdown.bodyElem.find('LI[data-romo-option-list-dropdown-option-value="'+newValue+'"]').addClass('selected');
+  this.romoDropdown.bodyElem.find(
+    'LI[data-romo-option-list-dropdown-option-value="'+newValue+'"]'
+  ).addClass('selected');
+  this.doSetSelectedValueAndText(
+    newValue,
+    this.selectedItemElem().data('romo-option-list-dropdown-option-display-text')
+  );
+}
+
+RomoOptionListDropdown.prototype.doSetSelectedValueAndText = function(newValue, newText) {
+  // need to use `attr` to persist selected values to the DOM for back button logic
+  // to work.  using `data` won't persist changes to DOM and breaks back button logic.
+  this.elem.attr('data-romo-option-list-dropdown-selected-value', newValue);
+  this.elem.attr('data-romo-option-list-dropdown-selected-text',  newText);
 
   this.prevValue = newValue;
 }


### PR DESCRIPTION
The picker, unlike the select, doesn't have markup to go lookup
extra meta on its options.  This especially comes into play when
dealing with showing a picker with a current value already set.
Because we didn't call to the server to get this option and it
wasn't chosen from the option list dropdown, we don't know what
display text to show in the dropdown elem for the given preset
value.

This adds `doSetSelectedValueAndText` methods to both the picker
and the option list dropdown.  This handles setting the selected
value/text on the option list dropdown element.  This is needed
b/c the picker doesn't keep its options around once the dropdown
is closed and so can't lookup selected data from option markup.

Now that we have selected data referenced in markup for both
selects and pickers, we need to handle setting a single value
on the picker.  Again, the picker doesn't have option markup to
go lookup the display text for a given value.  Instead, manually
ajax call the picker url with a `'value'` data param.  This will
signal the server to just return a list with a single result for
the item with the given value.  This single result is used to
set the selected value/text.  Again, this should only come into
play on init when setting preset values.

Finally, this updates the `'pageshow'` event handler that handles
back button usage.  In this case we can lookup the selected
value/text from the option list drodown as we are storing it on
its elem markup.

Note: the romo ajax needs to be init/bound on the picker elem,
not the option list dropdown elem.  The option list dropdown elem
is a dropdown and it already had special behavior attached to romo
ajax events due to how we use dropdowns loaded with ajax content.

@jcredding ready for review.