### PR TITLE
more small fixes to the picker and option list dropdown

### DIFF
--- a/assets/js/romo/option_list_dropdown.js
+++ b/assets/js/romo/option_list_dropdown.js
@@ -286,6 +286,11 @@ RomoOptionListDropdown.prototype._bindDropdownOptionFilter = function() {
   }, this));
   this.romoDropdown.elem.on('dropdown:popupClose', $.proxy(function(e, dropdown) {
     this.optionFilterElem.val('');
+    /*
+    don't call `_filterOptionElems()` here.  we need to keep the option markup as is
+    until the popup is opened again so selecting an option works.  selecting an option
+    depends on the selected item elem method which requires the markup to be in place
+    */
   }, this));
   this.romoDropdown.elem.on('dropdown:popupClosedByEsc', $.proxy(function(e, dropdown) {
     this.romoDropdown.elem.focus();
@@ -431,15 +436,15 @@ RomoOptionListDropdown.prototype._onElemKeyDown = function(e) {
       if (e.keyCode === 40 /* Down */  || e.keyCode === 38 /* Up */) {
         this.romoDropdown.doPopupOpen();
         return false;
-      } else if (this.optionFilter !== undefined &&
+      } else if (this.optionFilterElem !== undefined &&
                  Romo.nonInputTextKeyCodes().indexOf(e.keyCode) === -1 /* Input Text */)  {
         if (e.metaKey === false) {
           // don't prevent default on Cmd-* keys (preserve Cmd-R refresh, etc)
           e.preventDefault();
+          this.optionFilterElem.val(e.key);
+          this.romoDropdown.doPopupOpen();
         }
         e.stopPropagation();
-        this.optionFilterElem.val(e.key);
-        this.romoDropdown.doPopupOpen();
         return true;
       } else {
         return true;

--- a/assets/js/romo/picker.js
+++ b/assets/js/romo/picker.js
@@ -54,7 +54,7 @@ RomoPicker.prototype.doSetValue = function(value) {
   $.ajax({
     type:    'GET',
     url:     this.elem.data('romo-picker-url'),
-    data:    { 'value': value },
+    data:    { 'values': value },
     success: $.proxy(function(data, status, xhr) {
       if (data[0] !== undefined) {
         this.doSetSelectedValueAndText(data[0].value, data[0].displayText);
@@ -108,7 +108,11 @@ RomoPicker.prototype._bindOptionListDropdown = function() {
   }, this));
 
   this.romoOptionListDropdown.elem.on('romoOptionListDropdown:filterChange', $.proxy(function(e, filterValue, romoOptionListDropdown) {
-    this.elem.trigger('romoAjax:triggerInvoke', [{ 'filter': filterValue }]);
+    if (filterValue !== '') {
+      this.elem.trigger('romoAjax:triggerInvoke', [{ 'filter': filterValue }]);
+    } else {
+      this._setListItems(this.defaultOptionItems);
+    }
   }, this));
   this.romoOptionListDropdown.elem.on('romoOptionListDropdown:itemSelected', $.proxy(function(e, newValue, prevValue, optionListDropdown) {
     this.romoOptionListDropdown.elem.focus();
@@ -214,15 +218,20 @@ RomoPicker.prototype._bindAjax = function() {
     this.romoOptionListDropdown.elem.trigger('romoOptionListDropdown:triggerFilterIndicatorStart', []);
   }, this));
   this.elem.on('romoAjax:callSuccess', $.proxy(function(e, data, romoAjax) {
-    this.romoOptionListDropdown.doSetListItems(this.defaultOptionItems.concat(data));
+    this._setListItems(data);
     this.romoOptionListDropdown.elem.trigger('romoOptionListDropdown:triggerFilterIndicatorStop', []);
   }, this));
   this.elem.on('romoAjax:callError', $.proxy(function(e, xhr, romoAjax) {
-    this.romoOptionListDropdown.doSetListItems(this.defaultOptionItems);
+    this._setListItems(this.defaultOptionItems);
     this.romoOptionListDropdown.elem.trigger('romoOptionListDropdown:triggerFilterIndicatorStop', []);
   }, this));
 
   this.elem.romoAjax();
+}
+
+RomoPicker.prototype._setListItems = function(items) {
+  this.romoOptionListDropdown.doSetListItems(items);
+  this.romoOptionListDropdown.elem.trigger('romoOptionListDropdown:triggerListOptionsUpdate', [this.romoOptionListDropdown.optItemElems().first()]);
 }
 
 RomoPicker.prototype._buildDefaultOptionItems = function(e) {


### PR DESCRIPTION
This comes from live testing in an app:

* fix a typo in option list dropdown that prevented typing on the
  dropdown elem to open and filter the list
* added a comment to not filter the options on close to protect
  from breaking selecting an option in the picker
* switched the picker 'value' param to 'values'.  this is prep for
  supporting a multi picker as the "value" of the input would be
  a delimeted string of many values.
* switched the picker to reset the list to default values when the
  filter value is an empty string.  this was the originally
  intended behavior but was missed.
* added missing opt list trigger when the picker sets list items.
  this was missed previously and is needed to highlight the first
  item as you are filtering/changing the items in the list.
* don't include the default options (empty val if config'd) when
  setting filtered results.  this matches how the select filters.

![gif](https://user-images.githubusercontent.com/82110/29468654-c17a16e0-840a-11e7-8a7a-7408e0f285d6.gif)

@jcredding ready for review.