### PR TITLE
Update `RomoDatepicker` component to not use jquery

### DIFF
--- a/assets/js/romo/datepicker.js
+++ b/assets/js/romo/datepicker.js
@@ -1,11 +1,11 @@
 var RomoDatepicker = function(element) {
-  this.elem = $(element);
+  this.elem = element;
 
   this.defaultFormat    = 'yyyy-mm-dd'
   this.defaultPrevClass = undefined;
   this.defaultNextClass = undefined;
   this.itemSelector     = 'TD.romo-datepicker-day:not(.disabled)';
-  this.calTable         = $();
+  this.calTable         = undefined;
   this.date             = undefined;
   this.today            = RomoDate.today();
   this.prevValue        = undefined;
@@ -13,11 +13,11 @@ var RomoDatepicker = function(element) {
   this.doInit();
   this.doBindElem();
   this.doSetFormat();
-  this.doSetDate(this.elem.val());
+  this.doSetDate(this.elem.value);
   this.doBindDropdown();
   this.doBuildUI();
 
-  this.elem.trigger('datepicker:ready', [this]);
+  Romo.trigger(this.elem, 'romoDatepicker:ready', [this]);
 }
 
 RomoDatepicker.prototype.doInit = function() {
@@ -25,156 +25,162 @@ RomoDatepicker.prototype.doInit = function() {
 }
 
 RomoDatepicker.prototype.doBindElem = function() {
-  this.elem.attr('autocomplete', 'off');
-  this.elem.attr('data-romo-indicator-text-input-indicator-position', "right");
+  Romo.setAttr(this.elem, 'autocomplete', 'off');
+  Romo.setData(this.elem, 'romo-indicator-text-input-indicator-position', "right");
 
-  if (this.elem.data('romo-datepicker-indicator') !== undefined) {
-    this.elem.attr('data-romo-indicator-text-input-indicator', this.elem.data('romo-datepicker-indicator'));
+  if (Romo.data(this.elem, 'romo-datepicker-indicator') !== undefined) {
+    Romo.setData(this.elem, 'romo-indicator-text-input-indicator', Romo.data(this.elem, 'romo-datepicker-indicator'));
   }
-  if (this.elem.data('romo-datepicker-indicator-width-px') !== undefined) {
-    this.elem.attr('data-romo-indicator-text-input-indicator-width-px', this.elem.data('romo-datepicker-indicator-width-px'));
+  if (Romo.data(this.elem, 'romo-datepicker-indicator-width-px') !== undefined) {
+    Romo.setData(this.elem, 'romo-indicator-text-input-indicator-width-px', Romo.data(this.elem, 'romo-datepicker-indicator-width-px'));
   }
-  if (this.elem.data('romo-datepicker-btn-group') === true) {
-    this.elem.attr('data-romo-indicator-text-input-btn-group', this.elem.data('romo-datepicker-btn-group'));
+  if (Romo.data(this.elem, 'romo-datepicker-btn-group') === true) {
+    Romo.setData(this.elem, 'data-romo-indicator-text-input-btn-group', Romo.data(this.elem, 'romo-datepicker-btn-group'));
   }
-  if (this.elem.data('romo-datepicker-elem-display') !== undefined) {
-    this.elem.attr('data-romo-indicator-text-input-elem-display', this.elem.data('romo-datepicker-elem-display'));
+  if (Romo.data(this.elem, 'romo-datepicker-elem-display') !== undefined) {
+    Romo.setData(this.elem, 'data-romo-indicator-text-input-elem-display', Romo.data(this.elem, 'romo-datepicker-elem-display'));
   }
 
-  this.romoIndicatorTextInput = new RomoIndicatorTextInput(this.elem);
+  new RomoIndicatorTextInput(this.elem);
 
-  this.prevValue = this.elem.val();
-  this.elem.on('change', $.proxy(function(e) {
-    var newValue = this.elem.val();
-    this.elem.trigger('datepicker:change', [newValue, this.prevValue, this]);
+  this.prevValue = this.elem.value;
+  Romo.on(this.elem, 'change', Romo.proxy(function(e) {
+    var newValue = this.elem.value;
+    Romo.trigger(this.elem, 'romoDatepicker:change', [newValue, this.prevValue, this]);
     this.prevValue = newValue;
   }, this));
 
-  this.elem.on('romoIndicatorTextInput:indicatorClick', $.proxy(function(e) {
+  Romo.on(this.elem, 'romoIndicatorTextInput:indicatorClick', Romo.proxy(function(e) {
     this._clearBlurTimeout();
-    this.elem.trigger('datepicker:triggerPopupOpen');
+    Romo.trigger(this.elem, 'romoDatepicker:triggerPopupOpen');
   }, this));
 
-  this.elem.on('datepicker:triggerEnable', $.proxy(function(e) {
-    this.elem.trigger('romoIndicatorTextInput:triggerEnable', []);
+  Romo.on(this.elem, 'datepicker:triggerEnable', $.proxy(function(e) {
+    Romo.trigger(this.elem, 'romoIndicatorTextInput:triggerEnable', []);
   }, this));
-  this.elem.on('datepicker:triggerDisable', $.proxy(function(e) {
-    this.elem.trigger('romoIndicatorTextInput:triggerDisable', []);
+  Romo.on(this.elem, 'datepicker:triggerDisable', $.proxy(function(e) {
+    Romo.trigger(this.elem, 'romoIndicatorTextInput:triggerDisable', []);
   }, this));
-  this.elem.on('datepicker:triggerShow', $.proxy(function(e) {
-    this.elem.trigger('romoIndicatorTextInput:triggerShow', []);
+  Romo.on(this.elem, 'datepicker:triggerShow', $.proxy(function(e) {
+    Romo.trigger(this.elem, 'romoIndicatorTextInput:triggerShow', []);
   }, this));
-  this.elem.on('datepicker:triggerHide', $.proxy(function(e) {
-    this.elem.trigger('romoIndicatorTextInput:triggerHide', []);
+  Romo.on(this.elem, 'datepicker:triggerHide', $.proxy(function(e) {
+    Romo.trigger(this.elem, 'romoIndicatorTextInput:triggerHide', []);
   }, this));
 
-  this.elem.on('datepicker:triggerSetFormat', $.proxy(function(e) {
+  Romo.on(this.elem, 'romoDatepicker:triggerSetFormat', Romo.proxy(function(e) {
     this.doSetFormat();
   }, this));
-  this.elem.on('datepicker:triggerSetDate', $.proxy(this.onTriggerSetDate, this));
+  Romo.on(this.elem, 'romoDatepicker:triggerSetDate', Romo.proxy(this.onTriggerSetDate, this));
 }
 
 RomoDatepicker.prototype.doSetFormat = function() {
-  this.formatString = this.elem.data('romo-datepicker-format') || this.defaultFormat;
+  this.formatString = Romo.data(this.elem, 'romo-datepicker-format') || this.defaultFormat;
 }
 
 RomoDatepicker.prototype.doSetDate = function(value) {
   this.date = RomoDate.parse(value);
   if (this.date !== undefined) {
-    this.elem.val(RomoDate.format(this.date, this.formatString));
+    this.elem.value = RomoDate.format(this.date, this.formatString);
   } else {
-    this.elem.val(value);
+    this.elem.value = value;
   }
 }
 
 RomoDatepicker.prototype.doBindDropdown = function() {
-  this.elem.attr('data-romo-dropdown-disable-toggle', 'true');
-  if (this.elem.data('romo-dropdown-width') === undefined) {
-    this.elem.attr('data-romo-dropdown-width', 'elem');
+  Romo.setData(this.elem, 'romo-dropdown-disable-toggle', 'true');
+  if (Romo.data(this.elem, 'romo-dropdown-width') === undefined) {
+    Romo.setData(this.elem, 'romo-dropdown-width', 'elem');
   }
-  if (this.elem.width() < 175) {
-    this.elem.attr('data-romo-dropdown-width', '175px');
+  if (parseInt(Romo.css(this.elem, 'width')) < 175) {
+    Romo.setData(this.elem, 'romo-dropdown-width', '175px');
   }
   this.romoDropdown = new RomoDropdown(this.elem);
 
   this.romoDropdown.doSetPopupZIndex(this.elem);
-  this.romoDropdown.bodyElem.addClass('romo-datepicker-calendar');
-  this.romoDropdown.elem.on('romoDropdown:popupOpen', $.proxy(this.onPopupOpen, this));
-  this.romoDropdown.elem.on('romoDropdown:popupClose', $.proxy(this.onPopupClose, this));
-  this.romoDropdown.elem.on('blur', $.proxy(function(e) {
-    this.blurTimeoutId = setTimeout($.proxy(function() {
+  Romo.addClass(this.romoDropdown.bodyElem, 'romo-datepicker-calendar');
+  Romo.on(this.romoDropdown.elem, 'romoDropdown:popupOpen', Romo.proxy(this.onPopupOpen, this));
+  Romo.on(this.romoDropdown.elem, 'romoDropdown:popupClose', Romo.proxy(this.onPopupClose, this));
+  Romo.on(this.romoDropdown.elem, 'blur', Romo.proxy(function(e) {
+    this.blurTimeoutId = setTimeout(Romo.proxy(function() {
       if (this.popupMouseDown !== true) {
-        this.romoDropdown.elem.trigger('romoDropdown:triggerPopupClose', []);
+        Romo.trigger(this.romoDropdown.elem, 'romoDropdown:triggerPopupClose', []);
       }
     }, this), 10);
   }, this));
-  this.romoDropdown.elem.on('keydown', $.proxy(this.onElemKeyDown, this));
+  Romo.on(this.romoDropdown.elem, 'keydown', Romo.proxy(this.onElemKeyDown, this));
 
-  this.romoDropdown.elem.on('romoDropdown:toggle', $.proxy(function(e, romoDropdown) {
-    this.elem.trigger('datepicker:romoDropdown:toggle', [romoDropdown, this]);
+  Romo.on(this.romoDropdown.elem, 'romoDropdown:toggle', Romo.proxy(function(e, romoDropdown) {
+    Romo.trigger(this.elem, 'romoDatepicker:romoDropdown:toggle', [romoDropdown, this]);
   }, this));
-  this.romoDropdown.elem.on('romoDropdown:popupOpen', $.proxy(function(e, romoDropdown) {
-    this.elem.trigger('datepicker:romoDropdown:popupOpen', [romoDropdown, this]);
+  Romo.on(this.romoDropdown.elem, 'romoDropdown:popupOpen', Romo.proxy(function(e, romoDropdown) {
+    Romo.trigger(this.elem, 'romoDatepicker:romoDropdown:popupOpen', [romoDropdown, this]);
   }, this));
-  this.romoDropdown.elem.on('romoDropdown:popupClose', $.proxy(function(e, romoDropdown) {
-    this.elem.trigger('datepicker:romoDropdown:popupClose', [romoDropdown, this]);
+  Romo.on(this.romoDropdown.elem, 'romoDropdown:popupClose', Romo.proxy(function(e, romoDropdown) {
+    Romo.trigger(this.elem, 'romoDatepicker:romoDropdown:popupClose', [romoDropdown, this]);
   }, this));
 
-  this.elem.on('datepicker:triggerToggle', $.proxy(function(e) {
-    this.romoDropdown.elem.trigger('romoDropdown:triggerToggle', []);
+  Romo.on(this.elem, 'romoDatepicker:triggerToggle', Romo.proxy(function(e) {
+    Romo.trigger(this.romoDropdown.elem, 'romoDropdown:triggerToggle', []);
   }, this));
-  this.elem.on('datepicker:triggerPopupOpen', $.proxy(function(e) {
-    this.romoDropdown.elem.trigger('romoDropdown:triggerPopupOpen', []);
+  Romo.on(this.elem, 'romoDatepicker:triggerPopupOpen', Romo.proxy(function(e) {
+    Romo.trigger(this.romoDropdown.elem, 'romoDropdown:triggerPopupOpen', []);
   }, this));
-  this.elem.on('datepicker:triggerPopupClose', $.proxy(function(e) {
-    this.romoDropdown.elem.trigger('romoDropdown:triggerPopupClose', []);
+  Romo.on(this.elem, 'romoDatepicker:triggerPopupClose', Romo.proxy(function(e) {
+    Romo.trigger(this.romoDropdown.elem, 'romoDropdown:triggerPopupClose', []);
   }, this));
 }
 
 RomoDatepicker.prototype.doBuildUI = function() {
   this.calTable = this._buildCalendar();
-  this.romoDropdown.bodyElem.html('');
-  this.romoDropdown.bodyElem.append(this.calTable);
+  Romo.updateHtml(this.romoDropdown.bodyElem, '');
+  Romo.append(this.romoDropdown.bodyElem, this.calTable);
 
-  this.calTable.find('.romo-datepicker-prev').on('click', $.proxy(this.onPrevClick, this));
-  this.calTable.find('.romo-datepicker-next').on('click', $.proxy(this.onNextClick, this));
+  var prevElem = Romo.find(this.calTable, '.romo-datepicker-prev')[0];
+  Romo.on(prevElem, 'click', Romo.proxy(this.onPrevClick, this));
+  var nextElem = Romo.find(this.calTable, '.romo-datepicker-next')[0];
+  Romo.on(nextElem, 'click', Romo.proxy(this.onNextClick, this));
 }
 
 RomoDatepicker.prototype.doRefreshUI = function(date) {
   var rDate = date || this.date || this.today;
   this._refreshCalendar(rDate);
-  this.elem.trigger('datepicker:refresh', [rDate, this]);
+  Romo.trigger(this.elem, 'romoDatepicker:refresh', [rDate, this]);
 
-  this.calTable.find(this.itemSelector).on('mouseenter', $.proxy(this.onItemEnter, this));
-  this.calTable.find(this.itemSelector).on('click', $.proxy(this.onItemClick, this));
+  var itemElems = Romo.find(this.calTable, this.itemSelector);
+  itemElems.forEach(Romo.proxy(function(itemElem) {
+    Romo.on(itemElem, 'mouseenter', Romo.proxy(this.onItemEnter, this));
+    Romo.on(itemElem, 'click',      Romo.proxy(this.onItemClick, this));
+  }, this));
 
-  this.romoDropdown.popupElem.on('mousedown', $.proxy(this.onPopupMouseDown, this));
-  this.romoDropdown.popupElem.on('mouseup',   $.proxy(this.onPopupMouseUp, this));
+  Romo.on(this.romoDropdown.popupElem, 'mousedown', Romo.proxy(this.onPopupMouseDown, this));
+  Romo.on(this.romoDropdown.popupElem, 'mouseup',   Romo.proxy(this.onPopupMouseUp, this));
 }
 
 RomoDatepicker.prototype.doRefreshToPrevMonth = function() {
   var date  = this.refreshDate || this.date || (new Date);
   var pDate = RomoDate.lastDateOfPrevMonth(date);
   this.doRefreshUI(pDate);
-  this.elem.trigger('datepicker:prevRefresh', [pDate, this]);
+  Romo.trigger(this.elem, 'romoDatepicker:prevRefresh', [pDate, this]);
 }
 
 RomoDatepicker.prototype.doRefreshToNextMonth = function() {
   var date  = this.refreshDate || this.date || (new Date);
   var nDate = RomoDate.firstDateOfNextMonth(date);
   this.doRefreshUI(nDate);
-  this.elem.trigger('datepicker:nextRefresh', [nDate, this]);
+  Romo.trigger(this.elem, 'romoDatepicker:nextRefresh', [nDate, this]);
 }
 
 RomoDatepicker.prototype.doSelectHighlightedItem = function() {
-  var newValue  = this.calTable.find('TD.romo-datepicker-highlight').data('romo-datepicker-value');
+  var highlightElem = Romo.find(this.calTable, 'TD.romo-datepicker-highlight')[0];
+  var newValue      = Romo.data(highlightElem, 'romo-datepicker-value');
 
   this.romoDropdown.doPopupClose();
   this.doSetDate(newValue);
   this.elem.focus();
-  this.elem.trigger('datepicker:itemSelected', [newValue, this]);
+  Romo.trigger(this.elem, 'romoDatepicker:itemSelected', [newValue, this]);
   if (newValue !== this.prevValue) {
-    this.elem.trigger('datepicker:newItemSelected', [newValue, this]);
+    Romo.trigger(this.elem, 'romoDatepicker:newItemSelected', [newValue, this]);
   }
   // always publish the item selected events before publishing any change events
   this._triggerSetDateChangeEvent();
@@ -186,7 +192,7 @@ RomoDatepicker.prototype.onTriggerSetDate = function(e, value) {
 }
 
 RomoDatepicker.prototype.onElemKeyDown = function(e) {
-  if (this.elem.hasClass('disabled') === false) {
+  if (Romo.hasClass(this.elem, 'disabled') === false) {
     if (this.romoDropdown.popupOpen()) {
       return true;
     } else {
@@ -203,8 +209,8 @@ RomoDatepicker.prototype.onElemKeyDown = function(e) {
 }
 
 RomoDatepicker.prototype.onPopupOpen = function(e) {
-  if (this.elem.hasClass('disabled') === false) {
-    this.doSetDate(this.elem.val());
+  if (Romo.hasClass(this.elem, 'disabled') === false) {
+    this.doSetDate(this.elem.value);
     this.doRefreshUI();
   }
 }
@@ -218,7 +224,7 @@ RomoDatepicker.prototype.onItemEnter = function(e) {
     e.preventDefault();
     e.stopPropagation();
   }
-  this._highlightItem($(e.target));
+  this._highlightItem(e.target);
 }
 
 RomoDatepicker.prototype.onItemClick = function(e) {
@@ -259,16 +265,16 @@ RomoDatepicker.prototype.onPopupMouseUp = function(e) {
 // private
 
 RomoDatepicker.prototype._show = function(elem) {
-  elem.css('display', '');
+  Romo.show(elem);
 }
 
 RomoDatepicker.prototype._hide = function(elem) {
-  elem.css('display', 'none');
+  Romo.hide(elem);
 }
 
 RomoDatepicker.prototype._triggerSetDateChangeEvent = function() {
-  if (this.elem.val() !== this.prevValue) {
-    this.elem.trigger('change');
+  if (this.elem.value !== this.prevValue) {
+    Romo.trigger(this.elem, 'change');
   }
 }
 
@@ -280,59 +286,69 @@ RomoDatepicker.prototype._clearBlurTimeout = function() {
 }
 
 RomoDatepicker.prototype._refreshCalendar = function(date) {
-  this.calTable.find('.romo-datepicker-title').html(this._buildCalendarTitle(date));
-  this.calTable.find('tbody').empty().append(this._buildCalendarBody(date));
+  var titleElem = Romo.find(this.calTable, '.romo-datepicker-title')[0];
+  titleElem.innerText = this._buildCalendarTitle(date);
+
+  var tableBodyElem = Romo.find(this.calTable, 'tbody')[0];
+  Romo.updateHtml(tableBodyElem.innerHTML, '');
+  var rowElems = this._buildCalendarBodyRows(date);
+  rowElems.forEach(Romo.proxy(function(rowElem) {
+    Romo.append(tableBodyElem, rowElem);
+  }, this));
+
   this.refreshDate = date;
 }
 
 RomoDatepicker.prototype._buildCalendar = function() {
-  var table = $('<table></table>');
-  table.append(this._buildCalendarHeader());
-  table.append($('<tbody></tbody>'));
-  return table;
+  var tableElem = Romo.elems('<table></table>')[0];
+  Romo.append(tableElem, this._buildCalendarHeader());
+  Romo.append(tableElem, Romo.elems('<tbody></tbody>')[0]);
+  return tableElem;
 }
 
 RomoDatepicker.prototype._buildCalendarHeader = function() {
-  var prevClass = this.elem.data('romo-datepicker-prev') || this.defaultPrevClass;
-  var nextClass = this.elem.data('romo-datepicker-next') || this.defaultNextClass;
-  var header = $('<thead></thead');
+  var prevClass = Romo.data(this.elem, 'romo-datepicker-prev') || this.defaultPrevClass;
+  var nextClass = Romo.data(this.elem, 'romo-datepicker-next') || this.defaultNextClass;
+  var headerElem = Romo.elems('<thead></thead')[0];
 
-  var row = $('<tr></tr>');
-  var th = $('<th class="romo-datepicker-prev" title="Previous Month"></th>');
+  var titleRowElem = Romo.elems('<tr></tr>')[0];
+  var thPrevElem   = Romo.elems('<th class="romo-datepicker-prev" title="Previous Month"></th>')[0];
   if (prevClass) {
-    th.append('<i class="'+prevClass+'"></i>');
+    Romo.append(thPrevElem, Romo.elems('<i class="'+prevClass+'"></i>')[0]);
   } else {
-    th.text('<<');
+    thPrevElem.innerText = '<<';
   }
-  row.append(th);
-  row.append($('<th class="romo-datepicker-title" colspan="5"></th>'));
-  var th = $('<th class="romo-datepicker-next" title="Next Month"></th>');
+  Romo.append(titleRowElem, thPrevElem);
+
+  Romo.append(titleRowElem, Romo.elems('<th class="romo-datepicker-title" colspan="5"></th>')[0]);
+
+  var thNextElem = Romo.elems('<th class="romo-datepicker-next" title="Next Month"></th>')[0];
   if (nextClass) {
-    th.append('<i class="'+nextClass+'"></i>');
+    Romo.append(thNextElem, '<i class="'+nextClass+'"></i>');
   } else {
-    th.text('>>');
+    thNextElem.innerText = '>>';
   }
-  row.append(th);
-  header.append(row);
+  Romo.append(titleRowElem, thNextElem);
+  Romo.append(headerElem, titleRowElem);
 
-  row = $('<tr></tr>');
-  row.append($('<th class="romo-datepicker-day">S</th>'));
-  row.append($('<th class="romo-datepicker-day">M</th>'));
-  row.append($('<th class="romo-datepicker-day">T</th>'));
-  row.append($('<th class="romo-datepicker-day">W</th>'));
-  row.append($('<th class="romo-datepicker-day">T</th>'));
-  row.append($('<th class="romo-datepicker-day">F</th>'));
-  row.append($('<th class="romo-datepicker-day">S</th>'));
-  header.append(row);
+  var daysRowElem = Romo.elems('<tr></tr>')[0];
+  Romo.append(daysRowElem, Romo.elems('<th class="romo-datepicker-day">S</th>')[0]);
+  Romo.append(daysRowElem, Romo.elems('<th class="romo-datepicker-day">M</th>')[0]);
+  Romo.append(daysRowElem, Romo.elems('<th class="romo-datepicker-day">T</th>')[0]);
+  Romo.append(daysRowElem, Romo.elems('<th class="romo-datepicker-day">W</th>')[0]);
+  Romo.append(daysRowElem, Romo.elems('<th class="romo-datepicker-day">T</th>')[0]);
+  Romo.append(daysRowElem, Romo.elems('<th class="romo-datepicker-day">F</th>')[0]);
+  Romo.append(daysRowElem, Romo.elems('<th class="romo-datepicker-day">S</th>')[0]);
+  Romo.append(headerElem, daysRowElem);
 
-  return header;
+  return headerElem;
 }
 
 RomoDatepicker.prototype._buildCalendarTitle = function(date) {
   return RomoDate.format(date, 'MM yyyy');
 }
 
-RomoDatepicker.prototype._buildCalendarBody = function(date) {
+RomoDatepicker.prototype._buildCalendarBodyRows = function(date) {
   var html = [];
 
   // prefer showing as many past dates in each month as possible
@@ -386,12 +402,15 @@ RomoDatepicker.prototype._buildCalendarBody = function(date) {
     iDate = RomoDate.next(iDate);
   }
 
-  return $(html.join(''));
+  return Romo.elems(html.join(''));
 }
 
-RomoDatepicker.prototype._highlightItem = function(item) {
-  this.calTable.find('TD.romo-datepicker-highlight').removeClass('romo-datepicker-highlight');
-  item.addClass('romo-datepicker-highlight');
+RomoDatepicker.prototype._highlightItem = function(itemElem) {
+  var highlightElem = Romo.find(this.calTable, 'TD.romo-datepicker-highlight')[0]
+  if(highlightElem) {
+    highlightElem.removeClass('romo-datepicker-highlight');
+  }
+  Romo.addClass(itemElem, 'romo-datepicker-highlight');
 }
 
 Romo.onInitUI(function(elem) {


### PR DESCRIPTION
This updates the `RomoDatepicker` component to not use jquery.
This is part of the effort to no longer require jquery to use
Romo. This removes all of the jquery usage within the
`RomoDatepicker` component except for how it initializes an
indicator text input for its elem. This will be updated when the
indicator text input is updated to no longer use jquery. None of
the other components initialize a datepicker component.

This also updates the event names to be prefixed with
`romoDatepicker` instead of just `datepicker`. This is part of
having everything properly namespaced in romo and ensuring it
should work without issue with other javascript libraries.

@kellyredding - Ready for review.