### PR TITLE
add base js `Romo.is` method

### DIFF
--- a/assets/js/romo/base.js
+++ b/assets/js/romo/base.js
@@ -23,6 +23,17 @@ Romo.prototype.find = function(parentElem, selector) {
   return this.array(parentElem.querySelectorAll(selector));
 }
 
+Romo.prototype.is = function(elem, selector) {
+  return (
+    elem.matches               ||
+    elem.matchesSelector       ||
+    elem.msMatchesSelector     ||
+    elem.mozMatchesSelector    ||
+    elem.webkitMatchesSelector ||
+    elem.oMatchesSelector
+  ).call(elem, selector);
+};
+
 Romo.prototype.children = function(parentElem) {
   return this.array(parentElem.children);
 }


### PR DESCRIPTION
This is part of prepping to switch off of jQuery and on to Romo's
vanilla js API.  This `is` method emulates jQuery's `is` method
with a polyfill for older browsers.  I pulled this implementation
from: http://youmightnotneedjquery.com/#matches_selector.

@jcredding ready for review.