### PR TITLE
update the picker to store its own display text; update refresh ui

### DIFF
--- a/assets/js/romo/option_list_dropdown.js
+++ b/assets/js/romo/option_list_dropdown.js
@@ -63,24 +63,24 @@ RomoOptionListDropdown.prototype.doInit = function() {
   // override as needed
 }
 
-RomoOptionListDropdown.prototype.doSetNewValue = function(newValue) {
+RomoOptionListDropdown.prototype.doSetSelectedItem = function(itemValue) {
   this.selectedItemElem().removeClass('selected');
   this.romoDropdown.bodyElem.find(
-    'LI[data-romo-option-list-dropdown-option-value="'+newValue+'"]'
+    'LI[data-romo-option-list-dropdown-option-value="'+itemValue+'"]'
   ).addClass('selected');
   this.doSetSelectedValueAndText(
-    newValue,
+    this.selectedItemElem().data('romo-option-list-dropdown-option-value'),
     this.selectedItemElem().data('romo-option-list-dropdown-option-display-text')
   );
 }
 
-RomoOptionListDropdown.prototype.doSetSelectedValueAndText = function(newValue, newText) {
+RomoOptionListDropdown.prototype.doSetSelectedValueAndText = function(value, text) {
   // need to use `attr` to persist selected values to the DOM for back button logic
   // to work.  using `data` won't persist changes to DOM and breaks back button logic.
-  this.elem.attr('data-romo-option-list-dropdown-selected-value', newValue);
-  this.elem.attr('data-romo-option-list-dropdown-selected-text',  newText);
+  this.elem.attr('data-romo-option-list-dropdown-selected-value', value);
+  this.elem.attr('data-romo-option-list-dropdown-selected-text',  text);
 
-  this.prevValue = newValue;
+  this.prevValue = value;
 }
 
 /*
@@ -360,7 +360,7 @@ RomoOptionListDropdown.prototype._selectHighlightedItem = function() {
 
     this.elem.trigger('romoOptionListDropdown:itemSelected', [newValue, newText, this]);
     if (newValue !== prevValue) {
-      this.doSetNewValue(newValue);
+      this.doSetSelectedItem(newValue);
       // always publish the item selected events before publishing any change events
       this.elem.trigger('romoOptionListDropdown:newItemSelected', [newValue, newText, this]);
       this.elem.trigger('romoOptionListDropdown:change', [newValue, prevValue, this]);

--- a/assets/js/romo/select.js
+++ b/assets/js/romo/select.js
@@ -48,7 +48,7 @@ RomoSelect.prototype.doRefreshUI = function() {
 }
 
 RomoSelect.prototype.doSetValue = function(value) {
-  this.romoSelectDropdown.doSetNewValue(value);
+  this.romoSelectDropdown.doSetSelectedItem(value);
   this._setNewValue(value);
 }
 

--- a/assets/js/romo/select_dropdown.js
+++ b/assets/js/romo/select_dropdown.js
@@ -59,8 +59,8 @@ RomoSelectDropdown.prototype.doInit = function() {
   // override as needed
 }
 
-RomoSelectDropdown.prototype.doSetNewValue = function(newValue) {
-  this.romoOptionListDropdown.doSetNewValue(newValue);
+RomoSelectDropdown.prototype.doSetSelectedItem = function(newValue) {
+  this.romoOptionListDropdown.doSetSelectedItem(newValue);
 }
 
 /* private */


### PR DESCRIPTION
This is prep for adding a multi picker.  For the multi, it needs
to refresh many selected values.  The hidden input will know the
values and the order to display them in.  However, we can't rely
on the opt list dropdown for the display text b/c it can only
track a single value/text.  This switches to storing our own
display text so it can be expanded for multi in a future effort.

Like the opt list dropdown, we persist the display text to the
DOM so changes are preserved when using the back button.  The
picker now looks to this display text when refreshing the UI.

There were a few other loosley related cleanups here too:

* I made the `_refreshUI` method private b/c there is no need
  to call it publicly
* I changed the `_setValue` method to `_setValueAndText`.  We
  don't need to set them separately and I want their logic jux'd.
  I also moved the refresh UI out of the function b/c I felt it
  does more than the method name implies.
* I reworked the "doSet*" methods on the opt list dropdown.  The
  value and text one too "new" params but that distinction isn't
  necessarily true or even needed.  I renamed the set value method
  also b/c the "new" distinction doesn't matter and may not be
  true.  The new name is more accurate about what the method does.

Note: in a future effort, I'll make similar changes to the select
js.  However, it will still have its `_setValue` method b/c you
don't need to set the text - you can look it up from the option
markup if you know the option value.

@jcredding ready for review.