### PR TITLE
update select dropdowns to not render optgroups without child opts

### DIFF
--- a/assets/js/romo/select_dropdown.js
+++ b/assets/js/romo/select_dropdown.js
@@ -147,7 +147,10 @@ RomoSelectDropdown.prototype._buildOptionListItems = function(optionElems) {
     if (optionNode.tagName === "OPTION") {
       list.push(this._buildOptionItem($(optionNode)));
     } else if (optionNode.tagName === "OPTGROUP") {
-      list.push(this._buildOptGroupItem($(optionNode)));
+      var optGroupItem = this._buildOptGroupItem($(optionNode));
+      if (optGroupItem.items.length !== 0) {
+        list.push(optGroupItem);
+      }
     }
   }, this));
 


### PR DESCRIPTION
This keeps things clean when filtering grouped selects.  There is
no need to show a bunch of empty group lists as a user types and
filters down the option list.  This is possible b/c in PR 110 we
switched to re-rendering the list on filter changes.

Note: a side-effect of this is that any groups without options
at all in the markup will also not be displayed.

See #110 for reference.

Example:
![filter-out](https://user-images.githubusercontent.com/82110/29624208-1c697fb4-87ee-11e7-8fe9-ea63e9662e79.gif)

@jcredding ready for review.