### PR TITLE
Add `Romo.assign` util, use to merge javascript objects

### DIFF
--- a/assets/js/romo/base.js
+++ b/assets/js/romo/base.js
@@ -575,6 +575,31 @@ Romo.prototype.array = function(collection) {
   return Array.prototype.slice.call(collection);
 }
 
+Romo.prototype.assign = function(target) {
+  if(Object.assign) {
+    return Object.assign.apply(Object, arguments);
+  } else {
+    if (target == null) { // TypeError if undefined or null
+      throw new TypeError('Cannot convert undefined or null to object');
+    }
+    var to = Object(target);
+
+    for (var index = 1; index < arguments.length; index++) {
+      var nextSource = arguments[index];
+
+      if (nextSource != null) { // Skip over if undefined or null
+        for (var nextKey in nextSource) {
+          // Avoid bugs when hasOwnProperty is shadowed
+          if (Object.prototype.hasOwnProperty.call(nextSource, nextKey)) {
+            to[nextKey] = nextSource[nextKey];
+          }
+        }
+      }
+    }
+    return to;
+  }
+}
+
 Romo.prototype.proxy = function(fn, context) {
   var proxyFn    = fn.bind(context);
   proxyFn._romofid = this._fn(fn)._romofid;


### PR DESCRIPTION
This adds a `Romo.assign` util that can be used to merge
javascript objects. This is similar to jquery's `extend` only
it uses the `Object.assign` function if available or it uses
a polyfill if the `Object.assign` function is not available. I
pulled the polyfill implementation from:

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign

This is part of an effort to make Romo no longer dependent on jquery.

@kellyredding - Ready for review.