### PR TITLE
add select dropdown option for accepting "custom" values

### DIFF
--- a/assets/js/romo/select.js
+++ b/assets/js/romo/select.js
@@ -123,6 +123,12 @@ RomoSelect.prototype._buildSelectDropdownElem = function() {
   if (this.elem.data('romo-select-no-filter') !== undefined) {
     romoSelectDropdownElem.attr('data-romo-select-dropdown-no-filter', this.elem.data('romo-select-no-filter'));
   }
+  if (this.elem.data('romo-select-custom-option') !== undefined) {
+    romoSelectDropdownElem.attr('data-romo-select-dropdown-custom-option', this.elem.data('romo-select-custom-option'));
+  }
+  if (this.elem.data('romo-select-custom-option-prompt') !== undefined) {
+    romoSelectDropdownElem.attr('data-romo-select-dropdown-custom-option-prompt', this.elem.data('romo-select-custom-option-prompt'));
+  }
 
   var classList = this.elem.attr('class') !== undefined ? this.elem.attr('class').split(/\s+/) : [];
   $.each(classList, function(idx, classItem) {

--- a/assets/js/romo/select_dropdown.js
+++ b/assets/js/romo/select_dropdown.js
@@ -136,7 +136,7 @@ RomoSelectDropdown.prototype._bindElem = function() {
 
 RomoSelectDropdown.prototype._setListItems = function() {
   var optElems = this.optionElemsParent.children(this.optionElemSelector);
-  var items    = this._buildOptionListItems(optElems);
+  var items    = this._buildOptionListItems(optElems).concat(this._buildCustomOptionItems());
   this.romoOptionListDropdown.doSetListItems(items);
 }
 
@@ -183,6 +183,35 @@ RomoSelectDropdown.prototype._buildOptGroupItem = function(optGroupElem) {
   item['items'] = this._buildOptionListItems(optGroupElem.children(this.optionElemSelector));
 
   return item;
+}
+
+RomoSelectDropdown.prototype._buildCustomOptionItems = function() {
+  var items = [];
+
+  var value = this.romoOptionListDropdown.optionFilterValue();
+  if (value !== '' && this.elem.data('romo-select-dropdown-custom-option') === true) {
+    var prompt = this.elem.data('romo-select-dropdown-custom-option-prompt');
+    if (prompt !== undefined) {
+      items.push({
+        'type':  'optgroup',
+        'label': prompt,
+        'items': [this._buildCustomOptionItem(value)]
+      });
+    } else {
+      items.push(this._buildCustomOptionItem(value));
+    }
+  }
+
+  return items;
+}
+
+RomoSelectDropdown.prototype._buildCustomOptionItem = function(value) {
+  return {
+    'type':        'option',
+    'value':       value,
+    'displayText': value,
+    'displayHtml': value
+  };
 }
 
 Romo.onInitUI(function(e) {


### PR DESCRIPTION
This is similar to the same effort done for pickers in PR 109. By
"custom" we mean anything typed into the filter input.  With the
option set, as you type in the filter input, the select adds an
option to the end of the list matching what you've typed.  This is
now an option that can be selected.

Note: this option's value also matches what's been typed in the
input.  Anything processing the input value needs to be aware and
handle things appropriately.

Note: I updated the select component to proxy its data attrs to
the select dropdown so selects get the same behavior.

See #109 for reference.

![cust-select-opt](https://user-images.githubusercontent.com/82110/29627754-be08221c-87f8-11e7-9a01-56e637209136.gif)

@jcredding ready for review.