### PR TITLE
fix preset value handling in picker/select

### DIFF
--- a/assets/js/romo/picker.js
+++ b/assets/js/romo/picker.js
@@ -17,6 +17,15 @@ var RomoPicker = function(element) {
   this.doInit();
   this._bindElem();
 
+  var presetVal = this.elem[0].value;
+  if (presetVal !== '') {
+    this.doSetValue(presetVal);
+  } else if (this.elem.data('romo-picker-empty-option') === true) {
+    this.doSetValueAndText('', this.elem.data('romo-picker-empty-option-display-text') || '');
+  } else {
+    this.doSetValueAndText('', '');
+  }
+
   if (this.elem.attr('id') !== undefined) {
     $('label[for="'+this.elem.attr('id')+'"]').on('click', $.proxy(function(e) {
       this.romoOptionListDropdown.elem.focus();
@@ -46,6 +55,8 @@ RomoPicker.prototype.doSetValue = function(value) {
     success: $.proxy(function(data, status, xhr) {
       if (data[0] !== undefined) {
         this.doSetValueAndText(data[0].value, data[0].displayText);
+      } else  if (this.elem.data('romo-picker-empty-option') === true) {
+        this.doSetValueAndText('', this.elem.data('romo-picker-empty-option-display-text') || '');
       } else {
         this.doSetValueAndText('', '');
       }
@@ -76,11 +87,6 @@ RomoPicker.prototype._bindElem = function() {
   }, this));
 
   this.romoOptionListDropdown.doSetListItems(this.defaultOptionItems);
-
-  var presetVal = this.elem[0].value;
-  if (presetVal !== '') {
-    this.doSetValue(presetVal);
-  }
 }
 
 RomoPicker.prototype._bindOptionListDropdown = function() {
@@ -242,7 +248,7 @@ RomoPicker.prototype._buildDefaultOptionItems = function() {
     items.push({
       'type':        'option',
       'value':       '',
-      'displayText': '',
+      'displayText': (this.elem.data('romo-picker-empty-option-display-text') || ''),
       'displayHtml': '&nbsp;'
     });
   }

--- a/assets/js/romo/select.js
+++ b/assets/js/romo/select.js
@@ -14,6 +14,8 @@ var RomoSelect = function(element) {
   this.doInit();
   this._bindElem();
 
+  this.doSetValue(this.elem[0].value);
+
   if (this.elem.attr('id') !== undefined) {
     $('label[for="'+this.elem.attr('id')+'"]').on('click', $.proxy(function(e) {
       this.romoSelectDropdown.elem.focus();
@@ -55,12 +57,6 @@ RomoSelect.prototype._bindElem = function() {
   this.elem.on('select:triggerPopupClose', $.proxy(function(e) {
     this.romoSelectDropdown.elem.trigger('selectDropdown:triggerPopupClose', []);
   }, this));
-
-
-  var presetVal = this.elem[0].value;
-  if (presetVal !== '') {
-    this.doSetValue(presetVal);
-  }
 }
 
 RomoSelect.prototype._bindSelectDropdown = function() {


### PR DESCRIPTION
This switches to more robustly handling preset values in both
the select and picker.

This fixes a bug in the selects where an "empty option" with
non-empty display text wouldn't show up if the select had no
value.  We weren't setting the empty value if the value was empty.
This changes to always setting the value on init, even if it is
empty.

This also updates the picker to match setting its preset value
on init.  However, pickers have to handle their "empty options"
differently as there aren't options in the DOM for pickers.
Instead, if the preset value is empty, we look for the empty
option setting and use a new empty option display text setting if
available.  Otherwise we just set empty value/text.  The
`doSetValue` ajax success callback is updated similarly.  Finally
we use this new empty option display text setting when building
the empty option.

Overall, this gets selects and pickers both setting their preset
values (empty or not) consistently and also provides a way for
pickers to have empty options with custom display text like
selects do.

@jcredding ready for review.