### PR TITLE
Fix binding and unbinding to events on the window/document

### DIFF
--- a/assets/js/romo/base.js
+++ b/assets/js/romo/base.js
@@ -674,9 +674,13 @@ Romo.prototype._eid = 1;
 Romo.prototype._fid = 1;
 
 Romo.prototype._el = function(elem) {
-  elem._romoeid || (
-    elem._romoeid = (this.attr(elem, 'data-romo-eid') || this.setAttr(elem, 'data-romo-eid', this._eid++))
-  );
+  if (!elem._romoeid) {
+    if (elem !== window && elem !== document) {
+      elem._romoeid = (this.attr(elem, 'data-romo-eid') || this.setAttr(elem, 'data-romo-eid', this._eid++));
+    } else {
+      elem._romoeid = elem === window ? 'window' : 'document';
+    }
+  }
   return elem;
 }
 


### PR DESCRIPTION
This fixes binding and unbinding to events on the window/document.
This is part of an effort to no longer use jquery. This updates
the `_el` function to detect if the elem is the `window` or
`document` and if so it doesn't try to read or write an attribute
on them because they don't support the attribute methods. Instead
it uses a hard-coded identifier (`"window"` or `"document"`) for
them. This allows them to work with the event binding and ensures
we can bind and unbind events as needed.

@kellyredding - Ready for review. I rebased some stuff and was testing that the event binding worked on window and didn't need anything special done and saw this error.