### PR TITLE
add select/picker/option-list-dropdown option to open on focus

### DIFF
--- a/assets/js/romo/option_list_dropdown.js
+++ b/assets/js/romo/option_list_dropdown.js
@@ -13,6 +13,7 @@ var RomoOptionListDropdown = function(element) {
   var selCustomization = this.elem.data('romo-option-list-dropdown-item-selector-customization') || '';
   this.itemSelector    = 'LI[data-romo-option-list-dropdown-item="opt"]:not(.disabled)'+selCustomization;
   this.focusStyleClass = this.elem.data('romo-option-list-focus-style-class');
+  this.openOnFocus     = this.elem.data('romo-option-list-dropdown-open-on-focus');
 
   this.doInit();
   this._bindElem();
@@ -259,6 +260,12 @@ RomoOptionListDropdown.prototype._bindDropdownOptionFilter = function() {
     // remove any manual elem focus when elem is actually focused
     this.optionFilterFocused = false;
     this.romoDropdown.elem.removeClass(this.focusStyleClass);
+
+    if (this.openOnFocus === true) {
+      this.romoDropdown.elem.trigger('dropdown:triggerPopupOpen', []);
+    } else {
+      this.openOnFocus = this.elem.data('romo-option-list-dropdown-open-on-focus');
+    }
   }, this));
   this.romoDropdown.elem.on('blur', $.proxy(function(e) {
     if (this.blurTimeoutId !== undefined) {
@@ -291,6 +298,7 @@ RomoOptionListDropdown.prototype._bindDropdownOptionFilter = function() {
     this.optionFilterElem.trigger('indicatorTextInput:triggerPlaceIndicator');
     this.optionFilterElem.focus();
     this._filterOptionElems();
+    this.openOnFocus = false;
   }, this));
   this.romoDropdown.elem.on('dropdown:popupClose', $.proxy(function(e, dropdown) {
     this.optionFilterElem.val('');

--- a/assets/js/romo/picker.js
+++ b/assets/js/romo/picker.js
@@ -157,6 +157,9 @@ RomoPicker.prototype._buildOptionListDropdownElem = function() {
   if (this.elem.data('romo-picker-no-filter') !== undefined) {
     romoOptionListDropdownElem.attr('data-romo-option-list-dropdown-no-filter', this.elem.data('romo-picker-no-filter'));
   }
+  if (this.elem.data('romo-picker-open-on-focus') !== undefined) {
+    romoOptionListDropdownElem.attr('data-romo-option-list-dropdown-open-on-focus', this.elem.data('romo-picker-open-on-focus'));
+  }
 
   var classList = this.elem.attr('class') !== undefined ? this.elem.attr('class').split(/\s+/) : [];
   $.each(classList, function(idx, classItem) {

--- a/assets/js/romo/select.js
+++ b/assets/js/romo/select.js
@@ -129,6 +129,9 @@ RomoSelect.prototype._buildSelectDropdownElem = function() {
   if (this.elem.data('romo-select-custom-option-prompt') !== undefined) {
     romoSelectDropdownElem.attr('data-romo-select-dropdown-custom-option-prompt', this.elem.data('romo-select-custom-option-prompt'));
   }
+  if (this.elem.data('romo-select-open-on-focus') !== undefined) {
+    romoSelectDropdownElem.attr('data-romo-select-dropdown-open-on-focus', this.elem.data('romo-select-open-on-focus'));
+  }
 
   var classList = this.elem.attr('class') !== undefined ? this.elem.attr('class').split(/\s+/) : [];
   $.each(classList, function(idx, classItem) {

--- a/assets/js/romo/select_dropdown.js
+++ b/assets/js/romo/select_dropdown.js
@@ -80,6 +80,9 @@ RomoSelectDropdown.prototype._bindElem = function() {
   if (this.elem.data('romo-select-dropdown-filter-indicator-width-px') !== undefined) {
     this.elem.attr('data-romo-option-list-dropdown-filter-indicator-width-px', this.elem.data('romo-select-dropdown-filter-indicator-width-px'));
   }
+  if (this.elem.data('romo-select-dropdown-open-on-focus') !== undefined) {
+    this.elem.attr('data-romo-option-list-dropdown-open-on-focus', this.elem.data('romo-select-dropdown-open-on-focus'));
+  }
 
   this.elem.on('romoOptionListDropdown:dropdown:toggle', $.proxy(function(e, dropdown) {
     this.elem.trigger('selectDropdown:dropdown:toggle', [dropdown, this]);


### PR DESCRIPTION
This option will open the popup and focus the filter input when
the dropdown elem is focused.  This is a UX convenience that can
optionally be turned on.  It is particularly helpful for single
input forms that submit on input change.  No need to make the user
click to launch the form then click to open the popup then start
typing, etc.

The data attr and logic live on the option list dropdown: the
select dropdown, select, and picker components proxy the option
so all of these components get the same behavior.

Select:
![open](https://user-images.githubusercontent.com/82110/29629666-4c06b708-87ff-11e7-9759-23bdf59ff247.gif)

Picker:
![picker-open](https://user-images.githubusercontent.com/82110/29629672-50b3c750-87ff-11e7-92f4-9915578f2bd0.gif)

@jcredding ready for review.