### PR TITLE
fix custom options on selects: add custom option markup

### DIFF
--- a/assets/js/romo/select_dropdown.js
+++ b/assets/js/romo/select_dropdown.js
@@ -97,6 +97,19 @@ RomoSelectDropdown.prototype._bindElem = function() {
     this.elem.trigger('selectDropdown:itemSelected', [itemValue, itemDisplayText, this]);
   }, this));
   this.elem.on('romoOptionListDropdown:newItemSelected', $.proxy(function(e, itemValue, itemDisplayText, romoOptionListDropdown) {
+    var custOptElem = this.optionElemsParent.find('OPTION[data-romo-select-dropdown-custom-option="true"]');
+    if (this.optionElemsParent.find('OPTION[value="'+itemValue+'"]').length === 0){
+      // a custom value is being selected. add a custom option elem and update its value/text
+      if (custOptElem.length === 0) {
+        this.optionElemsParent.append('<option data-romo-select-dropdown-custom-option="true"></option>');
+        custOptElem = this.optionElemsParent.find('OPTION[data-romo-select-dropdown-custom-option="true"]');
+      }
+      custOptElem.attr('value', itemValue);
+      custOptElem.text(itemDisplayText);
+    } else if (custOptElem.length !== 0) {
+      // a non custom value is being selected. remove any existing custom option
+      custOptElem.remove();
+    }
     this.elem.trigger('selectDropdown:newItemSelected', [itemValue, itemDisplayText, this]);
   }, this));
   this.elem.on('romoOptionListDropdown:change', $.proxy(function(e, newValue, prevValue, romoOptionListDropdown) {
@@ -117,7 +130,7 @@ RomoSelectDropdown.prototype._bindElem = function() {
   this.romoOptionListDropdown = this.elem.romoOptionListDropdown()[0];
 
   this.elem.on('romoOptionListDropdown:filterChange', $.proxy(function(e, filterValue, romoOptionListDropdown) {
-    var elems    = this.optionElemsParent.find('option');
+    var elems    = this.optionElemsParent.find('OPTION');
     var wbFilter = new RomoWordBoundaryFilter(filterValue, elems, function(elem) {
       // The romo word boundary filter by default considers a space, "-" and "_"
       // as word boundaries.  We want to also consider other non-word characters


### PR DESCRIPTION
This allows selects to actually set a custom value.  Before the
dropdown would say a value was selected that there was no option
for so the value wouldn't take.  This updates the select
dropdown to actually create a custom option with the correct
value/text so it can be set as the selects value.

If a different custom option is subsequently chosen, the first
custom option is overridden.  If a non cusotm option is selected,
any custom option is removed as it is no longer needed.

![gif](https://user-images.githubusercontent.com/82110/29729274-277b86e0-89a1-11e7-9067-5e2cf5f33b4c.gif)

@jcredding ready for review.