### PR TITLE
integrate SelectedOptionsList with Select component

### DIFF
--- a/assets/js/romo/select.js
+++ b/assets/js/romo/select.js
@@ -14,7 +14,7 @@ var RomoSelect = function(element) {
   this.doInit();
   this._bindElem();
 
-  this.doSetValue(this.elem[0].value);
+  this.doSetValue(this._elemValues());
 
   if (this.elem.attr('id') !== undefined) {
     $('label[for="'+this.elem.attr('id')+'"]').on('click', $.proxy(function(e) {
@@ -38,30 +38,28 @@ RomoSelect.prototype.doInit = function() {
 }
 
 RomoSelect.prototype.doSetValue = function(value) {
-  // TODO: support multi
-  // if value is an Array
-  //   assume list of values
-  //   if sel opt list
-  //     `doSetListItems(value-text-items)`  // build items from values/options
-  //     set select dropdown to ''
-  //     set value
-  //   else
-  //     set select dropdown to data[0].value, data[0].displayText
-  //     set data[0].value
-  //   end
-  // else
-  //   if sel opt list
-  //     `doSetListItems([{value, text}])`   // lookup text from options
-  //     set select dropdown to ''
-  //     set value
-  //   else
-  //     set select dropdown to value, text
-  //     set value
-  //   end
-  // end
-  this.romoSelectDropdown.doSetSelectedItem(value);
-  this._setValue(value);
+  var values = undefined;
+  if (Array.isArray(value)) {
+    values = value;
+  } else {
+    values = [value];
+  }
+  values = values.filter($.proxy(function() {
+    return this.elem.find('OPTION[value="'+value+'"]')[0] !== undefined;
+  }, this));
 
+  this._setValues(values);
+  if (this.romoSelectedOptionsList !== undefined) {
+    var items = values.map($.proxy(function(value) {
+      return {
+        'value':       value,
+        'displayText': this.elem.find('OPTION[value="'+value+'"]').text().trim()
+      };
+    }, this));
+    this.romoSelectedOptionsList.doSetItems(items);
+  } else {
+    this.romoSelectDropdown.doSetSelectedItem(values[0]);
+  }
   this._refreshUI();
 }
 
@@ -91,7 +89,19 @@ RomoSelect.prototype._bindSelectedOptionsList = function() {
     if (this.elem.data('romo-select-multiple-max-rows') !== undefined) {
       this.romoSelectDropdown.elem.attr('data-romo-selected-options-list-max-rows', this.elem.data('romo-select-multiple-max-rows'));
     }
+
     this.romoSelectedOptionsList = new RomoSelectedOptionsList(this.romoSelectDropdown.elem);
+    this.romoSelectedOptionsList.elem.on('romoSelectedOptionsList:itemClick', $.proxy(function(e, itemValue, romoSelectedOptionsList) {
+      var currentValues = this._elemValues();
+      var index         = currentValues.indexOf(itemValue);
+      if (index > -1) {
+        currentValues.splice(index, 1);
+        this._setValues(currentValues);
+      }
+      this.romoSelectedOptionsList.doRemoveItem(itemValue);
+      this._refreshUI();
+    }, this));
+
     this.elemWrapper.before(this.romoSelectedOptionsList.elem);
     this.romoSelectedOptionsList.doRefreshUI();
   }
@@ -111,22 +121,22 @@ RomoSelect.prototype._bindSelectDropdown = function() {
   }, this));
 
   this.romoSelectDropdown.elem.on('selectDropdown:itemSelected', $.proxy(function(e, itemValue, itemDisplayText, selectDropdown) {
-    // TODO: if sel opt list, do nothing
     this.romoSelectDropdown.elem.focus();
     this.elem.trigger('select:itemSelected', [itemValue, itemDisplayText, this]);
   }, this));
   this.romoSelectDropdown.elem.on('selectDropdown:newItemSelected', $.proxy(function(e, itemValue, itemDisplayText, selectDropdown) {
-    // TODO: support multi
     if (this.romoSelectedOptionsList !== undefined) {
-      this.romoSelectedOptionsList.doAddItem({
-        'value':       itemValue,
-        'displayText': itemDisplayText
-      });
-      // set append-values
+      var currentValues = this._elemValues();
+      if (!currentValues.includes(itemValue)) {
+        this._setValues(currentValues.concat([itemValue]));
+        this.romoSelectedOptionsList.doAddItem({
+          'value':       itemValue,
+          'displayText': itemDisplayText
+        });
+      }
     } else {
-      this._setValue(itemValue);
+      this._setValues([itemValue]);
     }
-
     this._refreshUI();
     this.elem.trigger('select:newItemSelected', [itemValue, itemDisplayText, this]);
   }, this));
@@ -227,17 +237,37 @@ RomoSelect.prototype._buildSelectDropdownElem = function() {
   return romoSelectDropdownElem;
 }
 
-RomoSelect.prototype._setValue = function(value) {
-  // TODO: support multi
-  // where given value is an array
-  // and wehre elme[0].value is an array
-  var prevOptElem = this.elem.find('OPTION[value="'+this.elem[0].value+'"]');
-  var newOptElem  = this.elem.find('OPTION[value="'+value+'"]');
+RomoSelect.prototype._setValues = function(newValues) {
+  var currentValues = this._elemValues();
 
-  prevOptElem.removeAttr('selected');
-  prevOptElem.prop('selected', false);
-  newOptElem.attr('selected', 'selected');
-  newOptElem.prop('selected', true);
+  var unsetValues = currentValues.filter(function(value) {
+    return newValues.indexOf(value) === -1;
+  });
+  var setValues = newValues.filter(function(value) {
+    return currentValues.indexOf(value) === -1;
+  });
+  var unsetElems = unsetValues.reduce($.proxy(function(elems, value) {
+    return elems.add(this.elem.find('OPTION[value="'+value+'"]'));
+  }, this), $());
+  var setElems = setValues.reduce($.proxy(function(elems, value) {
+    return elems.add(this.elem.find('OPTION[value="'+value+'"]'));
+  }, this), $());
+
+  unsetElems.removeAttr('selected');
+  unsetElems.prop('selected', false);
+  setElems.attr('selected', 'selected');
+  setElems.prop('selected', true);
+}
+
+RomoSelect.prototype._elemValues = function() {
+  var selectedNodes = this.elem.find('OPTION[selected]').get();
+  if (selectedNodes.length === 0 && this.romoSelectedOptionsList === undefined) {
+    // if a non-multi select has no selected options, treat the first option as selected
+    selectedNodes = [this.elem.find('OPTION')[0]];
+  }
+  return selectedNodes.map(function(node) {
+    return ($(node).attr('value') || '');
+  });
 }
 
 RomoSelect.prototype._refreshUI = function() {
@@ -246,7 +276,7 @@ RomoSelect.prototype._refreshUI = function() {
     text = '';
     this.romoSelectedOptionsList.doRefreshUI();
   } else {
-    text = this.elem.find('OPTION[selected="selected"]').text().trim();
+    text = this.elem.find('OPTION[value="'+this._elemValues()[0]+'"]').text().trim();
   }
   if (text === '') {
     text = '&nbsp;'


### PR DESCRIPTION
This gets the custom multi select component working and fully
integrated with the selected options list UI.  I made a few
tweaks to how selects handle their values to support this:

* There are 3 main places where the integration occurs: setting
  preset/ad-hoc values in `doSetValue`, removing a value on
  `romoSelectedOptionsList:itemClick`, and adding a value on
  `selectDropdown:newItemSelected`.
* In general, I tried to do the minimum operations wherever
  possible.  This means only adding it the value isn't already
  added, the inverse for removal, and both for setting a set
  of values.
* Because we need to support multi-selects, we can no longer use
  `this.elem[0].value` to lookup the value for a select.  I wrote
  `_elemValues` to replace this.  It looks up the options that are
  selected and returns their values as an array.
* To simplify the handling between normal/multi selects, I
  switched all value handling to be array based.  Normal selects
  now just use single item value arrays while multi selects can
  have multi item value arrays.
* The only place this is not true is the public `doSetValue`
  method and corresponding trigger event.  Because this value can
  come from end-users, I check the value and cast it to an array
  if necessary.
* I also updated the `doSetValue` method to filter out values
  where there was no corresponding option.  This helps prevents
  weird edge cases.
* I rewrote the `_setValue` method to be `_setValues` and made it
  array based.  It compares the current values to the new values
  and only adds/removes options as needed.

Finally, this fixes a bug in refreshing the normal select's UI:
there are cases where no option is selected or there are no
at all.  In that case we treat the first option as selected and
return its single value with `_elemValues`.  If there are no
options, `_elemValues` returns `[""]` for normal selects and `[]`
for multi selects.

![gif](https://user-images.githubusercontent.com/82110/29944121-d313b864-8e61-11e7-9df2-66cdaa78f8df.gif)

@jcredding ready for review.