### PR TITLE
update select js refresh ui logic to match the picker js

### DIFF
--- a/assets/js/romo/picker.js
+++ b/assets/js/romo/picker.js
@@ -45,15 +45,15 @@ RomoPicker.prototype.doSetValue = function(value) {
     data:    { 'values': value },
     success: $.proxy(function(data, status, xhr) {
       if (data[0] !== undefined) {
-        this.doSetSelectedValueAndText(data[0].value, data[0].displayText);
+        this.doSetValueAndText(data[0].value, data[0].displayText);
       } else {
-        this.doSetSelectedValueAndText('', '');
+        this.doSetValueAndText('', '');
       }
     }, this),
   });
 }
 
-RomoPicker.prototype.doSetSelectedValueAndText = function(value, text) {
+RomoPicker.prototype.doSetValueAndText = function(value, text) {
   this.romoOptionListDropdown.doSetSelectedValueAndText(value, text);
   this._setValueAndText(value, text);
   this._refreshUI();

--- a/assets/js/romo/select.js
+++ b/assets/js/romo/select.js
@@ -13,7 +13,6 @@ var RomoSelect = function(element) {
 
   this.doInit();
   this._bindElem();
-  this.doRefreshUI();
 
   if (this.elem.attr('id') !== undefined) {
     $('label[for="'+this.elem.attr('id')+'"]').on('click', $.proxy(function(e) {
@@ -22,10 +21,7 @@ var RomoSelect = function(element) {
   }
 
   $(window).on("pageshow", $.proxy(function(e) {
-    var selectedVal = this.romoSelectDropdown.selectedItemValue();
-    if (selectedVal !== this.elem[0].value) {
-      this.doSetValue(selectedVal);
-    }
+    this._refreshUI();
   }, this));
 
   this.elem.on('select:triggerSetValue', $.proxy(function(e, value) {
@@ -39,17 +35,10 @@ RomoSelect.prototype.doInit = function() {
   // override as needed
 }
 
-RomoSelect.prototype.doRefreshUI = function() {
-  var text = this.romoSelectDropdown.selectedItemText();
-  if (text === '') {
-    text = '&nbsp;'
-  }
-  this.romoSelectDropdown.elem.find('.romo-select-text').html(text);
-}
-
 RomoSelect.prototype.doSetValue = function(value) {
   this.romoSelectDropdown.doSetSelectedItem(value);
-  this._setNewValue(value);
+  this._setValue(value);
+  this._refreshUI();
 }
 
 /* private */
@@ -92,10 +81,11 @@ RomoSelect.prototype._bindSelectDropdown = function() {
     this.elem.trigger('select:itemSelected', [itemValue, itemDisplayText, this]);
   }, this));
   this.romoSelectDropdown.elem.on('selectDropdown:newItemSelected', $.proxy(function(e, itemValue, itemDisplayText, selectDropdown) {
+    this._setValue(itemValue);
+    this._refreshUI();
     this.elem.trigger('select:newItemSelected', [itemValue, itemDisplayText, this]);
   }, this));
   this.romoSelectDropdown.elem.on('selectDropdown:change', $.proxy(function(e, newValue, prevValue, selectDropdown) {
-    this._setNewValue(newValue);
     this.elem.trigger('change');
     this.elem.trigger('select:change', [newValue, prevValue, this]);
   }, this));
@@ -199,9 +189,17 @@ RomoSelect.prototype._onCaretClick = function(e) {
   }
 }
 
-RomoSelect.prototype._setNewValue = function(newValue) {
+RomoSelect.prototype._setValue = function(newValue) {
   this.elem[0].value = newValue;
-  this.doRefreshUI();
+  this._refreshUI();
+}
+
+RomoSelect.prototype._refreshUI = function() {
+  var text = this.romoSelectDropdown.selectedItemText();
+  if (text === '') {
+    text = '&nbsp;'
+  }
+  this.romoSelectDropdown.elem.find('.romo-select-text').html(text);
 }
 
 RomoSelect.prototype._getCaretPaddingPx = function() {


### PR DESCRIPTION
This is all prep for adding multi select/picker support.  This
is really just to keep the picker/select implementaions as
similar as possible.  Like in PR 115:

* I made the `_refreshUI` method private b/c there is no need
  to call it publicly
* I moved the refresh UI logic out of the `_setValue` method b/c I
  felt it does more than the method name implies.

I also renamed the picker's `doSetSelectedValueAndText` method to
remove "Selected" from the name.  This method is more accurate
about what it does and is more consistent with the `doSetValue`
method above and the `doSetValue` method on selects.

@jcredding ready for review.