### PR TITLE
update datepicker, select, and picker "itemSelected" events

### DIFF
--- a/assets/js/romo/datepicker.js
+++ b/assets/js/romo/datepicker.js
@@ -178,7 +178,11 @@ RomoDatepicker.prototype.doSelectHighlightedItem = function() {
   this.romoDropdown.doPopupClose();
   this.doSetDate(newValue);
   this.elem.focus();
-  this.elem.trigger('datepicker:itemSelected', [newValue, this.prevValue, this]);
+  this.elem.trigger('datepicker:itemSelected', [newValue, this]);
+  if (newValue !== this.prevValue) {
+    this.elem.trigger('datepicker:newItemSelected', [newValue, this]);
+  }
+  // always publish the item selected events before publishing any change events
   this._triggerSetDateChangeEvent();
 }
 

--- a/assets/js/romo/option_list_dropdown.js
+++ b/assets/js/romo/option_list_dropdown.js
@@ -354,12 +354,15 @@ RomoOptionListDropdown.prototype._selectHighlightedItem = function() {
   if (curr.length !== 0) {
     var prevValue = this.prevValue;
     var newValue  = curr.data('romo-option-list-dropdown-option-value');
+    var newText   = curr.data('romo-option-list-dropdown-option-display-text');
 
     this.romoDropdown.doPopupClose();
-    this.elem.trigger('romoOptionListDropdown:itemSelected', [newValue, prevValue, this]);
 
+    this.elem.trigger('romoOptionListDropdown:itemSelected', [newValue, newText, this]);
     if (newValue !== prevValue) {
       this.doSetNewValue(newValue);
+      // always publish the item selected events before publishing any change events
+      this.elem.trigger('romoOptionListDropdown:newItemSelected', [newValue, newText, this]);
       this.elem.trigger('romoOptionListDropdown:change', [newValue, prevValue, this]);
     }
   }

--- a/assets/js/romo/picker.js
+++ b/assets/js/romo/picker.js
@@ -119,9 +119,12 @@ RomoPicker.prototype._bindOptionListDropdown = function() {
       this._setListItems(this.defaultOptionItems.concat(this._buildCustomOptionItems()));
     }
   }, this));
-  this.romoOptionListDropdown.elem.on('romoOptionListDropdown:itemSelected', $.proxy(function(e, newValue, prevValue, optionListDropdown) {
+  this.romoOptionListDropdown.elem.on('romoOptionListDropdown:itemSelected', $.proxy(function(e, itemValue, itemDisplayText, optionListDropdown) {
     this.romoOptionListDropdown.elem.focus();
-    this.elem.trigger('romoPicker:itemSelected', [newValue, prevValue, this]);
+    this.elem.trigger('romoPicker:itemSelected', [itemValue, itemDisplayText, this]);
+  }, this));
+  this.romoOptionListDropdown.elem.on('romoOptionListDropdown:newItemSelected', $.proxy(function(e, itemValue, itemDisplayText, optionListDropdown) {
+    this.elem.trigger('romoPicker:newItemSelected', [itemValue, itemDisplayText, this]);
   }, this));
   this.romoOptionListDropdown.elem.on('romoOptionListDropdown:change', $.proxy(function(e, newValue, prevValue, optionListDropdown) {
     this._setNewValue(newValue);

--- a/assets/js/romo/select.js
+++ b/assets/js/romo/select.js
@@ -87,9 +87,12 @@ RomoSelect.prototype._bindSelectDropdown = function() {
     this.elem.trigger('select:dropdown:popupClose', [dropdown, this]);
   }, this));
 
-  this.romoSelectDropdown.elem.on('selectDropdown:itemSelected', $.proxy(function(e, newValue, prevValue, selectDropdown) {
+  this.romoSelectDropdown.elem.on('selectDropdown:itemSelected', $.proxy(function(e, itemValue, itemDisplayText, selectDropdown) {
     this.romoSelectDropdown.elem.focus();
-    this.elem.trigger('select:itemSelected', [newValue, prevValue, this]);
+    this.elem.trigger('select:itemSelected', [itemValue, itemDisplayText, this]);
+  }, this));
+  this.romoSelectDropdown.elem.on('selectDropdown:newItemSelected', $.proxy(function(e, itemValue, itemDisplayText, selectDropdown) {
+    this.elem.trigger('select:newItemSelected', [itemValue, itemDisplayText, this]);
   }, this));
   this.romoSelectDropdown.elem.on('selectDropdown:change', $.proxy(function(e, newValue, prevValue, selectDropdown) {
     this._setNewValue(newValue);

--- a/assets/js/romo/select_dropdown.js
+++ b/assets/js/romo/select_dropdown.js
@@ -93,8 +93,11 @@ RomoSelectDropdown.prototype._bindElem = function() {
   this.elem.on('romoOptionListDropdown:dropdown:popupClose', $.proxy(function(e, dropdown) {
     this.elem.trigger('selectDropdown:dropdown:popupClose', [dropdown, this]);
   }, this));
-  this.elem.on('romoOptionListDropdown:itemSelected', $.proxy(function(e, newValue, prevValue, romoOptionListDropdown) {
-    this.elem.trigger('selectDropdown:itemSelected', [newValue, prevValue, this]);
+  this.elem.on('romoOptionListDropdown:itemSelected', $.proxy(function(e, itemValue, itemDisplayText, romoOptionListDropdown) {
+    this.elem.trigger('selectDropdown:itemSelected', [itemValue, itemDisplayText, this]);
+  }, this));
+  this.elem.on('romoOptionListDropdown:newItemSelected', $.proxy(function(e, itemValue, itemDisplayText, romoOptionListDropdown) {
+    this.elem.trigger('selectDropdown:newItemSelected', [itemValue, itemDisplayText, this]);
   }, this));
   this.elem.on('romoOptionListDropdown:change', $.proxy(function(e, newValue, prevValue, romoOptionListDropdown) {
     this.elem.trigger('selectDropdown:change', [newValue, prevValue, this]);


### PR DESCRIPTION
These events should never have been publishing the new/prev values
in their payloads - that is what the "change" event is for.  Also,
the previously didn't distinguish from any item being selected vs
just a new item being selected.

This updates the event payloads to just include the selected item
value.  This also adds publishing a second "newItemSelected" event
that only fires when a not previously selected item is selected.
Note: for the selects/pickers, the payload also includes the item
display text.

This is prep for reworking the selects and pickers to get them
ready for multi usage.  I chose to go ahead and update the
datepicker to keep it consistent with the select/picker.

Note: this also adds a helper comment to the opt list dropdown and
datepicker noting that the item selected events should always be
published before the change events.  This is by design and is
relied upon by other components so this reminds us not to change
the event firing order.  This order will also be needed when we
add the multi select/picker logic.

@jcredding ready for review.