### PR TITLE
selected options list items UI/UX

### DIFF
--- a/assets/css/romo/forms.scss
+++ b/assets/css/romo/forms.scss
@@ -369,17 +369,22 @@
   /* selected options list (used by multi selects/pickers) */
 
   .romo-selected-options-list {
-    cursor: pointer;
     font-weight: normal;
-    padding: 4px 0;
     @include user-select(none);
-
     background-color: $inputBgColor;
     color: $inputColor;
     @include border1;
 
     .romo-selected-options-list-items {
       min-height: 35px;
+    }
+    .romo-selected-options-list-items {
+      padding: 4px;
+    }
+    .romo-selected-options-list-item {
+      display: inline-block;
+      @include border1;
+      @include bg-alt;
     }
   }
 

--- a/assets/js/romo/select.js
+++ b/assets/js/romo/select.js
@@ -86,7 +86,7 @@ RomoSelect.prototype._bindSelectedOptionsList = function() {
   this.romoSelectedOptionsList = undefined;
   if (this.elem.prop('multiple') === true) {
     this.romoSelectedOptionsList = new RomoSelectedOptionsList(this.romoSelectDropdown.elem);
-    this.romoSelectDropdown.elem.before(this.romoSelectedOptionsList.elem);
+    this.elemWrapper.before(this.romoSelectedOptionsList.elem);
     this.romoSelectedOptionsList.doRefreshUI();
   }
 }
@@ -111,13 +111,15 @@ RomoSelect.prototype._bindSelectDropdown = function() {
   }, this));
   this.romoSelectDropdown.elem.on('selectDropdown:newItemSelected', $.proxy(function(e, itemValue, itemDisplayText, selectDropdown) {
     // TODO: support multi
-    // if sel opt list
-    //   `doAddListItem({value, text})`
-    //   set append-values
-    // else
-    //   set value
-    // end
-    this._setValue(itemValue);
+    if (this.romoSelectedOptionsList !== undefined) {
+      this.romoSelectedOptionsList.doAddItem({
+        'value':       itemValue,
+        'displayText': itemDisplayText
+      });
+      // set append-values
+    } else {
+      this._setValue(itemValue);
+    }
 
     this._refreshUI();
     this.elem.trigger('select:newItemSelected', [itemValue, itemDisplayText, this]);
@@ -233,7 +235,13 @@ RomoSelect.prototype._setValue = function(value) {
 }
 
 RomoSelect.prototype._refreshUI = function() {
-  var text = this.elem.find('OPTION[selected="selected"]').text().trim();
+  var text = undefined;
+  if (this.romoSelectedOptionsList !== undefined) {
+    text = '';
+    this.romoSelectedOptionsList.doRefreshUI();
+  } else {
+    text = this.elem.find('OPTION[selected="selected"]').text().trim();
+  }
   if (text === '') {
     text = '&nbsp;'
   }


### PR DESCRIPTION
This gets the UI and UX for the selected items in the selected
options list working.  This includes a bunch of tweaks that became
necessary when testing in the browser.

I chose to remove the "rm icon" design and instead switch to
striking thru the text on hover to signify that you can click and
remove the item.  I didn't want to clutter up the UI by adding in
a bunch of rm icon noise and the strikethru seems to get a similar
effect.  This also simplified the implementation by removing a
bunch of crappy rm icon handling code.

I also switched to calculating the max-width for an item until
after it was added to the DOM.  To properly calc this, you need
to take into account all the padding, borders, etc and not all of
that info is ready until it is in the DOM.

I removed auto refreshing the UI from the item set API methods.
This should not have been added as the design has always been to
just update the item set and let the user determine when to
refresh the UI (as part of a large refresh perhaps).

Finally, this updates some select logic to allow adding items
when they are selected.  This is just the bare minimum to test the
list UI and is incomplete.

![gif](https://user-images.githubusercontent.com/82110/29896333-35ffa610-8da2-11e7-8110-907156ef9af6.gif)

@jcredding ready for review.