### PR TITLE
Update `RomoCurrencyTextInput` component to not use jquery

### DIFF
--- a/assets/js/romo/currency_text_input.js
+++ b/assets/js/romo/currency_text_input.js
@@ -1,5 +1,5 @@
 var RomoCurrencyTextInput = function(element) {
-  this.elem            = $(element);
+  this.elem            = element;
   this.hiddenInputElem = undefined;
 
   this.defaultIndicatorPosition       = 'left';
@@ -11,7 +11,7 @@ var RomoCurrencyTextInput = function(element) {
   this.doInit();
   this.doBindElem();
 
-  this.elem.trigger('romoCurrencyTextInput:ready', [this]);
+  Romo.trigger(this.elem, 'romoCurrencyTextInput:ready', [this]);
 }
 
 RomoCurrencyTextInput.prototype.doInit = function() {
@@ -22,13 +22,13 @@ RomoCurrencyTextInput.prototype.doBindElem = function() {
   this.doBindIndicatorTextInput();
 
   this.hiddenInputElem = this._getHiddenInputElem();
-  this.elem.before(this.hiddenInputElem);
-  this.elem.attr('name', this._getNewInputName());
+  Romo.before(this.elem, this.hiddenInputElem);
+  Romo.setAttr(this.elem, 'name', this._getNewInputName());
 
-  this.elem.on('change', $.proxy(function(e) {
+  Romo.on(this.elem, 'change', Romo.proxy(function(e) {
     this.doUpdateInputValue();
   }, this));
-  this.elem.on('romoCurrencyTextInput:triggerUpdateInputValue', $.proxy(function(e) {
+  Romo.on(this.elem, 'romoCurrencyTextInput:triggerUpdateInputValue', Romo.proxy(function(e) {
     this.doUpdateInputValue();
   }, this));
 
@@ -36,78 +36,84 @@ RomoCurrencyTextInput.prototype.doBindElem = function() {
 }
 
 RomoCurrencyTextInput.prototype.doUpdateInputValue = function() {
-  var unFormattedValue = this._unFormatCurrencyValue(this.elem.val());
-  this.hiddenInputElem.val(unFormattedValue);
-  if (this.elem.data('romo-currency-text-input-format-for-currency') !== false) {
-    this.elem.val(this._formatCurrencyValue(unFormattedValue));
+  var unFormattedValue = this._unFormatCurrencyValue(this.elem.value);
+  this.hiddenInputElem.value = unFormattedValue;
+  if (Romo.data(this.elem, 'romo-currency-text-input-format-for-currency') !== false) {
+    this.elem.value = this._formatCurrencyValue(unFormattedValue);
   } else {
-    this.elem.val(unFormattedValue);
+    this.elem.value = unFormattedValue;
   }
 }
 
 RomoCurrencyTextInput.prototype.doSetValue = function(value) {
-  this.elem.val(value);
+  this.elem.value = value;
   this.doUpdateInputValue();
 }
 
 RomoCurrencyTextInput.prototype.doBindIndicatorTextInput = function() {
-  this.elem.attr(
-    'data-romo-indicator-text-input-indicator-position',
-    this.elem.data('romo-currency-text-input-indicator-position') || this.defaultIndicatorPosition
+  Romo.setData(
+    this.elem,
+    'romo-indicator-text-input-indicator-position',
+    Romo.data(this.elem, 'romo-currency-text-input-indicator-position') || this.defaultIndicatorPosition
   );
 
-  if (this.elem.data('romo-currency-text-input-indicator') !== undefined) {
-    this.elem.attr(
-      'data-romo-indicator-text-input-indicator',
-      this.elem.data('romo-currency-text-input-indicator')
+  if (Romo.data(this.elem, 'romo-currency-text-input-indicator') !== undefined) {
+    Romo.setData(
+      this.elem,
+      'romo-indicator-text-input-indicator',
+      Romo.data(this.elem, 'romo-currency-text-input-indicator')
     );
   }
-  if (this.elem.data('romo-currency-text-input-indicator-width-px') !== undefined) {
-    this.elem.attr(
-      'data-romo-indicator-text-input-indicator-width-px',
-      this.elem.data('romo-currency-text-input-indicator-width-px')
+  if (Romo.data(this.elem, 'romo-currency-text-input-indicator-width-px') !== undefined) {
+    Romo.setData(
+      this.elem,
+      'romo-indicator-text-input-indicator-width-px',
+      Romo.data(this.elem, 'romo-currency-text-input-indicator-width-px')
     );
   }
-  if (this.elem.data('romo-currency-text-input-indicator-padding-px') !== undefined) {
-    this.elem.attr(
-      'data-romo-indicator-text-input-indicator-padding-px',
-      this.elem.data('romo-currency-text-input-indicator-padding-px')
+  if (Romo.data(this.elem, 'romo-currency-text-input-indicator-padding-px') !== undefined) {
+    Romo.setData(
+      this.elem,
+      'romo-indicator-text-input-indicator-padding-px',
+      Romo.data(this.elem, 'romo-currency-text-input-indicator-padding-px')
     );
   }
-  if (this.elem.data('romo-currency-text-input-elem-display') !== undefined) {
-    this.elem.attr(
-      'data-romo-indicator-text-input-elem-display',
-      this.elem.data('romo-currency-text-input-elem-display')
+  if (Romo.data(this.elem, 'romo-currency-text-input-elem-display') !== undefined) {
+    Romo.setData(
+      this.elem,
+      'romo-indicator-text-input-elem-display',
+      Romo.data(this.elem, 'romo-currency-text-input-elem-display')
     );
   }
-  if (this.elem.data('romo-currency-text-input-btn-group') !== undefined) {
-    this.elem.attr(
-      'data-romo-indicator-text-input-btn-group',
-      this.elem.data('romo-currency-text-input-btn-group')
+  if (Romo.data(this.elem, 'romo-currency-text-input-btn-group') !== undefined) {
+    Romo.setData(
+      this.elem,
+      'romo-indicator-text-input-btn-group',
+      Romo.data(this.elem, 'romo-currency-text-input-btn-group')
     );
   }
 
-  this.elem.on('romoIndicatorTextInput:indicatorClick', $.proxy(function(e) {
-    this.elem.trigger('romoCurrencyTextInput:indicatorClick', []);
+  Romo.on(this.elem, 'romoIndicatorTextInput:indicatorClick', Romo.proxy(function(e) {
+    Romo.trigger(this.elem, 'romoCurrencyTextInput:indicatorClick', []);
   }, this));
 
-  this.elem.on('romoCurrencyTextInput:triggerPlaceIndicator', $.proxy(function(e) {
-    this.elem.trigger('romoIndicatorTextInput:triggerPlaceIndicator', []);
+  Romo.on(this.elem, 'romoCurrencyTextInput:triggerPlaceIndicator', Romo.proxy(function(e) {
+    Romo.trigger(this.elem, 'romoIndicatorTextInput:triggerPlaceIndicator', []);
   }, this));
-  this.elem.on('romoCurrencyTextInput:triggerEnable', $.proxy(function(e) {
-    this.elem.trigger('romoIndicatorTextInput:triggerEnable', []);
+  Romo.on(this.elem, 'romoCurrencyTextInput:triggerEnable', Romo.proxy(function(e) {
+    Romo.trigger(this.elem, 'romoIndicatorTextInput:triggerEnable', []);
   }, this));
-  this.elem.on('romoCurrencyTextInput:triggerDisable', $.proxy(function(e) {
-    this.elem.trigger('romoIndicatorTextInput:triggerDisable', []);
+  Romo.on(this.elem, 'romoCurrencyTextInput:triggerDisable', Romo.proxy(function(e) {
+    Romo.trigger(this.elem, 'romoIndicatorTextInput:triggerDisable', []);
   }, this));
-  this.elem.on('romoCurrencyTextInput:triggerShow', $.proxy(function(e) {
-    this.elem.trigger('romoIndicatorTextInput:triggerShow', []);
+  Romo.on(this.elem, 'romoCurrencyTextInput:triggerShow', Romo.proxy(function(e) {
+    Romo.trigger(this.elem, 'romoIndicatorTextInput:triggerShow', []);
   }, this));
-  this.elem.on('romoCurrencyTextInput:triggerHide', $.proxy(function(e) {
-    this.elem.trigger('romoIndicatorTextInput:triggerHide', []);
+  Romo.on(this.elem, 'romoCurrencyTextInput:triggerHide', Romo.proxy(function(e) {
+    Romo.trigger(this.elem, 'romoIndicatorTextInput:triggerHide', []);
   }, this));
 
-  this.romoIndicatorTextInput = new RomoIndicatorTextInput(this.elem);
+  new RomoIndicatorTextInput(this.elem);
 }
 
 // private
@@ -128,32 +134,37 @@ RomoCurrencyTextInput.prototype._unFormatCurrencyValue = function(inputValue) {
 
 RomoCurrencyTextInput.prototype._getFormatThousandsDelim = function() {
   return (
-    this.elem.data('romo-currency-text-input-format-thousands-delim') ||
+    Romo.data(this.elem, 'romo-currency-text-input-format-thousands-delim') ||
     this.defaultFormatThousandsDelim
   );
 }
 
 RomoCurrencyTextInput.prototype._getFormatDecimalDelim = function() {
   return (
-    this.elem.data('romo-currency-text-input-format-decimal-delim') ||
+    Romo.data(this.elem, 'romo-currency-text-input-format-decimal-delim') ||
     this.defaultFormatDecimalDelim
   );
 }
 
 RomoCurrencyTextInput.prototype._getFormatNumDecimalPlaces = function() {
-  var places = this.elem.data('romo-currency-text-input-format-num-decimal-places');
+  var places = Romo.data(this.elem, 'romo-currency-text-input-format-num-decimal-places');
   return !isNaN(places = Math.abs(places)) ? places : this.defaultFormatNumDecimalPlaces;
 }
 
 RomoCurrencyTextInput.prototype._getHiddenInputElem = function() {
-  return $('<input type="hidden" name="'+this.elem.attr('name')+'" value="'+this.elem.val()+'">');;
+  return Romo.elems(
+    '<input type="hidden" ' +
+           'name="'+Romo.attr(this.elem, 'name')+'" ' +
+           'value="'+this.elem.value+'"' +
+    '>'
+  )[0];
 }
 
 RomoCurrencyTextInput.prototype._getNewInputName = function() {
   return (
-    this.elem.attr('name')+
+    Romo.attr(this.elem, 'name')+
     '-'+
-    (this.elem.data('romo-currency-text-input-name-suffix') || this.defaultInputNameSuffix)
+    (Romo.data(this.elem, 'romo-currency-text-input-name-suffix') || this.defaultInputNameSuffix)
   );
 }
 


### PR DESCRIPTION
This updates the `RomoCurrencyTextInput` component to not use
jquery. This is part of the effort to no longer require jquery to
use Romo. This removes all of the jquery usage within the
`RomoCurrencyTextInput` component except for how it initializes
an indicator text input for its elem. This will be updated when
the indicator text input is updated to no longer use jquery. None
of the other components initialize a currency text input
component.

Note: This didn't update any event names because they are already
prefixed with `romoCurrencyTextInput`.

@kellyredding - Ready for review.