### PR TITLE
add SelectedOptionsList js component; design picker/select interactions

### DIFF
--- a/assets/js/romo/option_list_dropdown.js
+++ b/assets/js/romo/option_list_dropdown.js
@@ -68,10 +68,12 @@ RomoOptionListDropdown.prototype.doSetSelectedItem = function(itemValue) {
   this.romoDropdown.bodyElem.find(
     'LI[data-romo-option-list-dropdown-option-value="'+itemValue+'"]'
   ).addClass('selected');
+  // TODO: if selectedItemElem
   this.doSetSelectedValueAndText(
     this.selectedItemElem().data('romo-option-list-dropdown-option-value'),
     this.selectedItemElem().data('romo-option-list-dropdown-option-display-text')
   );
+  // TODO: else set '', ''
 }
 
 RomoOptionListDropdown.prototype.doSetSelectedValueAndText = function(value, text) {

--- a/assets/js/romo/picker.js
+++ b/assets/js/romo/picker.js
@@ -54,6 +54,7 @@ RomoPicker.prototype.doSetValue = function(value) {
     data:    { 'values': value },
     success: $.proxy(function(data, status, xhr) {
       if (data[0] !== undefined) {
+        // TODO: this.doSetValueAndText(data);
         this.doSetValueAndText(data[0].value, data[0].displayText);
       } else  if (this.elem.data('romo-picker-empty-option') === true) {
         this.doSetValueAndText('', this.elem.data('romo-picker-empty-option-display-text') || '');
@@ -65,8 +66,30 @@ RomoPicker.prototype.doSetValue = function(value) {
 }
 
 RomoPicker.prototype.doSetValueAndText = function(value, text) {
+  // TODO: support multi
+  // if value is an Array
+  //   assume list of items (value and displayText keys)
+  //   if sel opt list
+  //     `doSetListItems(value)`
+  //     set opt list dropdown to '', ''
+  //     set delim-sep-values, ''
+  //   else
+  //     set opt list dropdown to data[0].value, data[0].displayText
+  //     set data[0].value, data[0].displayText
+  //   end
+  // else
+  //   if sel opt list
+  //     `doSetListItems([{value, text}])`
+  //     set opt list dropdown to '', ''
+  //     set value, ''
+  //   else
+  //     set opt list dropdown to value, text
+  //     set value, text
+  //   end
+  // end
   this.romoOptionListDropdown.doSetSelectedValueAndText(value, text);
   this._setValueAndText(value, text);
+
   this._refreshUI();
 }
 
@@ -114,11 +137,20 @@ RomoPicker.prototype._bindOptionListDropdown = function() {
     }
   }, this));
   this.romoOptionListDropdown.elem.on('romoOptionListDropdown:itemSelected', $.proxy(function(e, itemValue, itemDisplayText, optionListDropdown) {
+    // TODO: if sel opt list, do nothing
     this.romoOptionListDropdown.elem.focus();
     this.elem.trigger('romoPicker:itemSelected', [itemValue, itemDisplayText, this]);
   }, this));
   this.romoOptionListDropdown.elem.on('romoOptionListDropdown:newItemSelected', $.proxy(function(e, itemValue, itemDisplayText, optionListDropdown) {
+    // TODO: support multi
+    // if sel opt list
+    //   `doAddListItem({value, text})`
+    //   set append-delim-sep-values, ''
+    // else
+    //   set value, text
+    // end
     this._setValueAndText(itemValue, itemDisplayText);
+
     this._refreshUI();
     this.elem.trigger('romoPicker:newItemSelected', [itemValue, itemDisplayText, this]);
   }, this));
@@ -304,6 +336,7 @@ RomoPicker.prototype._refreshUI = function() {
     text = '&nbsp;'
   }
   this.romoOptionListDropdown.elem.find('.romo-picker-text').html(text);
+  // TODO: if sel opt list, `doRefreshUI`
 }
 
 RomoPicker.prototype._onCaretClick = function(e) {

--- a/assets/js/romo/select.js
+++ b/assets/js/romo/select.js
@@ -38,8 +38,30 @@ RomoSelect.prototype.doInit = function() {
 }
 
 RomoSelect.prototype.doSetValue = function(value) {
+  // TODO: support multi
+  // if value is an Array
+  //   assume list of values
+  //   if sel opt list
+  //     `doSetListItems(value-text-items)`  // build items from values/options
+  //     set select dropdown to ''
+  //     set value
+  //   else
+  //     set select dropdown to data[0].value, data[0].displayText
+  //     set data[0].value
+  //   end
+  // else
+  //   if sel opt list
+  //     `doSetListItems([{value, text}])`   // lookup text from options
+  //     set select dropdown to ''
+  //     set value
+  //   else
+  //     set select dropdown to value, text
+  //     set value
+  //   end
+  // end
   this.romoSelectDropdown.doSetSelectedItem(value);
   this._setValue(value);
+
   this._refreshUI();
 }
 
@@ -73,11 +95,20 @@ RomoSelect.prototype._bindSelectDropdown = function() {
   }, this));
 
   this.romoSelectDropdown.elem.on('selectDropdown:itemSelected', $.proxy(function(e, itemValue, itemDisplayText, selectDropdown) {
+    // TODO: if sel opt list, do nothing
     this.romoSelectDropdown.elem.focus();
     this.elem.trigger('select:itemSelected', [itemValue, itemDisplayText, this]);
   }, this));
   this.romoSelectDropdown.elem.on('selectDropdown:newItemSelected', $.proxy(function(e, itemValue, itemDisplayText, selectDropdown) {
+    // TODO: support multi
+    // if sel opt list
+    //   `doAddListItem({value, text})`
+    //   set append-values
+    // else
+    //   set value
+    // end
     this._setValue(itemValue);
+
     this._refreshUI();
     this.elem.trigger('select:newItemSelected', [itemValue, itemDisplayText, this]);
   }, this));
