### PR TITLE
add dropdown `popup{Open|Closed}` methods; proxy/use in other components

### DIFF
--- a/assets/js/romo/datepicker.js
+++ b/assets/js/romo/datepicker.js
@@ -193,7 +193,7 @@ RomoDatepicker.prototype.onTriggerSetDate = function(e, value) {
 
 RomoDatepicker.prototype.onElemKeyDown = function(e) {
   if (this.elem.hasClass('disabled') === false) {
-    if (this.romoDropdown.popupElem.hasClass('romo-dropdown-open')) {
+    if (this.romoDropdown.popupOpen()) {
       return true;
     } else {
       if(e.keyCode === 40 /* Down */ ) {

--- a/assets/js/romo/dropdown.js
+++ b/assets/js/romo/dropdown.js
@@ -38,6 +38,14 @@ var RomoDropdown = function(element) {
   this.elem.trigger('dropdown:ready', [this]);
 }
 
+RomoDropdown.prototype.popupOpen = function() {
+  return this.popupElem.hasClass('romo-dropdown-open') === true;
+}
+
+RomoDropdown.prototype.popupClosed = function() {
+  return this.popupElem.hasClass('romo-dropdown-open') === false;
+}
+
 RomoDropdown.prototype.doInit = function() {
   // override as needed
 }
@@ -177,7 +185,7 @@ RomoDropdown.prototype.onToggleClick = function(e) {
 }
 
 RomoDropdown.prototype.doToggle = function() {
-  if (this.popupElem.hasClass('romo-dropdown-open')) {
+  if (this.popupOpen()) {
     setTimeout($.proxy(function() {
       this.doPopupClose();
     }, this), 100);
@@ -194,8 +202,7 @@ RomoDropdown.prototype.onPopupOpen = function(e) {
     e.preventDefault();
   }
 
-  if (this.elem.hasClass('disabled') === false &&
-      this.popupElem.hasClass('romo-dropdown-open') === false) {
+  if (this.elem.hasClass('disabled') === false && this.popupClosed()) {
     setTimeout($.proxy(function() {
       this.doPopupOpen();
     }, this), 100);
@@ -235,8 +242,7 @@ RomoDropdown.prototype.onPopupClose = function(e) {
     e.preventDefault();
   }
 
-  if (this.elem.hasClass('disabled') === false &&
-      this.popupElem.hasClass('romo-dropdown-open') === true) {
+  if (this.elem.hasClass('disabled') === false && this.popupOpen()) {
     setTimeout($.proxy(function() {
       this.doPopupClose();
     }, this), 100);
@@ -275,7 +281,7 @@ RomoDropdown.prototype.doUnBindElemKeyUp = function() {
 
 RomoDropdown.prototype.onElemKeyUp = function(e) {
   if (this.elem.hasClass('disabled') === false) {
-    if (this.popupElem.hasClass('romo-dropdown-open')) {
+    if (this.popupOpen()) {
       if(e.keyCode === 27 /* Esc */ ) {
         this.doPopupClose();
         this.elem.trigger('dropdown:popupClosedByEsc', [this]);

--- a/assets/js/romo/option_list_dropdown.js
+++ b/assets/js/romo/option_list_dropdown.js
@@ -29,6 +29,14 @@ RomoOptionListDropdown.prototype.popupElem = function() {
   return this.romoDropdown.popupElem;
 }
 
+RomoOptionListDropdown.prototype.popupOpen = function() {
+  return this.romoDropdown.popupOpen();
+}
+
+RomoOptionListDropdown.prototype.popupClosed = function() {
+  return this.romoDropdown.popupClosed();
+}
+
 RomoOptionListDropdown.prototype.selectedItemElem = function() {
   return this.romoDropdown.bodyElem.find('LI.selected');
 }
@@ -453,7 +461,7 @@ RomoOptionListDropdown.prototype._onPopupOpenBodyKeyDown = function(e) {
 
 RomoOptionListDropdown.prototype._onElemKeyDown = function(e) {
   if (this.elem.hasClass('disabled') === false) {
-    if (this.romoDropdown.popupElem.hasClass('romo-dropdown-open') === false) {
+    if (this.romoDropdown.popupClosed()) {
       if (e.keyCode === 40 /* Down */  || e.keyCode === 38 /* Up */) {
         this.romoDropdown.doPopupOpen();
         return false;

--- a/assets/js/romo/select_dropdown.js
+++ b/assets/js/romo/select_dropdown.js
@@ -31,6 +31,14 @@ RomoSelectDropdown.prototype.popupElem = function() {
   return this.romoOptionListDropdown.popupElem();
 }
 
+RomoSelectDropdown.prototype.popupOpen = function() {
+  return this.romoOptionListDropdown.popupOpen();
+}
+
+RomoSelectDropdown.prototype.popupClosed = function() {
+  return this.romoOptionListDropdown.popupClosed();
+}
+
 RomoSelectDropdown.prototype.selectedItemElem = function() {
   return this.romoOptionListDropdown.selectedItemElem();
 }


### PR DESCRIPTION
This is a cleanup from working on the multi selects/pickers.  The
logic for determining whether a dropdown's popup is open or not
should be centralized on the dropdown.

@jcredding FYI.  I'm going ahead and merging this to clean up for a PR I want to put up for the multi pickers.  Check me on all this, but I'm going to go ahead and merge to get that other PR up.