### PR TITLE
update indicator to calc its size based on container size

### DIFF
--- a/assets/js/romo/indicator.js
+++ b/assets/js/romo/indicator.js
@@ -8,29 +8,10 @@ $.fn.romoIndicator = function() {
 }
 
 var RomoIndicator = function(element) {
-  this.elem = $(element);
-  this.spinnerOpts = {
-    lines: 11, // The number of lines to draw
-    width: 2, // The line thickness
-    length: parseInt(this.elem.css('font-size')) / 2, // The length of each line
-    radius: parseInt(this.elem.css('font-size')) / 3, // The radius of the inner circle
-    corners: 1, // Corner roundness (0..1)
-    rotate: 0, // The rotation offset
-    direction: 1, // 1: clockwise, -1: counterclockwise
-    color: this.elem.css('color'), // #rgb or #rrggbb or array of colors
-    speed: 1, // Rounds per second
-    trail: 60, // Afterglow percentage
-    shadow: false, // Whether to render a shadow
-    hwaccel: false, // Whether to use hardware acceleration
-    className: 'spinner', // The CSS class to assign to the spinner
-    zIndex: 1000, // The z-index (defaults to 2000000000)
-    top: '50%', // Top position relative to parent
-    left: '50%'// Left position relative to parent
-  };
-
+  this.elem      = $(element);
   this.elemStyle = this.elem.attr('style');
+
   this.doInit();
-  this.spinner = new Spinner(this.spinnerOpts);
 
   this.elem.on('indicator:triggerStart', $.proxy(this.onStart, this));
   this.elem.on('indicator:triggerStop', $.proxy(this.onStop, this));
@@ -48,12 +29,12 @@ RomoIndicator.prototype.doInit = function() {
   // override as needed
 }
 
-RomoIndicator.prototype.onStart = function(e) {
+RomoIndicator.prototype.onStart = function(e, basisSize) {
   if (e !== undefined) {
     e.preventDefault();
   }
 
-  this.doStart();
+  this.doStart(basisSize);
 }
 
 RomoIndicator.prototype.onStop = function(e) {
@@ -64,7 +45,38 @@ RomoIndicator.prototype.onStop = function(e) {
   this.doStop();
 }
 
-RomoIndicator.prototype.doStart = function() {
+RomoIndicator.prototype.doStart = function(customBasisSize) {
+  var basisSize = customBasisSize;
+  if (basisSize === undefined) {
+    basisSize = this.elem.data('romo-indicator-basis-size');
+  }
+  if (basisSize === undefined) {
+    basisSize = Math.min(
+      parseInt(Romo.getComputedStyle(this.elem[0], "width")),
+      parseInt(Romo.getComputedStyle(this.elem[0], "height"))
+    )
+  }
+
+  var spinnerOpts = {
+    lines: 11, // The number of lines to draw
+    width: 2, // The line thickness
+    length: parseInt(basisSize) / 4.5, // The length of each line
+    radius: parseInt(basisSize) / 5.5, // The radius of the inner circle
+    corners: 1, // Corner roundness (0..1)
+    rotate: 0, // The rotation offset
+    direction: 1, // 1: clockwise, -1: counterclockwise
+    color: this.elem.css('color'), // #rgb or #rrggbb or array of colors
+    speed: 1, // Rounds per second
+    trail: 60, // Afterglow percentage
+    shadow: false, // Whether to render a shadow
+    hwaccel: false, // Whether to use hardware acceleration
+    className: 'spinner', // The CSS class to assign to the spinner
+    zIndex: 1000, // The z-index (defaults to 2000000000)
+    top: '50%', // Top position relative to parent
+    left: '50%'// Left position relative to parent
+  };
+  this.spinner = new Spinner(spinnerOpts);
+
   this.elemHtml  = this.elem.html();
   this.elemStyle = this.elem.attr('style');
   this.elem.css({
@@ -78,7 +90,10 @@ RomoIndicator.prototype.doStart = function() {
 }
 
 RomoIndicator.prototype.doStop = function() {
-  this.spinner.stop();
+  if (this.spinner !== undefined) {
+    this.spinner.stop();
+    this.spinner = undefined;
+  }
   if (this.elemHtml !== undefined) {
     this.elem.html(this.elemHtml);
   }

--- a/assets/js/romo/indicator_text_input.js
+++ b/assets/js/romo/indicator_text_input.js
@@ -68,20 +68,28 @@ RomoIndicatorTextInput.prototype._bindElem = function() {
   this.indicatorElem = $();
   var indicatorClass = this.elem.data('romo-indicator-text-input-indicator') || this.defaultIndicatorClass;
   if (indicatorClass !== undefined && indicatorClass !== 'none') {
-    this.indicatorElem = $('<i class="romo-indicator-text-input-indicator '+indicatorClass+'"></i>');
-    this.indicatorElem.romoIndicator();
+    this.indicatorElem = $('<div class="romo-indicator-text-input-indicator"><div><i class="'+indicatorClass+'"></i></div></div>');
     this.elem.after(this.indicatorElem);
     this.indicatorElem.on('click', $.proxy(this._onIndicatorClick, this));
     this._placeIndicatorElem();
 
+    this.indicatorIconContainerElem = this.indicatorElem.find('div');
+    if (this.elem.data('romo-indicator-text-input-indicator-basis-size') !== undefined) {
+      this.indicatorIconContainerElem.attr(
+        'data-romo-indicator-basis-size',
+        this.elem.data('romo-indicator-text-input-indicator-basis-size')
+      )
+    }
+    this.indicatorIconContainerElem.romoIndicator();
+
     this.elem.on('indicatorTextInput:triggerPlaceIndicator', $.proxy(function(e) {
       this._placeIndicatorElem();
     }, this));
-    this.elem.on('indicatorTextInput:triggerIndicatorStart', $.proxy(function(e) {
-      this.indicatorElem.trigger('indicator:triggerStart');
+    this.elem.on('indicatorTextInput:triggerIndicatorStart', $.proxy(function(e, basisSize) {
+      this.indicatorIconContainerElem.trigger('indicator:triggerStart', [basisSize]);
     }, this));
     this.elem.on('indicatorTextInput:triggerIndicatorStop', $.proxy(function(e) {
-      this.indicatorElem.trigger('indicator:triggerStop');
+      this.indicatorIconContainerElem.trigger('indicator:triggerStop');
     }, this));
   }
 

--- a/assets/js/romo/option_list_dropdown.js
+++ b/assets/js/romo/option_list_dropdown.js
@@ -140,7 +140,10 @@ RomoOptionListDropdown.prototype._bindElem = function() {
   }, this));
 
   this.elem.on('romoOptionListDropdown:triggerFilterIndicatorStart', $.proxy(function(e) {
-    this.optionFilterElem.trigger('indicatorTextInput:triggerIndicatorStart', []);
+    this.optionFilterElem.trigger(
+      'indicatorTextInput:triggerIndicatorStart',
+      [Romo.getComputedStyle(this.optionFilterElem[0], "height")]
+    );
   }, this));
   this.elem.on('romoOptionListDropdown:triggerFilterIndicatorStop', $.proxy(function(e) {
     this.optionFilterElem.trigger('indicatorTextInput:triggerIndicatorStop', []);


### PR DESCRIPTION
The previous implementation was based on font size calculations.
This is problematic b/c the calculations assumed the input/btn/etc
had 4 pixels of top/bottom padding such that the indicator would
fill the height of the container.  However, when I went to use
this in the option list dropdown filter UI, it removes the padding
from the filter input and sets a custom input height.  This meant
the indicator greatly overflowed the input height.  This really
just exposed how weak and assumption prone the previous
implementation was.

This new implementation bases the indicator size off a given
`basisSize`.  This basis size is gathered in a few ways.  By
default, it is calculated by getting the lesser of the container's
width/height.  This ensures that by default the indicator will fit
inside its container.  However, in the case this isn't desired,
you can specify a basis size via a data attr or by passing a basis
size when you trigger the start event.  Taking a basis size on
event trigger allows for dynamic calculated sizes and also allows
you to delay calculating the size you want until start-time.

To accommodate passing in custom basis sizes, I had to switch to
building the spinner opts and spinner until start-time.

The indicator text input has also been updated to proxy the event
basis size and the basis size data attr. It has also been updated
to properly nest and structure the indicator item in a container
so that the container can be used as the indicator (spinner)
component.  This means that things are positioned properly.  The
text input's indicator elem is absolutely positioned and absolutely
positioned elems can't be indicator components b/c when the
indicator is started it sets the elem to relative position which
breaks absolute positioning.  By nesting a container and making it
the indicator, we can safely position it relatively.

Finally, this updates the option list dropdown to trigger its
indicator start event with the input height of the filter.  This
allows the indicator to properly fill the height of the filter
input.

Example of indicator in picker filter UI:
![imagee8scm](https://user-images.githubusercontent.com/82110/29324570-2704f84e-81aa-11e7-9ac9-64c0fbb1df58.jpg)

@jcredding ready for review.

