### PR TITLE
rework how select dropdowns build their option list dropdown items

### DIFF
--- a/assets/js/romo/option_list_dropdown.js
+++ b/assets/js/romo/option_list_dropdown.js
@@ -504,6 +504,11 @@ RomoOptionListDropdown.prototype._nextListItem = function() {
     curr = curr.closest('UL.romo-option-list-optgroup') || curr;
     next = Romo.selectNext(curr, this.itemSelector+', UL.romo-option-list-optgroup');
   }
+  while (next.hasClass('romo-option-list-optgroup') && next.children().size() === 0) {
+    // keep trying until you find a opt group list with options or an option or nothing
+    curr = next;
+    next = Romo.selectNext(curr, this.itemSelector+', UL.romo-option-list-optgroup');
+  }
   if (next.length === 0) {
     // curr is the last opt elem (grouped or not) in the overall
     // list.  get the the first opt elem in the overall list
@@ -534,6 +539,11 @@ RomoOptionListDropdown.prototype._prevListItem = function() {
     // its list as the reference elem.  otherwise keep using the
     // hightlighted opt elem itself.
     curr = curr.closest('UL.romo-option-list-optgroup') || curr;
+    prev = Romo.selectPrev(curr, this.itemSelector+', UL.romo-option-list-optgroup');
+  }
+  while (prev.hasClass('romo-option-list-optgroup') && prev.children().size() === 0) {
+    // keep trying until you find a opt group list with options or an option or nothing
+    curr = prev;
     prev = Romo.selectPrev(curr, this.itemSelector+', UL.romo-option-list-optgroup');
   }
   if (prev.length === 0) {


### PR DESCRIPTION
This switches to doing all operations on the options markup elems
and then rebuilding the option list dropdown items from the
markdown.  This is prep for adding an option for to allow custom
values (like the picker has).  In order to do that feature, I need
selects to rebuild their option list as they are filtered.

The filter is now setup to filter the option elems, not the option
list dropdown item elems.  These option elems are marked with the
hidden class on filter.  The code to rebuild the option list
dropdown items ignores any hidden options.

Note: this means that nothing is using the option list dropdown's
`data-romo-option-list-dropdown-item-selector-customization` attr
anymore.  I chose to keep it in for now in case a need arises in
the future - the feature is still valid if not needed at this
moment.

Note: this also fixes yet another select prev/next bug.  I noticed
this when testing on a select with many groups.  The prev/next
logic would fail if the next/prev list had no options.  This
updates the logic to keep trying next/prev elems until it finds
an optgroup list with options, an option, or nothing.

Grouped example:
![grouped](https://user-images.githubusercontent.com/82110/29596431-c205b634-8782-11e7-8419-9d06c506aabd.gif)

Ungrouped example:
![ungrouped](https://user-images.githubusercontent.com/82110/29596436-c5d94f8c-8782-11e7-8faa-f57eaba3a984.gif)

@jcredding ready for review.