### PR TITLE
Fix `Romo.ajax` GET requests with `data`, add to query string

### DIFF
--- a/assets/js/romo/base.js
+++ b/assets/js/romo/base.js
@@ -433,8 +433,19 @@ Romo.prototype.decodeParamMap = [
 // AJAX
 
 Romo.prototype.ajax = function(settings) {
+  var httpMethod = (settings.type || 'GET').toUpperCase();
+  var xhrUrl     = settings.url || window.location.toString();
+  var xhrData    = settings.data ? settings.data : null
+  if (xhrData && httpMethod === 'GET') {
+    var xhrQuery = Romo.param(xhrData);
+    if (xhrQuery !== '') {
+      xhrUrl = (xhrUrl + '&' + xhrQuery).replace(/[&?]{1,2}/, '?');
+    }
+    xhrData = null;
+  }
+
   var xhr = new XMLHttpRequest();
-  xhr.open(settings.type || 'GET', settings.url, true, settings.username, settings.password);
+  xhr.open(httpMethod, xhrUrl, true, settings.username, settings.password);
   if (settings.responseType === 'arraybuffer' || settings.responseType === 'blob') {
     xhr.responseType = settings.responseType;
   }
@@ -458,7 +469,7 @@ Romo.prototype.ajax = function(settings) {
       }
     }
   };
-  xhr.send(settings.data ? settings.data : null);
+  xhr.send(xhrData);
 },
 
 // events


### PR DESCRIPTION
This fixes an issue with the `Romo.ajax` helper making GET
requests with the `data` key set. This is expected to send the
`data` key-values as params to the server but they were being
ignored because they were being added to the body of the request.
Most web servers will ignore the body of GET requests and only
parse the query string for request params. This made it seem like
the `Romo.ajax` was not sending the `data` key-values to the
server.

To fix this, the `Romo.ajax` helper now checks if the request is
a GET request and if it has data key-values. If so, it adds the
key-values to the query string and unsets the data so it's not
passed in the request body. This allows the data key-values to
properly be seen as request params on the server.

Note: This also updates the defaults for the url to use the
current url (`window.location`) if it's not provided. This ensures
we always have a string to append to.

@kellyredding - Ready for review.