### PR TITLE
fix a bug hitting backpace on selects/pickers

### DIFF
--- a/assets/js/romo/option_list_dropdown.js
+++ b/assets/js/romo/option_list_dropdown.js
@@ -481,10 +481,12 @@ RomoOptionListDropdown.prototype._onElemKeyDown = function(e) {
         return false;
       } else if (this.optionFilterElem !== undefined &&
                  Romo.nonInputTextKeyCodes().indexOf(e.keyCode) === -1 /* Input Text */)  {
+        // don't prevent default on Cmd-* keys (preserve Cmd-R refresh, etc)
         if (e.metaKey === false) {
-          // don't prevent default on Cmd-* keys (preserve Cmd-R refresh, etc)
           e.preventDefault();
-          this.optionFilterElem.val(e.key);
+          if (e.keyCode !== 8) { /* Backspace */
+            this.optionFilterElem.val(e.key);
+          }
           this.romoDropdown.doPopupOpen();
         }
         e.stopPropagation();


### PR DESCRIPTION
Hitting backspace would put the string "Backspace" in the filter
for option list dropdowns (selects/pickers).  This updates to
check for backspace and doesn't add its key to the input but does
open the popup.

@jcredding ready for review.