### PR TITLE
Fix selecting empty values with pickers when they have an initial value

### DIFF
--- a/assets/js/romo/picker.js
+++ b/assets/js/romo/picker.js
@@ -70,11 +70,14 @@ RomoPicker.prototype.doSetValueDatas = function(valueDatas) {
     this._setValuesAndDisplayText(values, '');
     this.romoSelectedOptionsList.doSetItems(datas);
   } else {
-    this._setValuesAndDisplayText(
-      values,
-      (displayTexts[0] || this.elem.data('romo-picker-empty-option-display-text') || '')
+    var displayText = displayTexts[0] ||
+                      this.elem.data('romo-picker-empty-option-display-text') ||
+                      '';
+    this._setValuesAndDisplayText(values, displayText);
+    this.romoOptionListDropdown.doSetSelectedValueAndText(
+      values[0],
+      displayText
     );
-    this.romoOptionListDropdown.doSetSelectedItem(values[0]);
   }
   this._refreshUI();
 }


### PR DESCRIPTION
This fixes an issue with selecting an empty value with a picker
when the picker has an initial value. The problem was the picker
wasn't properly selecting its initial value which caused it to
not see selecting an empty value as a change.

To fix the issue, this reverts back to calling
`doSetSelectedValueAndText` on its option list dropdown instead
of calling `doSetSelectedItem`. The reason this is done is to
avoid the option list dropdown trying to find a selected item
in its dropdown before it sets its current text and value. Since
it's a picker there are no items in its option list dropdown when
its initialized so it can never find a selected item. This would
cause the option list dropdown to set its value and text to empty
strings so when the empty option is selected it wouldn't see it as
a change. By using `doSetSelectedValueAndText` we bypass the
option list dropdown looking at its selected items. This allows
the option list dropdown to properly set its initial value and
text which allows it to see the empty option as a change.

@kellyredding - Ready for review.