### PR TITLE
fix some bugs in the option list dropdown

### DIFF
--- a/assets/css/romo/_mixins.scss
+++ b/assets/css/romo/_mixins.scss
@@ -363,6 +363,7 @@
 @mixin input-option-list-optgroup {
   font-size: $fontSize0;
   line-height: $lineHeight0;
+  padding: 0 $spacingSize0;
 
   background-color: $inputColor;
   color: $inputBgColor;

--- a/assets/css/romo/forms.scss
+++ b/assets/css/romo/forms.scss
@@ -342,11 +342,11 @@
     padding-left: $spacingSize1;
   }
 
-  .romo-input-option-list LI {
+  .romo-input-option-list LI[data-romo-option-list-dropdown-item="opt"] {
     @include input-option-list-option;
   }
 
-  .romo-input-option-list LI[data-romo-option-list-item="optgroup"] {
+  .romo-input-option-list LI[data-romo-option-list-dropdown-item="optgroup"] {
     @include input-option-list-optgroup;
   }
 


### PR DESCRIPTION
All of this should have been caught/fixed in PR 103 but was missed
b/c I didn't do thorough grouped option testing.  This cleans up
how grouped options are handled and also fixes a select prev/next
bug that was previously in select dropdowns.

Cleanups:

* properly style group listings
* fix a method name typo that caused building grouped listings to
  error
* renamed `_getHighlightedItemElem` with "elem" suffix per our
  conventions

I also rewrote the next/prev list item methods b/c there was a
pre-existing bug when you had ungrouped options with grouped ones.
This fixes so you can cycle between grouped and ungrouped.  The
only change/caveat is you can't have nested groups in other groups
so I updated the items "docs" comment to state that.

See #103 for reference.

@jcredding ready for review.