### PR TITLE
get selected options list max rows handling working

### DIFF
--- a/assets/js/romo/select.js
+++ b/assets/js/romo/select.js
@@ -85,6 +85,12 @@ RomoSelect.prototype._bindElem = function() {
 RomoSelect.prototype._bindSelectedOptionsList = function() {
   this.romoSelectedOptionsList = undefined;
   if (this.elem.prop('multiple') === true) {
+    if (this.elem.data('romo-select-multiple-item-class') !== undefined) {
+      this.romoSelectDropdown.elem.attr('data-romo-selected-options-list-item-class', this.elem.data('romo-select-multiple-item-class'));
+    }
+    if (this.elem.data('romo-select-multiple-max-rows') !== undefined) {
+      this.romoSelectDropdown.elem.attr('data-romo-selected-options-list-max-rows', this.elem.data('romo-select-multiple-max-rows'));
+    }
     this.romoSelectedOptionsList = new RomoSelectedOptionsList(this.romoSelectDropdown.elem);
     this.elemWrapper.before(this.romoSelectedOptionsList.elem);
     this.romoSelectedOptionsList.doRefreshUI();

--- a/assets/js/romo/selected_options_list.js
+++ b/assets/js/romo/selected_options_list.js
@@ -81,15 +81,23 @@ RomoSelectedOptionsList.prototype.doRefreshUI = function() {
   var uiListElemHeight = parseInt(Romo.getComputedStyle(uiListElem[0], "height"), 10);
   var firstItemNode    = uiListElem.find('.romo-selected-options-list-item')[0];
   if (firstItemNode !== undefined) {
-    var itemHeight = parseInt(Romo.getComputedStyle(firstItemNode, "height"), 10);
-    var maxRows    = this.focusElem.data('romo-selected-options-list-max-rows');
-    var maxHeight  = itemHeight * (maxRows || 0);
+    var itemHeight       = parseInt(Romo.getComputedStyle(firstItemNode, "height"), 10);
+    var itemMarginBottom = parseInt(Romo.getComputedStyle(firstItemNode, "margin-bottom"), 10);
+    var itemBorderWidth  = 1;
+    var listTopPad       = parseInt(Romo.getComputedStyle(uiListElem[0], "padding-top"), 10);
+    var listBottomPad    = parseInt(Romo.getComputedStyle(uiListElem[0], "padding-bottom"), 10);
+
+    var maxRows   = this.focusElem.data('romo-selected-options-list-max-rows') || 0;
+    var maxHeight = listTopPad+(itemHeight*maxRows)+(itemMarginBottom*(maxRows-1))+(2*itemBorderWidth*maxRows)+listBottomPad+(itemHeight/2);
   }
   if (maxRows !== undefined && (uiListElemHeight > maxHeight)) {
     this.elem.css({
       'height':     String(maxHeight)+'px',
       'overflow-y': 'auto'
     });
+    var itemElems    = uiListElem.find('.romo-selected-options-list-item');
+    var lastItemNode = itemElems[itemElems.length-1];
+    this._scrollListTopToItem($(lastItemNode));
   } else {
     this.elem.css({
       'height':     String(uiListElemHeight)+'px',
@@ -136,5 +144,18 @@ RomoSelectedOptionsList.prototype._onItemClick = function(e) {
   if (itemElem[0] !== undefined) {
     var value = itemElem.data('romo-selected-options-list-value');
     this.elem.trigger('romoSelectedOptionsList:itemClick', [value, this]);
+  }
+}
+
+RomoSelectedOptionsList.prototype._scrollListTopToItem = function(itemElem) {
+  if (itemElem[0] !== undefined) {
+    var scroll = this.elem;
+    scroll.scrollTop(0);
+
+    var scrollOffsetTop = scroll.offset().top;
+    var selOffsetTop    = itemElem.offset().top;
+    var selOffset       = itemElem.height() / 2;
+
+    scroll.scrollTop(selOffsetTop - scrollOffsetTop - selOffset);
   }
 }


### PR DESCRIPTION
This updates the max rows handling to make it calculate the max
height properly and also updated it to scroll to the last item
when the max-rows height limit is needed.  This means you will
always see the item you just selected at the bottom of the list.

Note: I updated the max height calc to properly account for list
padding and item margin/borders.  I chose to also add half a row
of extra height.  This shows that there is more above or below
the list to scroll to.  Without it, it might look like there are
only what you can see.

![gif](https://user-images.githubusercontent.com/82110/29898657-9e2196ae-8dac-11e7-90b2-5999f1d26ad5.gif)


@jcredding ready for review.