### PR TITLE
add picker option for accepting "custom" values

### DIFF
--- a/assets/js/romo/option_list_dropdown.js
+++ b/assets/js/romo/option_list_dropdown.js
@@ -5,8 +5,10 @@ $.fn.romoOptionListDropdown = function() {
 }
 
 var RomoOptionListDropdown = function(element) {
-  this.elem      = $(element);
-  this.prevValue = '';
+  this.elem = $(element);
+
+  this.prevValue       = '';
+  this.optionListItems = [];
 
   var selCustomization = this.elem.data('romo-option-list-dropdown-item-selector-customization') || '';
   this.itemSelector    = 'LI[data-romo-option-list-dropdown-item="opt"]:not(.disabled)'+selCustomization;
@@ -42,6 +44,10 @@ RomoOptionListDropdown.prototype.selectedItemText = function() {
   // using `data` works the first time but does some elem caching or something
   // so it won't work subsequent times.
   return this.elem.attr('data-romo-option-list-dropdown-selected-text');
+}
+
+RomoOptionListDropdown.prototype.optionFilterValue = function() {
+  return this.optionFilterElem.val();
 }
 
 RomoOptionListDropdown.prototype.optItemElems = function() {
@@ -101,6 +107,7 @@ Example:
 */
 
 RomoOptionListDropdown.prototype.doSetListItems = function(itemsList) {
+  this.optionListItems = itemsList;
   this.optionListContainer.html(this._buildListElem(itemsList));
 
   this._updateOptionsListUI();

--- a/assets/js/romo/select_dropdown.js
+++ b/assets/js/romo/select_dropdown.js
@@ -44,6 +44,10 @@ RomoSelectDropdown.prototype.selectedItemText = function() {
   return this.romoOptionListDropdown.selectedItemText();
 }
 
+RomoSelectDropdown.prototype.optionFilterValue = function() {
+  return this.romoOptionListDropdown.optionFilterValue();
+}
+
 RomoSelectDropdown.prototype.optItemElems = function() {
   return this.romoOptionListDropdown.optItemElems();
 }


### PR DESCRIPTION
And by custom we mean anything typed into the filter input.  With
the option set, as you type in the filter input, the select adds
an option to the end of the list matching what you've typed.  This
is now an option that can be selected.

Note: this option's value also matches what's been typed in the
input.  Anything processing the input value needs to be aware and
handle things appropriately.

Note: I added an `optionListItems` attr to the option list 
dropdown thinking I would need it but ended up not using it on 
this.  I chose to leave it in though b/c it doesn't hurt.  I also
proxied it through the select dropdown so both the picker and the
select can use it if a need comes up.

with prompt:
![gif](https://user-images.githubusercontent.com/82110/29587194-c7d8b3ac-8752-11e7-8b7c-ebcca5fa296b.gif)

without prompt:
![wo-prompt](https://user-images.githubusercontent.com/82110/29587201-d1248cb0-8752-11e7-9a15-5c6035281aee.gif)

@jcredding ready for review.