### PR TITLE
update selects to change their option DOM to set values

### DIFF
--- a/assets/js/romo/picker.js
+++ b/assets/js/romo/picker.js
@@ -279,13 +279,6 @@ RomoPicker.prototype._buildCustomOptionItem = function(value) {
   };
 }
 
-RomoPicker.prototype._onCaretClick = function(e) {
-  if (this.elem.prop('disabled') === false) {
-    this.romoOptionListDropdown.elem.focus();
-    this.elem.trigger('romoPicker:triggerPopupOpen');
-  }
-}
-
 RomoPicker.prototype._setValueAndText = function(value, text) {
   this.elem[0].value = value;
 
@@ -305,6 +298,13 @@ RomoPicker.prototype._refreshUI = function() {
     text = '&nbsp;'
   }
   this.romoOptionListDropdown.elem.find('.romo-picker-text').html(text);
+}
+
+RomoPicker.prototype._onCaretClick = function(e) {
+  if (this.elem.prop('disabled') === false) {
+    this.romoOptionListDropdown.elem.focus();
+    this.elem.trigger('romoPicker:triggerPopupOpen');
+  }
 }
 
 RomoPicker.prototype._getCaretPaddingPx = function() {

--- a/assets/js/romo/select.js
+++ b/assets/js/romo/select.js
@@ -182,24 +182,29 @@ RomoSelect.prototype._buildSelectDropdownElem = function() {
   return romoSelectDropdownElem;
 }
 
+RomoSelect.prototype._setValue = function(value) {
+  var prevOptElem = this.elem.find('OPTION[value="'+this.elem[0].value+'"]');
+  var newOptElem  = this.elem.find('OPTION[value="'+value+'"]');
+
+  prevOptElem.removeAttr('selected');
+  prevOptElem.prop('selected', false);
+  newOptElem.attr('selected', 'selected');
+  newOptElem.prop('selected', true);
+}
+
+RomoSelect.prototype._refreshUI = function() {
+  var text = this.elem.find('OPTION[selected="selected"]').text().trim();
+  if (text === '') {
+    text = '&nbsp;'
+  }
+  this.romoSelectDropdown.elem.find('.romo-select-text').html(text);
+}
+
 RomoSelect.prototype._onCaretClick = function(e) {
   if (this.elem.prop('disabled') === false) {
     this.romoSelectDropdown.elem.focus();
     this.elem.trigger('select:triggerPopupOpen');
   }
-}
-
-RomoSelect.prototype._setValue = function(newValue) {
-  this.elem[0].value = newValue;
-  this._refreshUI();
-}
-
-RomoSelect.prototype._refreshUI = function() {
-  var text = this.romoSelectDropdown.selectedItemText();
-  if (text === '') {
-    text = '&nbsp;'
-  }
-  this.romoSelectDropdown.elem.find('.romo-select-text').html(text);
 }
 
 RomoSelect.prototype._getCaretPaddingPx = function() {


### PR DESCRIPTION
This not only helps the selects render properly when the back
button is used, it is also a more robust way of setting the value
when there are multiple options to select.  This is prep for
adding multi-select support in a future effort.

Note: I had to use both `attr`/`removeAttr` and `prop`.  The attr
methods change the DOM - the prop method changes the value of the
select.  I would have just used the prop method but I wanted to
change the DOM for back button support.

Note: I also moved the `_onCaretClick` function in both the
picker and select - this was just to jux it next to the other
caret methods and should have been done previously.

Note: I removed calling `_refreshUI` from the `_setValue` method
in the select js.  This should have been done in PR 116 but was
missed and resulted in `_refreshUI` being called multiple times
in succession.

@jcredding ready for review.