### PR TITLE
update how get/set attr and get/set data work for consistency

### DIFF
--- a/assets/js/romo/base.js
+++ b/assets/js/romo/base.js
@@ -127,14 +127,18 @@ Romo.prototype.selectPrev = function(elem, selector) {
 // attributes, styles, classes
 
 Romo.prototype.attr = function(elem, attrName) {
-  return elem.getAttribute ? elem.getAttribute(attrName) : undefined;
+  var a = elem.getAttribute(attrName);
+  if (a === null) {
+    return undefined;
+  } else {
+    return a;
+  }
 }
 
 Romo.prototype.setAttr = function(elem, attrName, attrValue) {
-  if (elem.setAttribute) {
-    elem.setAttribute(attrName, attrValue);
-  }
-  return attrValue;
+  var v = String(attrValue);
+  elem.setAttribute(attrName, v);
+  return v;
 }
 
 Romo.prototype.data = function(elem, dataName) {
@@ -142,7 +146,7 @@ Romo.prototype.data = function(elem, dataName) {
 }
 
 Romo.prototype.setData = function(elem, dataName, dataValue) {
-  return this.setAttr(elem, "data-"+dataName, String(dataValue));
+  return this.setAttr(elem, "data-"+dataName, dataValue);
 }
 
 Romo.prototype.style = function(elem, styleName) {
@@ -683,6 +687,7 @@ Romo.prototype._deserializeValue = function(value) {
     if (value === "false")     { return false;      } // "false"      => false
     if (value === "undefined") { return undefined;  } // "undefined"  => undefined
     if (value === "null")      { return null;       } // "null"       => null
+    if (value === null)        { return undefined;  } // null         => undefined
     if (+value+"" === value)   { return +value;     } // "42.5"       => 42.5
     if (/^[\[\{]/.test(value)) { JSON.parse(value); } // JSON         => parse if valid
     return value;                                     // String       => self


### PR DESCRIPTION
This does a few tweaks to these methods to ensure they return
consistent values:

* We prefer `undefined` values over `null`, so the `getAttr`
  now manually checks for `null` return values and returns
  `undefined` instead.
* any `null` values are deserialized to `undefined`
* the set attr/data methods now both force the values to be
  strings and return the string values they set.
* the method checks were removed from get/set attr as there is
  good browser support for both.

There is now only one case where you can get null values out of
these methods: you use `setData` to write a `null` value.  This
gets serialized as `"null"` in `setAttr`.  Then you use `data`
to get that same attr out and `"null"` gets deserialized to
`null`.  Otherwise, any "null-ish" values will be returned as
`undefined`.

This is all part of tweaking Romo's new js API to be as
predictable and consistent as possible.

@jcredding ready for review.