### PR TITLE
selected options list ui tweaks after testing with selects

### DIFF
--- a/assets/css/romo/forms.scss
+++ b/assets/css/romo/forms.scss
@@ -318,7 +318,7 @@
     @include align-middle;
   }
 
-  /* input option list (used by selects vie option list dropdown) */
+  /* input option list (used by selects/pickers via option list dropdown) */
 
   .romo-input-option-list {
     cursor: pointer;
@@ -364,6 +364,23 @@
   .romo-input-option-list LI.disabled.romo-option-list-dropdown-highlight {
     background-color: $inputBgColor;
     color: $disabledColor;
+  }
+
+  /* selected options list (used by multi selects/pickers) */
+
+  .romo-selected-options-list {
+    cursor: pointer;
+    font-weight: normal;
+    padding: 4px 0;
+    @include user-select(none);
+
+    background-color: $inputBgColor;
+    color: $inputColor;
+    @include border1;
+
+    .romo-selected-options-list-items {
+      min-height: 35px;
+    }
   }
 
 }

--- a/assets/js/romo/select.js
+++ b/assets/js/romo/select.js
@@ -69,6 +69,7 @@ RomoSelect.prototype.doSetValue = function(value) {
 
 RomoSelect.prototype._bindElem = function() {
   this._bindSelectDropdown();
+  this._bindSelectedOptionsList();
 
   this.elem.on('select:triggerToggle', $.proxy(function(e) {
     this.romoSelectDropdown.elem.trigger('selectDropdown:triggerToggle', []);
@@ -79,6 +80,15 @@ RomoSelect.prototype._bindElem = function() {
   this.elem.on('select:triggerPopupClose', $.proxy(function(e) {
     this.romoSelectDropdown.elem.trigger('selectDropdown:triggerPopupClose', []);
   }, this));
+}
+
+RomoSelect.prototype._bindSelectedOptionsList = function() {
+  this.romoSelectedOptionsList = undefined;
+  if (this.elem.prop('multiple') === true) {
+    this.romoSelectedOptionsList = new RomoSelectedOptionsList(this.romoSelectDropdown.elem);
+    this.romoSelectDropdown.elem.before(this.romoSelectedOptionsList.elem);
+    this.romoSelectedOptionsList.doRefreshUI();
+  }
 }
 
 RomoSelect.prototype._bindSelectDropdown = function() {

--- a/assets/js/romo/selected_options_list.js
+++ b/assets/js/romo/selected_options_list.js
@@ -3,11 +3,9 @@ var RomoSelectedOptionsList = function(focusElem) {
   this.focusElem = focusElem; // picker/select dropdown elem
 
   this.items                  = [];
-  this.focusStyleClass        = this.elem.data('romo-option-list-focus-style-class');
   this.defaultRmIconClass     = undefined;
   this.defaultRmIconPaddingPx = 5;
   this.defaultRmIconPosition  = 'right'
-  this.focusBlurTimeoutId     = undefined;
 
   this.doInit();
   this._bindElem();
@@ -56,37 +54,43 @@ RomoSelectedOptionsList.prototype.doRemoveItem = function(itemValue) {
 
 RomoSelectedOptionsList.prototype.doRefreshUI = function() {
   var itemValues  = this._getItemValues();
-  var uiListElem  = this.elem.find('.romo-selected-option-list-items');
-  var uiItemElems = uiListElem.find('.romo-selected-option-list-item');
+  var uiListElem  = this.elem.find('.romo-selected-options-list-items');
+  var uiItemElems = uiListElem.find('.romo-selected-options-list-item');
   var uiValues    = uiItemElems.get().map(function(uiItemNode) {
-    return $(uiItemNode).data('romo-selected-option-list-value');
+    return $(uiItemNode).data('romo-selected-options-list-value');
   });
   var rmNodes = uiItemElems.get().filter(function(uiItemNode) {
-     return itemValues.indexOf($(uiItemNode).data('romo-selected-option-list-value')) === -1;
+     return itemValues.indexOf($(uiItemNode).data('romo-selected-options-list-value')) === -1;
    });
   var addItems = this.items.filter(function(item) {
     return uiValues.indexOf(item.value) === -1;
   });
-  rmNodes.each(function(rmNode) {
+  rmNodes.forEach(function(rmNode) {
     $(rmNode).remove();
   });
-  addItems.each(function(addItem) {
+  addItems.forEach(function(addItem) {
     uiListElem.append(this._buildItemElem(addItem));
   });
 
-  var firstItemNode    = uiListElem.find('.romo-selected-option-list-item')[0];
-  var itemHeight       = parseInt(Romo.getComputedStyle(firstItemNode, "height"), 10);
-  var maxRows          = this.elem.data('romo-selected-option-list-max-rows');
-  var maxHeight        = itemHeight * (maxRows || 0);
-  var uiListElemHeight = parseInt(Romo.getComputedStyle(uiListElem[0], "height"), 10);
+  var focusElemWidth = parseInt(Romo.getComputedStyle(this.focusElem[0], "width"), 10);
+  this.elem.css('width', String(focusElemWidth)+'px');
+
+  var maxRows          = undefined;
+  var uiListElemHeight = uiListElem.height();
+  var firstItemNode    = uiListElem.find('.romo-selected-options-list-item')[0];
+  if (firstItemNode !== undefined) {
+    var itemHeight = parseInt(Romo.getComputedStyle(firstItemNode, "height"), 10);
+    var maxRows    = this.elem.data('romo-selected-options-list-max-rows');
+    var maxHeight  = itemHeight * (maxRows || 0);
+  }
   if (maxRows !== undefined && (uiListElemHeight > maxHeight)) {
     this.elem.css({
-      'height':     maxHeight,
+      'height':     String(maxHeight)+'px',
       'overflow-y': 'auto'
     });
   } else {
     this.elem.css({
-      'height':     uiListElemHeight,
+      'height':     String(uiListElemHeight)+'px',
       'overflow-y': undefined
     });
   }
@@ -95,42 +99,22 @@ RomoSelectedOptionsList.prototype.doRefreshUI = function() {
 /* private */
 
 RomoSelectedOptionsList.prototype._bindElem = function() {
-  this.elem = $('<div class="romo-selected-option-list"><div class="romo-selected-option-list-items"></div></div>');
+  this.elem = $('<div class="romo-selected-options-list"><div class="romo-selected-options-list-items"></div></div>');
 
   this.elem.on('click', $.proxy(function(e) {
     if (e !== undefined) {
       e.stopPropagation();
-      e.prevenDefault();
+      e.preventDefault();
     }
     this.focusElem.focus();
   }, this));
 
-  this.focusElem.on('focus', $.proxy(function(e) {
-    if (this.focusBlurTimeoutId !== undefined) {
-      clearTimeout(this.focusBlurTimeoutId);
-    }
-    this.focusBlurTimeoutId = setTimeout($.proxy(function() {
-      this.elem.addClass(this.focusStyleClass);
-      this.focusBlurTimeoutId = undefined;
-    }, this), 10);
-  }, this));
-
-  this.focusElem.on('blur', $.proxy(function(e) {
-    if (this.focusBlurTimeoutId !== undefined) {
-      clearTimeout(this.focusBlurTimeoutId);
-    }
-    this.focusBlurTimeoutId = setTimeout($.proxy(function() {
-      this.elem.removeClass(this.focusStyleClass);
-      this.focusBlurTimeoutId = undefined;
-    }, this), 10);
-  }, this));
-
-  this.doSetListItems([]);
+  this.doSetItems([]);
 }
 
 RomoSelectedOptionsList.prototype._buildItemElem = function(item) {
-  var itemClass = this.data('romo-selected-option-list-item-class');
-  var itemElem  = $('<div class="romo-selected-option-list-item romo-nowrap '+itemClass+'"></div>');
+  var itemClass = this.data('romo-selected-options-list-item-class');
+  var itemElem  = $('<div class="romo-selected-options-list-item romo-nowrap '+itemClass+'"></div>');
   itemElem.append($('<div class="romo-crop-ellipsis romo-inline-block">'+(item.displayText || '')+'</div>'));
 
   var rmIconClass = this.elem.data('romo-picker-rm-icon') || this.defaultRmIconClass;
@@ -152,7 +136,7 @@ RomoSelectedOptionsList.prototype._buildItemElem = function(item) {
     rmIconElem.on('click', $.proxy(this._onRmIconClick, this));
   }
 
-  itemElem.attr('data-romo-selected-option-list-value', (item.value || ''));
+  itemElem.attr('data-romo-selected-options-list-value', (item.value || ''));
   itemElem.css('max-width', parseInt(Romo.getComputedStyle(this.elem[0], "width"), 10)+'px');
 
   return itemElem;
@@ -163,9 +147,9 @@ RomoSelectedOptionsList.prototype._getItemValues = function() {
 }
 
 RomoSelectedOptionsList.prototype._onRmIconClick = function(e) {
-  var itemElem = $(e.target).closest('.romo-selected-option-list-item');
+  var itemElem = $(e.target).closest('.romo-selected-options-list-item');
   if (itemElem[0] !== undefined) {
-    var value = itemElem.data('romo-selected-option-list-value');
+    var value = itemElem.data('romo-selected-options-list-value');
     this.elem.trigger('romoSelectedOptionsList:rmIconClick', [value, this]);
   }
 }


### PR DESCRIPTION
This is a first pass at tweaking/verifying the selected options
list ui after testing with selects.  There was enough changes
here that I wanted to go ahead and have them looked at so they
don't junk up future efforts.  I got some things wrong that
became apparent when loading up the UI in the browser.

The changes here:

* I removed all focus styling and managing on focus/blur.  After
  seeing the UI, the extra styling felt noisy.
* I added some very basic styles to the component ui.  This is
  just a starting point for the list container ui.
* I fixed a typo in all the css class names and data attr names.
* I fixed a method name typo and `preventDefault` method typo.
* I also fixed some bugs in calculating the ui height.  I didn't
  address the case where there was no items selected.

UI:
![gif](https://user-images.githubusercontent.com/82110/29884426-14cbdad2-8d79-11e7-96c0-2ec6a7b67319.gif)

@jcredding ready for review.