### PR TITLE
update opt list dropdown focus logic to better handle open on focus

### DIFF
--- a/assets/js/romo/option_list_dropdown.js
+++ b/assets/js/romo/option_list_dropdown.js
@@ -93,6 +93,15 @@ RomoOptionListDropdown.prototype.doSetSelectedValueAndText = function(value, tex
   this.prevValue = value;
 }
 
+RomoOptionListDropdown.prototype.doFocus = function(openOnFocus) {
+  if (openOnFocus === true) {
+    this.openOnFocus = true;
+  } else if (openOnFocus === false) {
+    this.openOnFocus = false;
+  }
+  this.elem.focus();
+}
+
 /*
 Options are specified as a list of items.  Each 'option' item object
 has either display text or html, a value, and can optionally be

--- a/assets/js/romo/picker.js
+++ b/assets/js/romo/picker.js
@@ -28,7 +28,7 @@ var RomoPicker = function(element) {
 
   if (this.elem.attr('id') !== undefined) {
     $('label[for="'+this.elem.attr('id')+'"]').on('click', $.proxy(function(e) {
-      this.romoOptionListDropdown.elem.focus();
+      this.romoOptionListDropdown.doFocus();
     }, this));
   }
 
@@ -137,8 +137,7 @@ RomoPicker.prototype._bindOptionListDropdown = function() {
     }
   }, this));
   this.romoOptionListDropdown.elem.on('romoOptionListDropdown:itemSelected', $.proxy(function(e, itemValue, itemDisplayText, optionListDropdown) {
-    // TODO: if sel opt list, do nothing
-    this.romoOptionListDropdown.elem.focus();
+    this.romoOptionListDropdown.doFocus();
     this.elem.trigger('romoPicker:itemSelected', [itemValue, itemDisplayText, this]);
   }, this));
   this.romoOptionListDropdown.elem.on('romoOptionListDropdown:newItemSelected', $.proxy(function(e, itemValue, itemDisplayText, optionListDropdown) {
@@ -341,7 +340,7 @@ RomoPicker.prototype._refreshUI = function() {
 
 RomoPicker.prototype._onCaretClick = function(e) {
   if (this.elem.prop('disabled') === false) {
-    this.romoOptionListDropdown.elem.focus();
+    this.romoOptionListDropdown.doFocus();
     this.elem.trigger('romoPicker:triggerPopupOpen');
   }
 }

--- a/assets/js/romo/select.js
+++ b/assets/js/romo/select.js
@@ -18,7 +18,7 @@ var RomoSelect = function(element) {
 
   if (this.elem.attr('id') !== undefined) {
     $('label[for="'+this.elem.attr('id')+'"]').on('click', $.proxy(function(e) {
-      this.romoSelectDropdown.elem.focus();
+      this.romoSelectDropdown.doFocus();
     }, this));
   }
 
@@ -101,6 +101,10 @@ RomoSelect.prototype._bindSelectedOptionsList = function() {
       this.romoSelectedOptionsList.doRemoveItem(itemValue);
       this._refreshUI();
     }, this));
+    this.romoSelectedOptionsList.elem.on('romoSelectedOptionsList:listClick', $.proxy(function(e, romoSelectedOptionsList) {
+      this.romoSelectDropdown.elem.trigger('dropdown:triggerPopupClose', []);
+      this.romoSelectDropdown.doFocus(false);
+    }, this));
 
     this.elemWrapper.before(this.romoSelectedOptionsList.elem);
     this.romoSelectedOptionsList.doRefreshUI();
@@ -121,7 +125,7 @@ RomoSelect.prototype._bindSelectDropdown = function() {
   }, this));
 
   this.romoSelectDropdown.elem.on('selectDropdown:itemSelected', $.proxy(function(e, itemValue, itemDisplayText, selectDropdown) {
-    this.romoSelectDropdown.elem.focus();
+    this.romoSelectDropdown.doFocus();
     this.elem.trigger('select:itemSelected', [itemValue, itemDisplayText, this]);
   }, this));
   this.romoSelectDropdown.elem.on('selectDropdown:newItemSelected', $.proxy(function(e, itemValue, itemDisplayText, selectDropdown) {
@@ -286,7 +290,7 @@ RomoSelect.prototype._refreshUI = function() {
 
 RomoSelect.prototype._onCaretClick = function(e) {
   if (this.elem.prop('disabled') === false) {
-    this.romoSelectDropdown.elem.focus();
+    this.romoSelectDropdown.doFocus();
     this.elem.trigger('select:triggerPopupOpen');
   }
 }

--- a/assets/js/romo/select_dropdown.js
+++ b/assets/js/romo/select_dropdown.js
@@ -71,6 +71,10 @@ RomoSelectDropdown.prototype.doSetSelectedItem = function(newValue) {
   this.romoOptionListDropdown.doSetSelectedItem(newValue);
 }
 
+RomoSelectDropdown.prototype.doFocus = function(openOnFocus) {
+  this.romoOptionListDropdown.doFocus(openOnFocus);
+}
+
 /* private */
 
 RomoSelectDropdown.prototype._bindElem = function() {

--- a/assets/js/romo/selected_options_list.js
+++ b/assets/js/romo/selected_options_list.js
@@ -116,7 +116,7 @@ RomoSelectedOptionsList.prototype._bindElem = function() {
       e.stopPropagation();
       e.preventDefault();
     }
-    this.focusElem.focus();
+    this.elem.trigger('romoSelectedOptionsList:listClick', [this]);
   }, this));
 
   this.doSetItems([]);


### PR DESCRIPTION
This is more cleanup that came from working on the multi picker.
I was testing the multi picker with open on focus and found a
weird open toggle issue.  This came up when I clicked on the
selected options list.  The desired behavior is that it would
close the popup and just focus the opt list dropdown.  However,
b/c of the open on focus option, it close the popup, focus the
opt list dropdown and then re-open the popup.

I added a `doFocus` method on the opt list dropdown that I'm now
using to focuse the dropdown.  It takes an optional arg to specify
whether is should open on focus or not.  If given true or false
it sets that on the dropdown and then focuses it.  If no arg is
given, it leaves the open on focus attr as is.  This allows me
to declare that the popup should not open on focus when clicking
the selected options list (ie removing selected options).

I also updated the selected options list to now trigger an event
when it is clicked instead of just blindly focusing the focus
elem.  This allows me a hook to call `doFocus` appropriately on
the select and in the future on the picker.

@jcredding FYI again.  I want to go ahead and merge this so I can get the multi picker PR up and you are out today.  Check me on this, make any comments, and I'll address them in some follow up.  Thanks man.