@@ -179,6 +210,9 @@ RomoSelect.prototype._buildSelectDropdownElem = function() {
 }
 
 RomoSelect.prototype._setValue = function(value) {
+  // TODO: support multi
+  // where given value is an array
+  // and wehre elme[0].value is an array
   var prevOptElem = this.elem.find('OPTION[value="'+this.elem[0].value+'"]');
   var newOptElem  = this.elem.find('OPTION[value="'+value+'"]');
 

--- a/assets/js/romo/selected_options_list.js
+++ b/assets/js/romo/selected_options_list.js
@@ -1,0 +1,185 @@
+var RomoSelectedOptionsList = function(focusElem) {
+  this.elem      = undefined;
+  this.focusElem = focusElem; // picker/select dropdown elem
+
+  this.items                  = [];
+  this.focusStyleClass        = this.elem.data('romo-option-list-focus-style-class');
+  this.defaultRmIconClass     = undefined;
+  this.defaultRmIconPaddingPx = 5;
+  this.defaultRmIconPosition  = 'right'
+  this.focusBlurTimeoutId     = undefined;
+
+  this.doInit();
+  this._bindElem();
+}
+
+RomoSelectedOptionsList.prototype.doInit = function() {
+  // override as needed
+}
+
+/*
+Options are specified as a list of items.  Each 'option' item object
+has display text and a value. They are compatible with the option list
+dropdown option items.
+
+Example:
+[ { 'type': 'option', 'value': 'a', 'displayText': 'A' },
+  { 'type': 'option', 'value': 'b', 'displayText': 'B' },
+  { 'type': 'option', 'value': 'c', 'displayText': 'C' }
+]
+*/
+
+RomoSelectedOptionsList.prototype.doSetItems = function(itemsList) {
+  this.items = itemsList;
+  this.doRefreshUI();
+}
+
+RomoSelectedOptionsList.prototype.doClearItems = function() {
+  this.items = [];
+  this.doRefreshUI();
+}
+
+RomoSelectedOptionsList.prototype.doAddItem = function(item) {
+  if (!this._getItemValues().includes(item.value)) {
+    this.items.push(item);
+    this.doRefreshUI();
+  }
+}
+
+RomoSelectedOptionsList.prototype.doRemoveItem = function(itemValue) {
+  var index = this._getItemValues().indexOf(itemValue);
+  if (index > -1) {
+    this.items.splice(index, 1);
+    this.doRefreshUI();
+  }
+}
+
+RomoSelectedOptionsList.prototype.doRefreshUI = function() {
+  var itemValues  = this._getItemValues();
+  var uiListElem  = this.elem.find('.romo-selected-option-list-items');
+  var uiItemElems = uiListElem.find('.romo-selected-option-list-item');
+  var uiValues    = uiItemElems.get().map(function(uiItemNode) {
+    return $(uiItemNode).data('romo-selected-option-list-value');
+  });
+  var rmNodes = uiItemElems.get().filter(function(uiItemNode) {
+     return itemValues.indexOf($(uiItemNode).data('romo-selected-option-list-value')) === -1;
+   });
+  var addItems = this.items.filter(function(item) {
+    return uiValues.indexOf(item.value) === -1;
+  });
+  rmNodes.each(function(rmNode) {
+    $(rmNode).remove();
+  });
+  addItems.each(function(addItem) {
+    uiListElem.append(this._buildItemElem(addItem));
+  });
+
+  var firstItemNode    = uiListElem.find('.romo-selected-option-list-item')[0];
+  var itemHeight       = parseInt(Romo.getComputedStyle(firstItemNode, "height"), 10);
+  var maxRows          = this.elem.data('romo-selected-option-list-max-rows');
+  var maxHeight        = itemHeight * (maxRows || 0);
+  var uiListElemHeight = parseInt(Romo.getComputedStyle(uiListElem[0], "height"), 10);
+  if (maxRows !== undefined && (uiListElemHeight > maxHeight)) {
+    this.elem.css({
+      'height':     maxHeight,
+      'overflow-y': 'auto'
+    });
+  } else {
+    this.elem.css({
+      'height':     uiListElemHeight,
+      'overflow-y': undefined
+    });
+  }
+}
+
+/* private */
+
+RomoSelectedOptionsList.prototype._bindElem = function() {
+  this.elem = $('<div class="romo-selected-option-list"><div class="romo-selected-option-list-items"></div></div>');
+
+  this.elem.on('click', $.proxy(function(e) {
+    if (e !== undefined) {
+      e.stopPropagation();
+      e.prevenDefault();
+    }
+    this.focusElem.focus();
+  }, this));
+
+  this.focusElem.on('focus', $.proxy(function(e) {
+    if (this.focusBlurTimeoutId !== undefined) {
+      clearTimeout(this.focusBlurTimeoutId);
+    }
+    this.focusBlurTimeoutId = setTimeout($.proxy(function() {
+      this.elem.addClass(this.focusStyleClass);
+      this.focusBlurTimeoutId = undefined;
+    }, this), 10);
+  }, this));
+
+  this.focusElem.on('blur', $.proxy(function(e) {
+    if (this.focusBlurTimeoutId !== undefined) {
+      clearTimeout(this.focusBlurTimeoutId);
+    }
+    this.focusBlurTimeoutId = setTimeout($.proxy(function() {
+      this.elem.removeClass(this.focusStyleClass);
+      this.focusBlurTimeoutId = undefined;
+    }, this), 10);
+  }, this));
+
+  this.doSetListItems([]);
+}
+
+RomoSelectedOptionsList.prototype._buildItemElem = function(item) {
+  var itemClass = this.data('romo-selected-option-list-item-class');
+  var itemElem  = $('<div class="romo-selected-option-list-item romo-nowrap '+itemClass+'"></div>');
+  itemElem.append($('<div class="romo-crop-ellipsis romo-inline-block">'+(item.displayText || '')+'</div>'));
+
+  var rmIconClass = this.elem.data('romo-picker-rm-icon') || this.defaultRmIconClass;
+  if (rmIconClass !== undefined && rmIconClass !== 'none') {
+    var rmIconElem = $('<div class="romo-inline-block romo-pointer"><i class="romo-picker-rm-icon '+rmIconClass+'"></i></div>');
+
+    var rmIconPaddingPx = this._getRmIconPaddingPx();
+    var rmIconPosition  = this._getRmIconPosition();
+    this.caretElem.css({
+      'padding-left':  rmIconPaddingPx,
+      'padding-right': rmIconPaddingPx,
+    });
+    if (rmIconPosition === 'left') {
+      itemElem.prepend(rmIconElem);
+    } else {
+      itemElem.append(rmIconElem);
+    }
+
+    rmIconElem.on('click', $.proxy(this._onRmIconClick, this));
+  }
+
+  itemElem.attr('data-romo-selected-option-list-value', (item.value || ''));
+  itemElem.css('max-width', parseInt(Romo.getComputedStyle(this.elem[0], "width"), 10)+'px');
+
+  return itemElem;
+}
+
+RomoSelectedOptionsList.prototype._getItemValues = function() {
+  return this.items.map(function(item) { return item.value; });
+}
+
+RomoSelectedOptionsList.prototype._onRmIconClick = function(e) {
+  var itemElem = $(e.target).closest('.romo-selected-option-list-item');
+  if (itemElem[0] !== undefined) {
+    var value = itemElem.data('romo-selected-option-list-value');
+    this.elem.trigger('romoSelectedOptionsList:rmIconClick', [value, this]);
+  }
+}
+
+RomoSelectedOptionsList.prototype._getRmIconPaddingPx = function() {
+  return (
+    this.elem.data('romo-picker-rm-icon-padding-px') ||
+    this.defaultRmIconPaddingPx
+  );
+}
+
+RomoSelectedOptionsList.prototype._getRmIconPosition = function() {
+  return (
+    this.elem.data('romo-picker-rm-icon-position') ||
+    this.defaultRmIconPosition
+  );
+}

--- a/lib/romo/dassets.rb
+++ b/lib/romo/dassets.rb
@@ -56,6 +56,7 @@ module Romo::Dassets
         'js/romo/indicator.js',
         'js/romo/indicator_text_input.js',
         'js/romo/currency_text_input.js',
+        'js/romo/selected_options_list.js',
         'js/romo/option_list_dropdown.js',
         'js/romo/select_dropdown.js',
         'js/romo/select.js',

--- a/test/unit/dassets_tests.rb
+++ b/test/unit/dassets_tests.rb
@@ -58,6 +58,7 @@ module Romo::Dassets
         'js/romo/indicator.js',
         'js/romo/indicator_text_input.js',
         'js/romo/currency_text_input.js',
+        'js/romo/selected_options_list.js',
         'js/romo/option_list_dropdown.js',
         'js/romo/select_dropdown.js',
         'js/romo/select.js',


### PR DESCRIPTION
This is prep for adding multi support for romo pickers/selects.
This component is the common UI handling for the selected options
for each.

This component's api includes methods to set items, clear items,
add item, remove item, and refresh ui.  The design is that you
modify the item set using the api methods and then call refresh
ui to update the markup.

In addtion, each selected item's markup supports an optional
rm icon.  If clicked, the component publishes an rm icon clicked
event that can be bound to for running remove logic.  It is
expected that the rm api method would be called at some point
after the event is published.

Here are some of the other smaller UI features:

* the selected ui is synced on refresh - the items are compared to
  the ui and only the items that need to be added are added and
  the ui items that need removing are removed.  This avoids any
  ui flashes with a clear and rebuild approach.
* the lists height grows as needed up to an option max rows.  If
  no max-rows is configured, the height grows infinitely.
* the component is built with a "focus elem".  This component is
  not designed to be directly focused (it will be paired with a
  select/picker that will be focused).  If the elem is clicked, it
  focuses its focus elem.  If its focus elem is focused/blurred,
  a focus style class is added/removed to the elem to make it
  appear as it is focused/blurred as part of the focus elem being
  focused/blurred.

This is the first pass at this component and its usage. In a
coming, I'll intergrate this with selects/pickers with the multi
prop and polish the UX.

Note: I went ahead and psuedo-code added notes for integrating
with the select/picker.  I wanted to be sure I could use this
as is and integrate it as designed.  These notes will be removed
in a coming effort.

@jcredding ready for review.