### PR TITLE
update select dropdown to sanitize its options

### DIFF
--- a/assets/js/romo/select_dropdown.js
+++ b/assets/js/romo/select_dropdown.js
@@ -136,8 +136,21 @@ RomoSelectDropdown.prototype._bindElem = function() {
     }
   }, this));
 
+  this._sanitizeOptions();
   this._setListItems();
   this.elem.trigger('romoOptionListDropdown:triggerListOptionsUpdate', [this.selectedItemElem()]);
+}
+
+RomoSelectDropdown.prototype._sanitizeOptions = function() {
+  // set any options without a value to value=""
+  // all options are required to have a value for things to work
+  // this and the select component assume value attrs for all options
+  $.each(this.optionElemsParent.find('OPTION'), $.proxy(function(idx, optionNode) {
+    var optElem = $(optionNode);
+    if (optElem.attr('value') === undefined) {
+      optElem.attr('value', '');
+    }
+  }, this));
 }
 
 RomoSelectDropdown.prototype._setListItems = function() {


### PR DESCRIPTION
Specifically this updates any options without a value to have an
explicit `value=""`.  The seclect and select dropdown both expect
all options to have a value.  This enforces it.

This is particularly helpful b/c we sometimes define the "default"
or "empty" option without a value b/c the "" is implied.  This
keeps things from breaking when we forget the `value=""`.

@jcredding ready for review. 