### PR TITLE
romoAjax: fix bug with invokes with data

### DIFF
--- a/assets/js/romo/ajax.js
+++ b/assets/js/romo/ajax.js
@@ -41,19 +41,29 @@ RomoAjax.prototype.doBindElem = function() {
   if (this.invokeOn !== undefined) {
     this.elem.on(this.invokeOn, $.proxy(this.onInvoke, this));
   }
-  this.elem.on('romoAjax:triggerInvoke', $.proxy(this.onInvoke, this));
+  this.elem.on('romoAjax:triggerInvoke', $.proxy(this.onTriggerInvoke, this));
 }
 
 RomoAjax.prototype.doUnbindElem = function() {
   if (this.invokeOn !== undefined) {
     this.elem.off(this.invokeOn, $.proxy(this.onInvoke, this));
   }
-  this.elem.off('romoAjax:triggerInvoke', $.proxy(this.onInvoke, this));
+  this.elem.off('romoAjax:triggerInvoke', $.proxy(this.onTriggerInvoke, this));
 }
 
-RomoAjax.prototype.onInvoke = function(e, data) {
+RomoAjax.prototype.onInvoke = function(e) {
   if (e !== undefined) {
     e.preventDefault();
+  }
+
+  if (this.elem.hasClass('disabled') === false) {
+    this.doInvoke();
+  }
+}
+
+RomoAjax.prototype.onTriggerInvoke = function(e, data) {
+  if (e !== undefined) {
+    e.stopPropagation();
   }
 
   if (this.elem.hasClass('disabled') === false) {

--- a/assets/js/romo/picker.js
+++ b/assets/js/romo/picker.js
@@ -277,15 +277,18 @@ RomoPicker.prototype._bindAjax = function() {
 
   this.elem.on('romoAjax:callStart', $.proxy(function(e, data, romoAjax) {
     this.romoOptionListDropdown.elem.trigger('romoOptionListDropdown:triggerFilterIndicatorStart', []);
+    return false;
   }, this));
   this.elem.on('romoAjax:callSuccess', $.proxy(function(e, data, romoAjax) {
     this.filteredOptionItems = data;
     this._setListItems(this.filteredOptionItems.concat(this._buildCustomOptionItems()));
     this.romoOptionListDropdown.elem.trigger('romoOptionListDropdown:triggerFilterIndicatorStop', []);
+    return false;
   }, this));
   this.elem.on('romoAjax:callError', $.proxy(function(e, xhr, romoAjax) {
     this._setListItems(this.defaultOptionItems.concat(this._buildCustomOptionItems()));
     this.romoOptionListDropdown.elem.trigger('romoOptionListDropdown:triggerFilterIndicatorStop', []);
+    return false;
   }, this));
 
   this.elem.romoAjax();


### PR DESCRIPTION
This adds a second event handler, `onTriggerInvoke` that is now
used exculsively with the 'romoAjax:triggerInvoke' event.  This
allows having separate event processing for triggered invokes
vs auto invokes (from a click for example).  Auto invokes never
expect/take data where trigger invokes do.  This fixes a bug
where you use an event that passes unrelated data as an auto
invoke.  Without this, the unrelated data would be interpreted
as invoke data which is not intended.

This also adds `return false` directives to the picker's romo
ajax event handlers.  Since romo ajax components are prone to
being nested, it is a good practice to stop propagation on any
romo ajax events.  This handles that for pickers.

@jcredding ready for review.