### PR TITLE
add base `data` and `setData` methods

### DIFF
--- a/assets/js/romo/base.js
+++ b/assets/js/romo/base.js
@@ -105,6 +105,14 @@ Romo.prototype.setAttr = function(elem, attrName, attrValue) {
   return attrValue;
 }
 
+Romo.prototype.data = function(elem, dataName) {
+  return this._deserializeValue(this.attr(elem, "data-"+dataName));
+}
+
+Romo.prototype.setData = function(elem, dataName, dataValue) {
+  return this.setAttr(elem, "data-"+dataName, String(dataValue));
+}
+
 Romo.prototype.style = function(elem, styleName) {
   return elem.style[styleName];
 }
@@ -610,6 +618,20 @@ Romo.prototype._handlers = {};
 
 Romo.prototype._handlerKey = function(elem, eventName, fn) {
   return 'eid--'+this._el(elem)._romoeid+'--'+eventName+'--fid--'+this._fn(fn)._romofid;
+}
+
+Romo.prototype._deserializeValue = function(value) {
+  try {
+    if (value === "true")      { return true;       } // "true"       => true
+    if (value === "false")     { return false;      } // "false"      => false
+    if (value === "undefined") { return undefined;  } // "undefined"  => undefined
+    if (value === "null")      { return null;       } // "null"       => null
+    if (+value+"" === value)   { return +value;     } // "42.5"       => 42.5
+    if (/^[\[\{]/.test(value)) { JSON.parse(value); } // JSON         => parse if valid
+    return value;                                     // String       => self
+  } catch(e) {
+    return value
+  }
 }
 
 // TODO: rework w/o jQuery


### PR DESCRIPTION
This continues the goal of replacing the jQuery api that Romo
uses with its own vanilla js api.  This adds `data` and `setData`
methods to compliment the `attr` and `setAttr` methods.  The
difference is that the data methods auto prepend `data-` to the
given data names and they serialize/deserialize the values the
get/set. The data methods use the attr methods to read/persist
the values from/to the DOM.

@jcredding ready for review.  The deserialization logic was inspired from Zepto, btw.