### PR TITLE
Update `RomoDropdown` component to not use jquery

### DIFF
--- a/assets/js/romo/datepicker.js
+++ b/assets/js/romo/datepicker.js
@@ -95,39 +95,39 @@ RomoDatepicker.prototype.doBindDropdown = function() {
   if (this.elem.width() < 175) {
     this.elem.attr('data-romo-dropdown-width', '175px');
   }
-  this.romoDropdown = this.elem.romoDropdown()[0];
+  this.romoDropdown = new RomoDropdown(this.elem);
 
   this.romoDropdown.doSetPopupZIndex(this.elem);
   this.romoDropdown.bodyElem.addClass('romo-datepicker-calendar');
-  this.romoDropdown.elem.on('dropdown:popupOpen', $.proxy(this.onPopupOpen, this));
-  this.romoDropdown.elem.on('dropdown:popupClose', $.proxy(this.onPopupClose, this));
+  this.romoDropdown.elem.on('romoDropdown:popupOpen', $.proxy(this.onPopupOpen, this));
+  this.romoDropdown.elem.on('romoDropdown:popupClose', $.proxy(this.onPopupClose, this));
   this.romoDropdown.elem.on('blur', $.proxy(function(e) {
     this.blurTimeoutId = setTimeout($.proxy(function() {
       if (this.popupMouseDown !== true) {
-        this.romoDropdown.elem.trigger('dropdown:triggerPopupClose', []);
+        this.romoDropdown.elem.trigger('romoDropdown:triggerPopupClose', []);
       }
     }, this), 10);
   }, this));
   this.romoDropdown.elem.on('keydown', $.proxy(this.onElemKeyDown, this));
 
-  this.romoDropdown.elem.on('dropdown:toggle', $.proxy(function(e, dropdown) {
-    this.elem.trigger('datepicker:dropdown:toggle', [dropdown, this]);
+  this.romoDropdown.elem.on('romoDropdown:toggle', $.proxy(function(e, romoDropdown) {
+    this.elem.trigger('datepicker:romoDropdown:toggle', [romoDropdown, this]);
   }, this));
-  this.romoDropdown.elem.on('dropdown:popupOpen', $.proxy(function(e, dropdown) {
-    this.elem.trigger('datepicker:dropdown:popupOpen', [dropdown, this]);
+  this.romoDropdown.elem.on('romoDropdown:popupOpen', $.proxy(function(e, romoDropdown) {
+    this.elem.trigger('datepicker:romoDropdown:popupOpen', [romoDropdown, this]);
   }, this));
-  this.romoDropdown.elem.on('dropdown:popupClose', $.proxy(function(e, dropdown) {
-    this.elem.trigger('datepicker:dropdown:popupClose', [dropdown, this]);
+  this.romoDropdown.elem.on('romoDropdown:popupClose', $.proxy(function(e, romoDropdown) {
+    this.elem.trigger('datepicker:romoDropdown:popupClose', [romoDropdown, this]);
   }, this));
 
   this.elem.on('datepicker:triggerToggle', $.proxy(function(e) {
-    this.romoDropdown.elem.trigger('dropdown:triggerToggle', []);
+    this.romoDropdown.elem.trigger('romoDropdown:triggerToggle', []);
   }, this));
   this.elem.on('datepicker:triggerPopupOpen', $.proxy(function(e) {
-    this.romoDropdown.elem.trigger('dropdown:triggerPopupOpen', []);
+    this.romoDropdown.elem.trigger('romoDropdown:triggerPopupOpen', []);
   }, this));
   this.elem.on('datepicker:triggerPopupClose', $.proxy(function(e) {
-    this.romoDropdown.elem.trigger('dropdown:triggerPopupClose', []);
+    this.romoDropdown.elem.trigger('romoDropdown:triggerPopupClose', []);
   }, this));
 }
 

--- a/assets/js/romo/dropdown.js
+++ b/assets/js/romo/dropdown.js
@@ -1,25 +1,24 @@
 var RomoDropdown = function(element) {
-  this.elem = $(element);
+  this.elem = element;
   this.doInitPopup();
   this.romoAjax = new RomoAjax(this.elem);
   this.romoAjax.doUnbindElem(); // disable auto invoke on click
 
-  if (this.elem.data('romo-dropdown-disable-click-invoke') !== true) {
-    this.elem.unbind('click');
-    this.elem.on('click', $.proxy(this.onToggleClick, this));
+  if (Romo.data(this.elem, 'romo-dropdown-disable-click-invoke') !== true) {
+    Romo.on(this.elem, 'click', Romo.proxy(this.onToggleClick, this));
   }
-  this.elem.on('dropdown:triggerToggle', $.proxy(this.onToggleClick, this));
-  this.elem.on('dropdown:triggerPopupOpen', $.proxy(this.onPopupOpen, this));
-  this.elem.on('dropdown:triggerPopupClose', $.proxy(this.onPopupClose, this));
-  this.elem.on('romoAjax:callStart', $.proxy(function(e, romoAjax) {
+  Romo.on(this.elem, 'romoDropdown:triggerToggle', Romo.proxy(this.onToggleClick, this));
+  Romo.on(this.elem, 'romoDropdown:triggerPopupOpen', Romo.proxy(this.onPopupOpen, this));
+  Romo.on(this.elem, 'romoDropdown:triggerPopupClose', Romo.proxy(this.onPopupClose, this));
+  Romo.on(this.elem, 'romoAjax:callStart', Romo.proxy(function(e, romoAjax) {
     this.doLoadBodyStart();
     return false;
   }, this));
-  this.elem.on('romoAjax:callSuccess', $.proxy(function(e, data, romoAjax) {
+  Romo.on(this.elem, 'romoAjax:callSuccess', Romo.proxy(function(e, data, romoAjax) {
     this.doLoadBodySuccess(data);
     return false;
   }, this));
-  this.elem.on('romoAjax:callError', $.proxy(function(e, xhr, romoAjax) {
+  Romo.on(this.elem, 'romoAjax:callError', Romo.proxy(function(e, xhr, romoAjax) {
     this.doLoadBodyError(xhr);
     return false;
   }, this));
@@ -29,15 +28,15 @@ var RomoDropdown = function(element) {
   this.doInit();
   this.doInitBody();
 
-  this.elem.trigger('dropdown:ready', [this]);
+  Romo.trigger(this.elem, 'romoDropdown:ready', [this]);
 }
 
 RomoDropdown.prototype.popupOpen = function() {
-  return this.popupElem.hasClass('romo-dropdown-open') === true;
+  return Romo.hasClass(this.popupElem, 'romo-dropdown-open') === true;
 }
 
 RomoDropdown.prototype.popupClosed = function() {
-  return this.popupElem.hasClass('romo-dropdown-open') === false;
+  return Romo.hasClass(this.popupElem, 'romo-dropdown-open') === false;
 }
 
 RomoDropdown.prototype.doInit = function() {
@@ -45,39 +44,39 @@ RomoDropdown.prototype.doInit = function() {
 }
 
 RomoDropdown.prototype.doInitPopup = function() {
-  this.popupElem = $('<div class="romo-dropdown-popup"><div class="romo-dropdown-body"></div></div>');
-  this.popupElem.appendTo(this.elem.closest(this.elem.data('romo-dropdown-append-to-closest') || 'body'));
+  this.popupElem = Romo.elems('<div class="romo-dropdown-popup"><div class="romo-dropdown-body"></div></div>')[0];
+  var popupParentElem = Romo.closest(this.elem, Romo.data(this.elem, 'romo-dropdown-append-to-closest') || 'body');
+  Romo.append(popupParentElem, this.popupElem);
 
-  this.popupElem.on('modal:popupOpen', $.proxy(function(e) {
+  this.popupElem.on('modal:popupOpen', Romo.proxy(function(e) {
     this.doUnBindWindowBodyClick();
     this.doUnBindWindowBodyKeyUp();
     this.doUnBindElemKeyUp();
   }, this));
-  this.popupElem.on('modal:popupClose', $.proxy(function(e) {
+  this.popupElem.on('modal:popupClose', Romo.proxy(function(e) {
     this.doBindWindowBodyClick();
     this.doBindWindowBodyKeyUp();
     this.doBindElemKeyUp();
   }, this));
 
-  this.bodyElem = this.popupElem.find('> .romo-dropdown-body');
-  if (this.elem.data('romo-dropdown-style-class') !== undefined) {
-    this.bodyElem.addClass(this.elem.data('romo-dropdown-style-class'));
+  this.bodyElem = Romo.find(this.popupElem, '> .romo-dropdown-body')[0];
+  if (Romo.data(this.elem, 'romo-dropdown-style-class') !== undefined) {
+    Romo.addClass(this.bodyElem, Romo.data(this.elem, 'romo-dropdown-style-class'));
   }
 
-  this.contentElem = $();
+  this.contentElem = undefined;
 
-  var positionData = this._parsePositionData(this.elem.data('romo-dropdown-position'));
+  var positionData = this._parsePositionData(Romo.data(this.elem, 'romo-dropdown-position'));
   this.popupPosition  = positionData.position  || 'bottom';
   this.popupAlignment = positionData.alignment || 'left';
-  this.popupElem.attr('data-romo-dropdown-position',  this.popupPosition);
-  this.popupElem.attr('data-romo-dropdown-alignment', this.popupAlignment);
-  this.popupElem.attr('data-romo-dropdown-fixed', this.elem.data('romo-dropdown-fixed'));
+  Romo.setData(this.popupElem, 'romo-dropdown-position',  this.popupPosition);
+  Romo.setData(this.popupElem, 'romo-dropdown-alignment', this.popupAlignment);
 
   this.doSetPopupZIndex(this.elem);
 
   // don't propagate click events on the popup elem.  this prevents the popup
   // from closing when clicked (see body click event bind on popup open)
-  this.popupElem.on('click', function(e) {
+  Romo.on(this.popupElem, 'click', function(e) {
     if (e !== undefined) {
       e.stopPropagation();
     }
@@ -88,7 +87,7 @@ RomoDropdown.prototype.doInitPopup = function() {
   // delay adding it b/c other components may `append` generated dropdowns
   // meaning the dropdown is removed and then re-added.  if added immediately
   // the "remove" part will incorrectly remove the popup.
-  setTimeout($.proxy(function() {
+  setTimeout(Romo.proxy(function() {
     Romo.parentChildElems.add(this.elem, [this.popupElem]);
   }, this), 1);
 }
@@ -96,73 +95,63 @@ RomoDropdown.prototype.doInitPopup = function() {
 RomoDropdown.prototype.doInitBody = function() {
   this.doResetBody();
 
-  this.contentElem = this.bodyElem.find('.romo-dropdown-content').last();
-  if (this.contentElem.size() === 0) {
+  var contentElems = Romo.find(this.bodyElem, '.romo-dropdown-content');
+  this.contentElem = contentElems[contentElems.length - 1];
+  if (this.contentElem === undefined) {
     this.contentElem = this.bodyElem;
   }
 
-  this.closeElem = this.popupElem.find('[data-romo-dropdown-close="true"]');
-  this.closeElem.unbind('click');
-  this.closeElem.on('click', $.proxy(this.onPopupClose, this));
+  this.closeElem = Romo.find(this.popupElem, '[data-romo-dropdown-close="true"]')[0];
+  Romo.on(this.closeElem, 'click', Romo.proxy(this.onPopupClose, this));
 
-  this.contentElem.css({
-    'min-height': this.elem.data('romo-dropdown-min-height'),
-    'height':     this.elem.data('romo-dropdown-height'),
-    'overflow-x': this.elem.data('romo-dropdown-overflow-x') || 'auto',
-    'overflow-y': this.elem.data('romo-dropdown-overflow-y') || 'auto'
-  });
+  Romo.setStyle(this.contentElem, 'min-height', Romo.data(this.elem, 'romo-dropdown-min-height'));
+  Romo.setStyle(this.contentElem, 'height',     Romo.data(this.elem, 'romo-dropdown-height'));
+  Romo.setStyle(this.contentElem, 'overflow-x', Romo.data(this.elem, 'romo-dropdown-overflow-x') || 'auto');
+  Romo.setStyle(this.contentElem, 'overflow-y', Romo.data(this.elem, 'romo-dropdown-overflow-y') || 'auto');
 
-  if (this.elem.data('romo-dropdown-max-height') === undefined) {
-    this.elem.attr('data-romo-dropdown-max-height', 'detect');
+  if (Romo.data(this.elem, 'romo-dropdown-max-height') === undefined) {
+    Romo.setData(this.elem, 'romo-dropdown-max-height', 'detect');
   }
-  if (this.elem.data('romo-dropdown-max-height') !== 'detect') {
-    this.contentElem.css({
-      'max-height': this.elem.data('romo-dropdown-max-height')
-    });
+  if (Romo.data(this.elem, 'romo-dropdown-max-height') !== 'detect') {
+    Romo.setStyle(this.contentElem, 'max-height', Romo.data(this.elem, 'romo-dropdown-max-height'));
   }
 
-  if (this.elem.data('romo-dropdown-width') === 'elem') {
-    this.popupElem.css({
-      'width': this.elem.css('width')
-    });
+  if (Romo.data(this.elem, 'romo-dropdown-width') === 'elem') {
+    Romo.setStyle(this.popupElem, 'width', Romo.css(this.elem, 'width'));
   } else {
-    this.contentElem.css({
-      'min-width':  this.elem.data('romo-dropdown-min-width'),
-      'max-width':  this.elem.data('romo-dropdown-max-width'),
-      'width':      this.elem.data('romo-dropdown-width')
-    });
+    Romo.setStyle(this.contentElem, 'min-width', Romo.data(this.elem, 'romo-dropdown-min-width'));
+    Romo.setStyle(this.contentElem, 'max-width', Romo.data(this.elem, 'romo-dropdown-max-width'));
+    Romo.setStyle(this.contentElem, 'width',     Romo.data(this.elem, 'romo-dropdown-width'));
   }
 }
 
 RomoDropdown.prototype.doResetBody = function() {
-  this.contentElem.css({
-    'min-width':  '',
-    'max-width':  '',
-    'width':      '',
-    'min-height': '',
-    'max-height': '',
-    'height':     '',
-    'overflow-x': '',
-    'overflow-y': ''
-  });
+  Romo.setStyle(this.contentElem, 'min-width',  '');
+  Romo.setStyle(this.contentElem, 'max-width',  '');
+  Romo.setStyle(this.contentElem, 'width',      '');
+  Romo.setStyle(this.contentElem, 'min-height', '');
+  Romo.setStyle(this.contentElem, 'max-height', '');
+  Romo.setStyle(this.contentElem, 'height',     '');
+  Romo.setStyle(this.contentElem, 'overflow-x', '');
+  Romo.setStyle(this.contentElem, 'overflow-y', '');
 }
 
 RomoDropdown.prototype.doLoadBodyStart = function() {
-  this.bodyElem.html('');
+  this.bodyElem.innerHTML = '';
   this.doInitBody();
   this.doPlacePopupElem();
-  this.elem.trigger('dropdown:loadBodyStart', [this]);
+  Romo.trigger(this.elem, 'romoDropdown:loadBodyStart', [this]);
 }
 
 RomoDropdown.prototype.doLoadBodySuccess = function(data) {
-  Romo.initHtml(this.bodyElem, data);
+  Romo.initUpdateHtml(this.bodyElem, data);
   this.doInitBody();
   this.doPlacePopupElem();
-  this.elem.trigger('dropdown:loadBodySuccess', [data, this]);
+  Romo.trigger(this.elem, 'romoDropdown:loadBodySuccess', [data, this]);
 }
 
 RomoDropdown.prototype.doLoadBodyError = function(xhr) {
-  this.elem.trigger('dropdown:loadBodyError', [xhr, this]);
+  Romo.trigger(this.elem, 'romoDropdown:loadBodyError', [xhr, this]);
 }
 
 RomoDropdown.prototype.onToggleClick = function(e) {
@@ -170,8 +159,8 @@ RomoDropdown.prototype.onToggleClick = function(e) {
     e.preventDefault();
   }
 
-  if (this.elem.hasClass('disabled') === false &&
-      this.elem.data('romo-dropdown-disable-toggle') !== true) {
+  if (Romo.hasClass(this.elem, 'disabled') === false &&
+      Romo.data(this.elem, 'romo-dropdown-disable-toggle') !== true) {
     this.doToggle();
     return true;
   }
@@ -180,15 +169,15 @@ RomoDropdown.prototype.onToggleClick = function(e) {
 
 RomoDropdown.prototype.doToggle = function() {
   if (this.popupOpen()) {
-    setTimeout($.proxy(function() {
+    setTimeout(Romo.proxy(function() {
       this.doPopupClose();
     }, this), 100);
   } else {
-    setTimeout($.proxy(function() {
+    setTimeout(Romo.proxy(function() {
       this.doPopupOpen();
     }, this), 100);
   }
-  this.elem.trigger('dropdown:toggle', [this]);
+  Romo.trigger(this.elem, 'romoDropdown:toggle', [this]);
 }
 
 RomoDropdown.prototype.onPopupOpen = function(e) {
@@ -196,21 +185,22 @@ RomoDropdown.prototype.onPopupOpen = function(e) {
     e.preventDefault();
   }
 
-  if (this.elem.hasClass('disabled') === false && this.popupClosed()) {
-    setTimeout($.proxy(function() {
+  if (Romo.hasClass(this.elem, 'disabled') === false && this.popupClosed()) {
+    setTimeout(Romo.proxy(function() {
       this.doPopupOpen();
     }, this), 100);
   }
 }
 
 RomoDropdown.prototype.doPopupOpen = function() {
-  if (this.elem.data('romo-dropdown-content-elem') !== undefined) {
-    this.doLoadBodySuccess($(this.elem.data('romo-dropdown-content-elem')).html())
+  if (Romo.data(this.elem, 'romo-dropdown-content-elem') !== undefined) {
+    var contentElem = Romo.elems(Romo.data(this.elem, 'romo-dropdown-content-elem'))[0];
+    this.doLoadBodySuccess(contentElem.outerHTML);
   } else {
     this.romoAjax.doInvoke();
   }
 
-  this.popupElem.addClass('romo-dropdown-open');
+  Romo.addClass(this.popupElem, 'romo-dropdown-open');
   this.doPlacePopupElem();
 
   // bind an event to close the popup when clicking away from the
@@ -218,7 +208,7 @@ RomoDropdown.prototype.doPopupOpen = function() {
   // click event to propagate.  If no timeout, we'll bind this
   // event, then the toggle click will propagate which will call
   // this event and immediately close the popup.
-  setTimeout($.proxy(function() {
+  setTimeout(Romo.proxy(function() {
     this.doBindWindowBodyClick();
   }, this), 100);
 
@@ -226,9 +216,9 @@ RomoDropdown.prototype.doPopupOpen = function() {
   this.doBindWindowBodyKeyUp();
 
   // bind window resizes reposition dropdown
-  $(window).on('resize', $.proxy(this.onResizeWindow, this));
+  Romo.on(window, 'resize', Romo.proxy(this.onResizeWindow, this));
 
-  this.elem.trigger('dropdown:popupOpen', [this]);
+  Romo.trigger(this.elem, 'romoDropdown:popupOpen', [this]);
 }
 
 RomoDropdown.prototype.onPopupClose = function(e) {
@@ -236,15 +226,15 @@ RomoDropdown.prototype.onPopupClose = function(e) {
     e.preventDefault();
   }
 
-  if (this.elem.hasClass('disabled') === false && this.popupOpen()) {
-    setTimeout($.proxy(function() {
+  if (Romo.hasClass(this.elem, 'disabled') === false && this.popupOpen()) {
+    setTimeout(Romo.proxy(function() {
       this.doPopupClose();
     }, this), 100);
   }
 }
 
 RomoDropdown.prototype.doPopupClose = function() {
-  this.popupElem.removeClass('romo-dropdown-open');
+  Romo.removeClass(this.popupElem, 'romo-dropdown-open');
 
   // unbind any event to close the popup when clicking away from it
   this.doUnBindWindowBodyClick();
@@ -253,32 +243,32 @@ RomoDropdown.prototype.doPopupClose = function() {
   this.doUnBindWindowBodyKeyUp();
 
   // unbind window resizes reposition dropdown
-  $(window).off('resize', $.proxy(this.onResizeWindow, this));
+  Romo.off(window, 'resize', Romo.proxy(this.onResizeWindow, this));
 
   // clear the content elem markup if configured to
-  if (this.elem.data('romo-dropdown-clear-content') === true) {
-    this.contentElem.html('');
+  if (Romo.data(this.elem, 'romo-dropdown-clear-content') === true) {
+    this.contentElem.innerHTML = '';
   }
 
-  this.elem.trigger('dropdown:popupClose', [this]);
+  Romo.trigger(this.elem, 'romoDropdown:popupClose', [this]);
 }
 
 RomoDropdown.prototype.doBindElemKeyUp = function() {
-  this.elem.on('keyup', $.proxy(this.onElemKeyUp, this));
-  this.popupElem.on('keyup', $.proxy(this.onElemKeyUp, this));
+  Romo.on(this.elem, 'keyup', Romo.proxy(this.onElemKeyUp, this));
+  Romo.on(this.popupElem, 'keyup', Romo.proxy(this.onElemKeyUp, this));
 }
 
 RomoDropdown.prototype.doUnBindElemKeyUp = function() {
-  this.elem.off('keyup', $.proxy(this.onElemKeyUp, this));
-  this.popupElem.off('keyup', $.proxy(this.onElemKeyUp, this));
+  Romo.off(this.elem, 'keyup', Romo.proxy(this.onElemKeyUp, this));
+  Romo.off(this.popupElem, 'keyup', Romo.proxy(this.onElemKeyUp, this));
 }
 
 RomoDropdown.prototype.onElemKeyUp = function(e) {
-  if (this.elem.hasClass('disabled') === false) {
+  if (Romo.hasClass(this.elem, 'disabled') === false) {
     if (this.popupOpen()) {
       if(e.keyCode === 27 /* Esc */ ) {
         this.doPopupClose();
-        this.elem.trigger('dropdown:popupClosedByEsc', [this]);
+        Romo.trigger(this.elem, 'romoDropdown:popupClosedByEsc', [this]);
         return false;
       } else {
         return true;
@@ -291,38 +281,49 @@ RomoDropdown.prototype.onElemKeyUp = function(e) {
 }
 
 RomoDropdown.prototype.doBindWindowBodyClick = function() {
-  $('body').on('click', $.proxy(this.onWindowBodyClick, this));
-  $('body').on('modal:mousemove', $.proxy(this.onWindowBodyClick, this));
+  var bodyElem = Romo.f('body')[0];
+  Romo.on(bodyElem, 'click', Romo.proxy(this.onWindowBodyClick, this));
+  Romo.on(bodyElem, 'modal:mousemove', Romo.proxy(this.onWindowBodyClick, this));
 }
 
 RomoDropdown.prototype.doUnBindWindowBodyClick = function() {
-  $('body').off('click', $.proxy(this.onWindowBodyClick, this));
-  $('body').off('modal:mousemove', $.proxy(this.onWindowBodyClick, this));
+  var bodyElem = Romo.f('body')[0];
+  Romo.off(bodyElem, 'click', Romo.proxy(this.onWindowBodyClick, this));
+  Romo.off(bodyElem, 'modal:mousemove', Romo.proxy(this.onWindowBodyClick, this));
 }
 
 RomoDropdown.prototype.onWindowBodyClick = function(e) {
   // if not clicked on the popup elem or the elem
-  var target = $(e.target);
-  if (e !== undefined &&
-      target.parents('.romo-dropdown-popup').size() === 0 &&
-      target.closest(this.elem).size() === 0) {
-    this.doPopupClose();
+  if (e !== undefined) {
+    var parentPopupElems = Romo.parents(e.target, '.romo-dropdown-popup');
+
+    var elemIsParentOfTarget = false;
+    Romo.parents(e.target).forEach(Romo.proxy(function(parentElem) {
+      if(elemIsParentOfTarget){ return; }
+      elemIsParentOfTarget = parentElem == this.elem;
+    }, this));
+
+    if (parentPopupElems.length === 0 && elemIsParentOfTarget === false) {
+      this.doPopupClose();
+    }
   }
   return true;
 }
 
 RomoDropdown.prototype.doBindWindowBodyKeyUp = function() {
-  $('body').on('keyup', $.proxy(this.onWindowBodyKeyUp, this));
+  var bodyElem = Romo.f('body')[0];
+  Romo.on(bodyElem, 'keyup', Romo.proxy(this.onWindowBodyKeyUp, this));
 }
 
 RomoDropdown.prototype.doUnBindWindowBodyKeyUp = function() {
-  $('body').off('keyup', $.proxy(this.onWindowBodyKeyUp, this));
+  var bodyElem = Romo.f('body')[0];
+  Romo.off(bodyElem, 'keyup', Romo.proxy(this.onWindowBodyKeyUp, this));
 }
 
 RomoDropdown.prototype.onWindowBodyKeyUp = function(e) {
   if (e.keyCode === 27 /* Esc */) {
     this.doPopupClose();
-    this.elem.trigger('dropdown:popupClosedByEsc', [this]);
+    Romo.trigger(this.elem, 'romoDropdown:popupClosedByEsc', [this]);
   }
   return true;
 }
@@ -333,20 +334,20 @@ RomoDropdown.prototype.onResizeWindow = function(e) {
 }
 
 RomoDropdown.prototype.doPlacePopupElem = function() {
-  if (this.elem.parents('.romo-modal-popup').size() !== 0) {
-    this.popupElem.css({'position': 'fixed'});
+  if (Romo.parents(this.elem, '.romo-modal-popup').length !== 0) {
+    Romo.setStyle(this.popupElem, 'position', 'fixed');
   }
 
-  var pos = $.extend({}, this.elem[0].getBoundingClientRect(), this.elem.offset());
-  var w = this.popupElem[0].offsetWidth;
-  var h = this.popupElem[0].offsetHeight;
+  var pos = Romo.assign({}, this.elem.getBoundingClientRect(), Romo.offset(this.elem));
+  var w = this.popupElem.offsetWidth;
+  var h = this.popupElem.offsetHeight;
   var offset = {};
 
-  var configHeight = this.elem.data('romo-dropdown-height') || this.elem.data('romo-dropdown-max-height');
+  var configHeight = Romo.data(this.elem, 'romo-dropdown-height') || Romo.data(this.elem, 'romo-dropdown-max-height');
   var configPosition = this.popupPosition;
 
   if (configHeight === 'detect') {
-    var popupHeight = this.popupElem.height();
+    var popupHeight = parseInt(Romo.css(this.popupElem, 'height'));
     var topAvailHeight = this._getPopupMaxAvailableHeight('top');
     var bottomAvailHeight = this._getPopupMaxAvailableHeight('bottom');
 
@@ -363,8 +364,8 @@ RomoDropdown.prototype.doPlacePopupElem = function() {
 
     // remove any height difference between the popup and content elems
     // assumes popup height always greater than or equal to content height
-    configHeight = configHeight - (h - this.contentElem[0].offsetHeight);
-    this.contentElem.css({'max-height': configHeight.toString() + 'px'});
+    configHeight = configHeight - (h - this.contentElem.offsetHeight);
+    Romo.setStyle(this.contentElem, 'max-height', configHeight.toString() + 'px');
   }
 
   if(h > configHeight) {
@@ -374,32 +375,29 @@ RomoDropdown.prototype.doPlacePopupElem = function() {
   switch (configPosition) {
     case 'top':
       var pad = 2;
-      $.extend(offset, { top: pos.top - h - pad });
+      Romo.assign(offset, { top: pos.top - h - pad });
       break;
     case 'bottom':
       var pad = 2;
-      $.extend(offset, { top: pos.top + pos.height + pad });
+      Romo.assign(offset, { top: pos.top + pos.height + pad });
       break;
   }
   switch (this.popupAlignment) {
     case 'left':
-      $.extend(offset, { left: pos.left });
+      Romo.assign(offset, { left: pos.left });
       break;
     case 'right':
-      $.extend(offset, { left: pos.left + pos.width - w });
+      Romo.assign(offset, { left: pos.left + pos.width - w });
       break;
   }
 
-  $.extend(offset, {
-    top:  this._roundPosOffsetVal(offset['top']),
-    left: this._roundPosOffsetVal(offset['left'])
-  });
-  this.popupElem.offset(offset);
+  Romo.setStyle(this.popupElem, 'top',  this._roundPosOffsetVal(offset.top));
+  Romo.setStyle(this.popupElem, 'left', this._roundPosOffsetVal(offset.left));
 }
 
 RomoDropdown.prototype.doSetPopupZIndex = function(relativeElem) {
   var relativeZIndex = Romo.parseZIndex(relativeElem);
-  this.popupElem.css({'z-index': relativeZIndex + 1200}); // see z-index.css
+  Romo.setStyle(this.popupElem, 'z-index', relativeZIndex + 1200); // see z-index.css
 }
 
 RomoDropdown.prototype._parsePositionData = function(posString) {
@@ -412,12 +410,12 @@ RomoDropdown.prototype._getPopupMaxAvailableHeight = function(position) {
 
   switch (position) {
     case 'top':
-      var elemTop = this.elem[0].getBoundingClientRect().top;
+      var elemTop = this.elem.getBoundingClientRect().top;
       maxHeight = elemTop - this._getPopupMaxHeightDetectPad(position);
       break;
     case 'bottom':
-      var elemBottom = this.elem[0].getBoundingClientRect().bottom;
-      maxHeight = $(window).height() - elemBottom - this._getPopupMaxHeightDetectPad(position);
+      var elemBottom = this.elem.getBoundingClientRect().bottom;
+      maxHeight = window.innerHeight - elemBottom - this._getPopupMaxHeightDetectPad(position);
       break;
   }
 
@@ -425,7 +423,7 @@ RomoDropdown.prototype._getPopupMaxAvailableHeight = function(position) {
 }
 
 RomoDropdown.prototype._getPopupMaxHeightDetectPad = function(position) {
-  return this.elem.data('romo-dropdown-max-height-detect-pad-'+position) || this.elem.data('romo-dropdown-max-height-detect-pad') || 10;
+  return Romo.data(this.elem, 'romo-dropdown-max-height-detect-pad-'+position) || Romo.data(this.elem, 'romo-dropdown-max-height-detect-pad') || 10;
 }
 
 RomoDropdown.prototype._roundPosOffsetVal = function(value) {

--- a/assets/js/romo/dropdown_form.js
+++ b/assets/js/romo/dropdown_form.js
@@ -1,7 +1,7 @@
 var RomoDropdownForm = function(element) {
   this.elem = $(element);
 
-  this.dropdown = this.elem.romoDropdown()[0];
+  this.romoDropdown = new RomoDropdown(this.elem);
   this.doBindDropdown();
 
   this.form = undefined;
@@ -11,7 +11,7 @@ var RomoDropdownForm = function(element) {
     }
   }, this));
   this.doBindForm();
-  this.elem.on('dropdown:loadBodySuccess', $.proxy(function(e, data, dropdown) {
+  this.elem.on('romoDropdown:loadBodySuccess', $.proxy(function(e, data, romoDropdown) {
     this.doBindForm();
     this.elem.trigger('dropdownForm:formReady', [this.form, this]);
   }, this));
@@ -29,34 +29,34 @@ if (this.elem.data('romo-dropdown-clear-content') === undefined) {
     this.elem.attr('data-romo-dropdown-clear-content', 'true');
   }
 
-  this.elem.on('dropdown:ready', $.proxy(function(e, dropdown) {
-    this.elem.trigger('dropdownForm:dropdown:ready', [dropdown, this]);
+  this.elem.on('romoDropdown:ready', $.proxy(function(e, romoDropdown) {
+    this.elem.trigger('dropdownForm:romoDropdown:ready', [romoDropdown, this]);
   }, this));
-  this.elem.on('dropdown:toggle', $.proxy(function(e, dropdown) {
-    this.elem.trigger('dropdownForm:dropdown:toggle', [dropdown, this]);
+  this.elem.on('romoDropdown:toggle', $.proxy(function(e, romoDropdown) {
+    this.elem.trigger('dropdownForm:romoDropdown:toggle', [romoDropdown, this]);
   }, this));
-  this.elem.on('dropdown:popupOpen', $.proxy(function(e, dropdown) {
-    this.elem.trigger('dropdownForm:dropdown:popupOpen', [dropdown, this]);
+  this.elem.on('romoDropdown:popupOpen', $.proxy(function(e, romoDropdown) {
+    this.elem.trigger('dropdownForm:romoDropdown:popupOpen', [romoDropdown, this]);
   }, this));
-  this.elem.on('dropdown:popupClose', $.proxy(function(e, dropdown) {
-    this.elem.trigger('dropdownForm:dropdown:popupClose', [dropdown, this]);
+  this.elem.on('romoDropdown:popupClose', $.proxy(function(e, romoDropdown) {
+    this.elem.trigger('dropdownForm:romoDropdown:popupClose', [romoDropdown, this]);
   }, this));
-  this.elem.on('dropdown:loadBodyStart', $.proxy(function(e, dropdown) {
-    this.elem.trigger('dropdownForm:dropdown:loadBodyStart', [dropdown, this]);
+  this.elem.on('romoDropdown:loadBodyStart', $.proxy(function(e, romoDropdown) {
+    this.elem.trigger('dropdownForm:romoDropdown:loadBodyStart', [romoDropdown, this]);
   }, this));
-  this.elem.on('dropdown:loadBodySuccess', $.proxy(function(e, data, dropdown) {
-    this.elem.trigger('dropdownForm:dropdown:loadBodySuccess', [data, dropdown, this]);
+  this.elem.on('romoDropdown:loadBodySuccess', $.proxy(function(e, data, romoDropdown) {
+    this.elem.trigger('dropdownForm:romoDropdown:loadBodySuccess', [data, romoDropdown, this]);
   }, this));
-  this.elem.on('dropdown:loadBodyError', $.proxy(function(e, xhr, dropdown) {
-    this.elem.trigger('dropdownForm:dropdown:loadBodyError', [xhr, dropdown, this]);
+  this.elem.on('romoDropdown:loadBodyError', $.proxy(function(e, xhr, romoDropdown) {
+    this.elem.trigger('dropdownForm:romoDropdown:loadBodyError', [xhr, romoDropdown, this]);
   }, this));
-  this.elem.on('dropdown:dismiss', $.proxy(function(e, dropdown) {
-    this.elem.trigger('dropdownForm:dropdown:dismiss', [dropdown, this]);
+  this.elem.on('romoDropdown:dismiss', $.proxy(function(e, romoDropdown) {
+    this.elem.trigger('dropdownForm:romoDropdown:dismiss', [romoDropdown, this]);
   }, this));
 }
 
 RomoDropdownForm.prototype.doBindForm = function() {
-  var formElem = this.dropdown.popupElem.find('[data-romo-form-auto="dropdownForm"]');
+  var formElem = this.romoDropdown.popupElem.find('[data-romo-form-auto="dropdownForm"]');
 
   formElem.on('form:clearMsgs', $.proxy(function(e, form) {
     this.elem.trigger('dropdownForm:form:clearMsgs', [form, this]);
@@ -86,8 +86,8 @@ RomoDropdownForm.prototype.doBindForm = function() {
     this.elem.trigger('dropdownForm:form:browserSubmit', [form, this]);
   }, this));
 
-  var submitElement = this.dropdown.popupElem.find('[data-romo-form-submit]')[0];
-  var indicatorElements = this.dropdown.popupElem.find('[data-romo-indicator-auto="true"]');
+  var submitElement = this.romoDropdown.popupElem.find('[data-romo-form-submit]')[0];
+  var indicatorElements = this.romoDropdown.popupElem.find('[data-romo-indicator-auto="true"]');
   this.form = formElem.romoForm(submitElement, indicatorElements)[0];
 }
 

--- a/assets/js/romo/option_list_dropdown.js
+++ b/assets/js/romo/option_list_dropdown.js
@@ -139,17 +139,17 @@ RomoOptionListDropdown.prototype.doSetListItems = function(itemsList) {
 
 RomoOptionListDropdown.prototype._bindElem = function() {
   this.elem.on('keydown',             $.proxy(this._onElemKeyDown, this));
-  this.elem.on('dropdown:popupOpen',  $.proxy(this._onPopupOpen,   this));
-  this.elem.on('dropdown:popupClose', $.proxy(this._onPopupClose,  this));
+  this.elem.on('romoDropdown:popupOpen',  $.proxy(this._onPopupOpen,   this));
+  this.elem.on('romoDropdown:popupClose', $.proxy(this._onPopupClose,  this));
 
-  this.elem.on('dropdown:toggle', $.proxy(function(e, dropdown) {
-    this.elem.trigger('romoOptionListDropdown:dropdown:toggle', [dropdown, this]);
+  this.elem.on('romoDropdown:toggle', $.proxy(function(e, romoDropdown) {
+    this.elem.trigger('romoOptionListDropdown:romoDropdown:toggle', [romoDropdown, this]);
   }, this));
-  this.elem.on('dropdown:popupOpen', $.proxy(function(e, dropdown) {
-    this.elem.trigger('romoOptionListDropdown:dropdown:popupOpen', [dropdown, this]);
+  this.elem.on('romoDropdown:popupOpen', $.proxy(function(e, romoDropdown) {
+    this.elem.trigger('romoOptionListDropdown:romoDropdown:popupOpen', [romoDropdown, this]);
   }, this));
-  this.elem.on('dropdown:popupClose', $.proxy(function(e, dropdown) {
-    this.elem.trigger('romoOptionListDropdown:dropdown:popupClose', [dropdown, this]);
+  this.elem.on('romoDropdown:popupClose', $.proxy(function(e, romoDropdown) {
+    this.elem.trigger('romoOptionListDropdown:romoDropdown:popupClose', [romoDropdown, this]);
   }, this));
 
   this.elem.on('romoOptionListDropdown:triggerListOptionsUpdate', $.proxy(function(e, highlightOptionElem) {
@@ -157,13 +157,13 @@ RomoOptionListDropdown.prototype._bindElem = function() {
   }, this));
 
   this.elem.on('romoOptionListDropdown:triggerToggle', $.proxy(function(e) {
-    this.elem.trigger('dropdown:triggerToggle', []);
+    this.elem.trigger('romoDropdown:triggerToggle', []);
   }, this));
   this.elem.on('romoOptionListDropdown:triggerPopupOpen', $.proxy(function(e) {
-    this.elem.trigger('dropdown:triggerPopupOpen', []);
+    this.elem.trigger('romoDropdown:triggerPopupOpen', []);
   }, this));
   this.elem.on('romoOptionListDropdown:triggerPopupClose', $.proxy(function(e) {
-    this.elem.trigger('dropdown:triggerPopupClose', []);
+    this.elem.trigger('romoDropdown:triggerPopupClose', []);
   }, this));
 
   this.elem.on('romoOptionListDropdown:triggerFilterIndicatorStart', $.proxy(function(e) {
@@ -176,7 +176,7 @@ RomoOptionListDropdown.prototype._bindElem = function() {
     this.optionFilterElem.trigger('indicatorTextInput:triggerIndicatorStop', []);
   }, this));
 
-  this.romoDropdown = this.elem.romoDropdown()[0];
+  this.romoDropdown = new RomoDropdown(this.elem);
   this.romoDropdown.doSetPopupZIndex(this.elem);
 
   this.romoDropdown.popupElem.on('keydown',   $.proxy(this._onElemKeyDown,    this));
@@ -280,7 +280,7 @@ RomoOptionListDropdown.prototype._bindDropdownOptionFilter = function() {
     this.romoDropdown.elem.removeClass(this.focusStyleClass);
 
     if (this.openOnFocus === true) {
-      this.romoDropdown.elem.trigger('dropdown:triggerPopupOpen', []);
+      this.romoDropdown.elem.trigger('romoDropdown:triggerPopupOpen', []);
     } else {
       this.openOnFocus = this.elem.data('romo-option-list-dropdown-open-on-focus');
     }
@@ -294,7 +294,7 @@ RomoOptionListDropdown.prototype._bindDropdownOptionFilter = function() {
     this.romoDropdown.elem.removeClass(this.focusStyleClass);
     this.blurTimeoutId = setTimeout($.proxy(function() {
       if (this.popupMouseDown !== true && this.optionFilterFocused !== true) {
-        this.romoDropdown.elem.trigger('dropdown:triggerPopupClose', []);
+        this.romoDropdown.elem.trigger('romoDropdown:triggerPopupClose', []);
       }
     }, this), 10);
   }, this));
@@ -312,13 +312,13 @@ RomoOptionListDropdown.prototype._bindDropdownOptionFilter = function() {
     this.romoDropdown.elem.removeClass(this.focusStyleClass);
   }, this));
 
-  this.romoDropdown.elem.on('dropdown:popupOpen', $.proxy(function(e, dropdown) {
+  this.romoDropdown.elem.on('romoDropdown:popupOpen', $.proxy(function(e, romoDropdown) {
     this.optionFilterElem.trigger('indicatorTextInput:triggerPlaceIndicator');
     this.optionFilterElem.focus();
     this._filterOptionElems();
     this.openOnFocus = false;
   }, this));
-  this.romoDropdown.elem.on('dropdown:popupClose', $.proxy(function(e, dropdown) {
+  this.romoDropdown.elem.on('romoDropdown:popupClose', $.proxy(function(e, romoDropdown) {
     this.optionFilterElem.val('');
     /*
     don't call `_filterOptionElems()` here.  we need to keep the option markup as is
@@ -326,7 +326,7 @@ RomoOptionListDropdown.prototype._bindDropdownOptionFilter = function() {
     depends on the selected item elem method which requires the markup to be in place
     */
   }, this));
-  this.romoDropdown.elem.on('dropdown:popupClosedByEsc', $.proxy(function(e, dropdown) {
+  this.romoDropdown.elem.on('romoDropdown:popupClosedByEsc', $.proxy(function(e, romoDropdown) {
     this.romoDropdown.elem.focus();
   }, this));
   this.optionFilterElem.on('click', $.proxy(function(e) {

--- a/assets/js/romo/picker.js
+++ b/assets/js/romo/picker.js
@@ -118,7 +118,7 @@ RomoPicker.prototype._bindSelectedOptionsList = function() {
       this._refreshUI();
     }, this));
     this.romoSelectedOptionsList.elem.on('romoSelectedOptionsList:listClick', $.proxy(function(e, romoSelectedOptionsList) {
-      this.romoOptionListDropdown.elem.trigger('dropdown:triggerPopupClose', []);
+      this.romoOptionListDropdown.elem.trigger('romoDropdown:triggerPopupClose', []);
       this.romoOptionListDropdown.doFocus(false);
     }, this));
 
@@ -130,14 +130,14 @@ RomoPicker.prototype._bindSelectedOptionsList = function() {
 RomoPicker.prototype._bindOptionListDropdown = function() {
   this.romoOptionListDropdown = this._buildOptionListDropdownElem().romoOptionListDropdown(this.elem)[0];
 
-  this.romoOptionListDropdown.elem.on('romoOptionListDropdown:dropdown:toggle', $.proxy(function(e, dropdown, optionListDropdown) {
-    this.elem.trigger('romoPicker:dropdown:toggle', [dropdown, this]);
+  this.romoOptionListDropdown.elem.on('romoOptionListDropdown:romoDropdown:toggle', $.proxy(function(e, romoDropdown, optionListDropdown) {
+    this.elem.trigger('romoPicker:romoDropdown:toggle', [romoDropdown, this]);
   }, this));
-  this.romoOptionListDropdown.elem.on('romoOptionListDropdown:dropdown:popupOpen', $.proxy(function(e, dropdown, optionListDropdown) {
-    this.elem.trigger('romoPicker:dropdown:popupOpen', [dropdown, this]);
+  this.romoOptionListDropdown.elem.on('romoOptionListDropdown:romoDropdown:popupOpen', $.proxy(function(e, romoDropdown, optionListDropdown) {
+    this.elem.trigger('romoPicker:romoDropdown:popupOpen', [romoDropdown, this]);
   }, this));
-  this.romoOptionListDropdown.elem.on('romoOptionListDropdown:dropdown:popupClose', $.proxy(function(e, dropdown, optionListDropdown) {
-    this.elem.trigger('romoPicker:dropdown:popupClose', [dropdown, this]);
+  this.romoOptionListDropdown.elem.on('romoOptionListDropdown:romoDropdown:popupClose', $.proxy(function(e, romoDropdown, optionListDropdown) {
+    this.elem.trigger('romoPicker:romoDropdown:popupClose', [romoDropdown, this]);
   }, this));
 
   this.romoOptionListDropdown.elem.on('romoOptionListDropdown:filterChange', $.proxy(function(e, filterValue, romoOptionListDropdown) {

--- a/assets/js/romo/select.js
+++ b/assets/js/romo/select.js
@@ -96,7 +96,7 @@ RomoSelect.prototype._bindSelectedOptionsList = function() {
       this._refreshUI();
     }, this));
     this.romoSelectedOptionsList.elem.on('romoSelectedOptionsList:listClick', $.proxy(function(e, romoSelectedOptionsList) {
-      this.romoSelectDropdown.elem.trigger('dropdown:triggerPopupClose', []);
+      this.romoSelectDropdown.elem.trigger('romoDropdown:triggerPopupClose', []);
       this.romoSelectDropdown.doFocus(false);
     }, this));
 
@@ -108,14 +108,14 @@ RomoSelect.prototype._bindSelectedOptionsList = function() {
 RomoSelect.prototype._bindSelectDropdown = function() {
   this.romoSelectDropdown = this._buildSelectDropdownElem().romoSelectDropdown(this.elem)[0];
 
-  this.romoSelectDropdown.elem.on('selectDropdown:dropdown:toggle', $.proxy(function(e, dropdown, selectDropdown) {
-    this.elem.trigger('select:dropdown:toggle', [dropdown, this]);
+  this.romoSelectDropdown.elem.on('selectDropdown:romoDropdown:toggle', $.proxy(function(e, romoDropdown, selectDropdown) {
+    this.elem.trigger('select:romoDropdown:toggle', [romoDropdown, this]);
   }, this));
-  this.romoSelectDropdown.elem.on('selectDropdown:dropdown:popupOpen', $.proxy(function(e, dropdown, selectDropdown) {
-    this.elem.trigger('select:dropdown:popupOpen', [dropdown, this]);
+  this.romoSelectDropdown.elem.on('selectDropdown:romoDropdown:popupOpen', $.proxy(function(e, romoDropdown, selectDropdown) {
+    this.elem.trigger('select:romoDropdown:popupOpen', [romoDropdown, this]);
   }, this));
-  this.romoSelectDropdown.elem.on('selectDropdown:dropdown:popupClose', $.proxy(function(e, dropdown, selectDropdown) {
-    this.elem.trigger('select:dropdown:popupClose', [dropdown, this]);
+  this.romoSelectDropdown.elem.on('selectDropdown:romoDropdown:popupClose', $.proxy(function(e, romoDropdown, selectDropdown) {
+    this.elem.trigger('select:romoDropdown:popupClose', [romoDropdown, this]);
   }, this));
 
   this.romoSelectDropdown.elem.on('selectDropdown:itemSelected', $.proxy(function(e, itemValue, itemDisplayText, selectDropdown) {

--- a/assets/js/romo/select_dropdown.js
+++ b/assets/js/romo/select_dropdown.js
@@ -90,14 +90,14 @@ RomoSelectDropdown.prototype._bindElem = function() {
     this.elem.attr('data-romo-option-list-dropdown-open-on-focus', this.elem.data('romo-select-dropdown-open-on-focus'));
   }
 
-  this.elem.on('romoOptionListDropdown:dropdown:toggle', $.proxy(function(e, dropdown) {
-    this.elem.trigger('selectDropdown:dropdown:toggle', [dropdown, this]);
+  this.elem.on('romoOptionListDropdown:romoDropdown:toggle', $.proxy(function(e, romoDropdown) {
+    this.elem.trigger('selectDropdown:romoDropdown:toggle', [romoDropdown, this]);
   }, this));
-  this.elem.on('romoOptionListDropdown:dropdown:popupOpen', $.proxy(function(e, dropdown) {
-    this.elem.trigger('selectDropdown:dropdown:popupOpen', [dropdown, this]);
+  this.elem.on('romoOptionListDropdown:romoDropdown:popupOpen', $.proxy(function(e, romoDropdown) {
+    this.elem.trigger('selectDropdown:romoDropdown:popupOpen', [romoDropdown, this]);
   }, this));
-  this.elem.on('romoOptionListDropdown:dropdown:popupClose', $.proxy(function(e, dropdown) {
-    this.elem.trigger('selectDropdown:dropdown:popupClose', [dropdown, this]);
+  this.elem.on('romoOptionListDropdown:romoDropdown:popupClose', $.proxy(function(e, romoDropdown) {
+    this.elem.trigger('selectDropdown:romoDropdown:popupClose', [romoDropdown, this]);
   }, this));
   this.elem.on('romoOptionListDropdown:itemSelected', $.proxy(function(e, itemValue, itemDisplayText, romoOptionListDropdown) {
     this.elem.trigger('selectDropdown:itemSelected', [itemValue, itemDisplayText, this]);


### PR DESCRIPTION
This updates the `RomoDropdown` component to not use jquery. This
is part of the effort to no longer require jquery to use Romo.
This removes all of the jquery usage within the `RomoDropdown`
component and also updates the datepicker, dropdown form, option
list dropdown, picker, select, and select dropdown components to
not use the jquery method for initializing a romo dropdown
component.

This removes using jquery's `unbind` to remove all event
handlers from elems. The `Romo.off` doesn't support unbinding all
event handlers but we also decided that Romo doesn't need to be
this aggressive with its components elems. This allows users to
bind event handlers to the same events that romo dropdown does
(though it's not recommended).

This also updates the event names to be prefixed with
`romoDropdown` instead of just `dropdown` and renames variables as
well. This is part of having everything properly namespaced in
romo and ensuring it should work without issue with other
javascript libraries.

@kellyredding - Ready for review.