### PR TITLE
add in scroll top/left handling methods to base Romo api

### DIFF
--- a/assets/js/romo/base.js
+++ b/assets/js/romo/base.js
@@ -153,6 +153,30 @@ Romo.prototype.offset = function(elem) {
   };
 }
 
+Romo.prototype.scrollTop = function(elem) {
+  return ('scrollTop' in elem) ? elem.scrollTop : elem.pageYOffset;
+}
+
+Romo.prototype.scrollLeft = function(elem) {
+  return ('scrollLeft' in elem) ? elem.scrollLeft : elem.pageXOffset;
+}
+
+Romo.prototype.setScrollTop = function(elem, value) {
+  if ('scrollTop' in elem) {
+    elem.scrollTop = value;
+  } else {
+    elem.scrollTo(elem.scrollX, value);
+  }
+}
+
+Romo.prototype.setScrollLeft = function(elem, value) {
+  if ('scrollLeft' in elem) {
+    elem.scrollLeft = value;
+  } else {
+    elem.scrollTo(value, elem.scrollY);
+  }
+}
+
 // TODO: rework w/o jQuery
 Romo.prototype.getComputedStyle = function(node, styleName) {
   return window.getComputedStyle(node, null).getPropertyValue(styleName);


### PR DESCRIPTION
This is part of getting an adequate jQuery replacement api in
place.  We need these methods to properly get/set the scroll
position of elements.  This was missed in the original api
additions.

Note: the `scrollTop` and `scrollLeft` methods are supported
differently in the browsers.  `scrollTop` seems fairly well
supported.  However, `scrollLeft` seems to only be supported well
in Chrome and Edge.  This is the reason for adding these methods.
If `scrollLeft` was supported like `scrollTop`, I wouldn't add the
methods and just use the native implementations.

See: https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollTop
See: https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollLeft

@jcredding ready for review.