### PR TITLE
Update `RomoModal` component to not use jquery

### DIFF
--- a/assets/js/romo/dropdown.js
+++ b/assets/js/romo/dropdown.js
@@ -48,12 +48,12 @@ RomoDropdown.prototype.doInitPopup = function() {
   var popupParentElem = Romo.closest(this.elem, Romo.data(this.elem, 'romo-dropdown-append-to-closest') || 'body');
   Romo.append(popupParentElem, this.popupElem);
 
-  this.popupElem.on('modal:popupOpen', Romo.proxy(function(e) {
+  Romo.on(this.popupElem, 'romoModal:popupOpen', Romo.proxy(function(e) {
     this.doUnBindWindowBodyClick();
     this.doUnBindWindowBodyKeyUp();
     this.doUnBindElemKeyUp();
   }, this));
-  this.popupElem.on('modal:popupClose', Romo.proxy(function(e) {
+  Romo.on(this.popupElem, 'romoModal:popupClose', Romo.proxy(function(e) {
     this.doBindWindowBodyClick();
     this.doBindWindowBodyKeyUp();
     this.doBindElemKeyUp();
@@ -137,7 +137,7 @@ RomoDropdown.prototype.doResetBody = function() {
 }
 
 RomoDropdown.prototype.doLoadBodyStart = function() {
-  this.bodyElem.innerHTML = '';
+  Romo.updateHtml(this.bodyElem, '');
   this.doInitBody();
   this.doPlacePopupElem();
   Romo.trigger(this.elem, 'romoDropdown:loadBodyStart', [this]);
@@ -247,7 +247,7 @@ RomoDropdown.prototype.doPopupClose = function() {
 
   // clear the content elem markup if configured to
   if (Romo.data(this.elem, 'romo-dropdown-clear-content') === true) {
-    this.contentElem.innerHTML = '';
+    Romo.updateHtml(this.contentElem, '');
   }
 
   Romo.trigger(this.elem, 'romoDropdown:popupClose', [this]);
@@ -283,13 +283,13 @@ RomoDropdown.prototype.onElemKeyUp = function(e) {
 RomoDropdown.prototype.doBindWindowBodyClick = function() {
   var bodyElem = Romo.f('body')[0];
   Romo.on(bodyElem, 'click', Romo.proxy(this.onWindowBodyClick, this));
-  Romo.on(bodyElem, 'modal:mousemove', Romo.proxy(this.onWindowBodyClick, this));
+  Romo.on(bodyElem, 'romoModal:mousemove', Romo.proxy(this.onWindowBodyClick, this));
 }
 
 RomoDropdown.prototype.doUnBindWindowBodyClick = function() {
   var bodyElem = Romo.f('body')[0];
   Romo.off(bodyElem, 'click', Romo.proxy(this.onWindowBodyClick, this));
-  Romo.off(bodyElem, 'modal:mousemove', Romo.proxy(this.onWindowBodyClick, this));
+  Romo.off(bodyElem, 'romoModal:mousemove', Romo.proxy(this.onWindowBodyClick, this));
 }
 
 RomoDropdown.prototype.onWindowBodyClick = function(e) {

--- a/assets/js/romo/modal.js
+++ b/assets/js/romo/modal.js
@@ -1,25 +1,24 @@
 var RomoModal = function(element) {
-  this.elem = $(element);
+  this.elem = element;
   this.doInitPopup();
   this.romoAjax = new RomoAjax(this.elem);
   this.romoAjax.doUnbindElem(); // disable auto invoke on click
 
-  if (this.elem.data('romo-modal-disable-click-invoke') !== true) {
-    this.elem.unbind('click');
-    this.elem.on('click', $.proxy(this.onToggleClick, this));
+  if (Romo.data(this.elem, 'romo-modal-disable-click-invoke') !== true) {
+    Romo.on(this.elem, 'click', Romo.proxy(this.onToggleClick, this));
   }
-  this.elem.on('modal:triggerToggle', $.proxy(this.onToggleClick, this));
-  this.elem.on('modal:triggerPopupOpen', $.proxy(this.onPopupOpen, this));
-  this.elem.on('modal:triggerPopupClose', $.proxy(this.onPopupClose, this));
-  this.elem.on('romoAjax:callStart', $.proxy(function(e, romoAjax) {
+  Romo.on(this.elem, 'romoModal:triggerToggle', Romo.proxy(this.onToggleClick, this));
+  Romo.on(this.elem, 'romoModal:triggerPopupOpen', Romo.proxy(this.onPopupOpen, this));
+  Romo.on(this.elem, 'romoModal:triggerPopupClose', Romo.proxy(this.onPopupClose, this));
+  Romo.on(this.elem, 'romoAjax:callStart', Romo.proxy(function(e, romoAjax) {
     this.doLoadBodyStart();
     return false;
   }, this));
-  this.elem.on('romoAjax:callSuccess', $.proxy(function(e, data, romoAjax) {
+  Romo.on(this.elem, 'romoAjax:callSuccess', Romo.proxy(function(e, data, romoAjax) {
     this.doLoadBodySuccess(data);
     return false;
   }, this));
-  this.elem.on('romoAjax:callError', $.proxy(function(e, xhr, romoAjax) {
+  Romo.on(this.elem, 'romoAjax:callError', Romo.proxy(function(e, xhr, romoAjax) {
     this.doLoadBodyError(xhr);
     return false;
   }, this));
@@ -29,7 +28,7 @@ var RomoModal = function(element) {
   this.doInit();
   this.doInitBody();
 
-  this.elem.trigger('modal:ready', [this]);
+  Romo.trigger(this.elem, 'romoModal:ready', [this]);
 }
 
 RomoModal.prototype.doInit = function() {
@@ -37,24 +36,25 @@ RomoModal.prototype.doInit = function() {
 }
 
 RomoModal.prototype.doInitPopup = function() {
-  this.popupElem = $('<div class="romo-modal-popup"><div class="romo-modal-body"></div></div>');
-  this.popupElem.appendTo(this.elem.closest(this.elem.data('romo-modal-append-to-closest') || 'body'));
+  this.popupElem = Romo.elems('<div class="romo-modal-popup"><div class="romo-modal-body"></div></div>')[0];
+  var popupParentElem = Romo.closest(this.elem, Romo.data(this.elem, 'romo-dropdown-append-to-closest') || 'body');
+  Romo.append(popupParentElem, this.popupElem)
 
-  this.bodyElem = this.popupElem.find('> .romo-modal-body');
-  if (this.elem.data('romo-modal-style-class') !== undefined) {
-    this.bodyElem.addClass(this.elem.data('romo-modal-style-class'));
+  this.bodyElem = Romo.find(this.popupElem, '> .romo-modal-body')[0];
+  if (Romo.data(this.elem, 'romo-modal-style-class') !== undefined) {
+    Romo.addClass(this.bodyElem, Romo.data(this.elem, 'romo-modal-style-class'));
   }
 
-  this.contentElem = $();
-  this.closeElem   = $();
-  this.dragElem    = $();
+  this.contentElem = undefined;
+  this.closeElem   = undefined;
+  this.dragElem    = undefined;
 
   // the popup should be treated like a child elem.  add it to Romo's
   // parent-child elems so it will be removed when the elem is removed.
   // delay adding it b/c other components may `append` generated modals
   // meaning the modal is removed and then re-added.  if added immediately
   // the "remove" part will incorrectly remove the popup.
-  setTimeout($.proxy(function() {
+  setTimeout(Romo.proxy(function() {
     Romo.parentChildElems.add(this.elem, [this.popupElem]);
   }, this), 1);
 }
@@ -62,69 +62,70 @@ RomoModal.prototype.doInitPopup = function() {
 RomoModal.prototype.doInitBody = function() {
   this.doResetBody();
 
-  this.contentElem = this.bodyElem.find('.romo-modal-content').last();
-  if (this.contentElem.size() === 0) {
+
+  var contentElems = Romo.find(this.bodyElem, '.romo-modal-content');
+  this.contentElem = contentElems[contentElems.length - 1];
+  if (this.contentElem === undefined) {
     this.contentElem = this.bodyElem;
   }
 
-  this.closeElem = this.popupElem.find('[data-romo-modal-close="true"]');
-  this.closeElem.unbind('click');
-  this.closeElem.on('click', $.proxy(this.onPopupClose, this));
+  this.closeElem = Romo.find(this.popupElem, '[data-romo-modal-close="true"]')[0];
+  Romo.on(this.closeElem, 'click', Romo.proxy(this.onPopupClose, this));
 
-  this.dragElem = this.popupElem.find('[data-romo-modal-drag="true"]');
-  this.dragElem.addClass('romo-modal-grab');
-  this.dragElem.on('mousedown', $.proxy(this.onMouseDown, this));
+  this.dragElem = Romo.find(this.popupElem, '[data-romo-modal-drag="true"]')[0];
+  Romo.addClass(this.dragElem, 'romo-modal-grab');
+  Romo.on(this.dragElem, 'mousedown', Romo.proxy(this.onMouseDown, this));
 
   var css = {
-    'min-width':  this.elem.data('romo-modal-min-width'),
-    'max-width':  this.elem.data('romo-modal-max-width'),
-    'width':      this.elem.data('romo-modal-width'),
-    'min-height': this.elem.data('romo-modal-min-height'),
-    'height':     this.elem.data('romo-modal-height'),
+    'min-width':  Romo.data(this.elem, 'romo-modal-min-width'),
+    'max-width':  Romo.data(this.elem, 'romo-modal-max-width'),
+    'width':      Romo.data(this.elem, 'romo-modal-width'),
+    'min-height': Romo.data(this.elem, 'romo-modal-min-height'),
+    'height':     Romo.data(this.elem, 'romo-modal-height'),
     'overflow-x': 'auto',
     'overflow-y': 'auto'
   }
 
-  if (this.elem.data('romo-modal-max-height') === undefined) {
-    this.elem.attr('data-romo-modal-max-height', 'detect');
+  if (Romo.data(this.elem, 'romo-modal-max-height') === undefined) {
+    Romo.setAttr(this.elem, 'data-romo-modal-max-height', 'detect');
   }
-  if (this.elem.data('romo-modal-max-height') !== 'detect') {
-    css['max-height'] = this.elem.data('romo-modal-max-height');
+  if (Romo.data(this.elem, 'romo-modal-max-height') !== 'detect') {
+    css['max-height'] = Romo.data(this.elem, 'romo-modal-max-height');
   }
 
-  this.contentElem.css(css);
+  for (var key in css) {
+    Romo.setStyle(this.contentElem, key, css[key]);
+  }
 }
 
 RomoModal.prototype.doResetBody = function() {
-  this.contentElem.css({
-    'min-width':  '',
-    'max-width':  '',
-    'width':      '',
-    'min-height': '',
-    'max-height': '',
-    'height':     '',
-    'overflow':   ''
-  });
+  Romo.setStyle(this.contentElem, 'min-width',  '');
+  Romo.setStyle(this.contentElem, 'max-width',  '');
+  Romo.setStyle(this.contentElem, 'width',      '');
+  Romo.setStyle(this.contentElem, 'min-height', '');
+  Romo.setStyle(this.contentElem, 'max-height', '');
+  Romo.setStyle(this.contentElem, 'height',     '');
+  Romo.setStyle(this.contentElem, 'overflow',   '');
 
-  this.closeElem.off('click', $.proxy(this.onPopupClose, this));
+  Romo.off(this.closeElem, 'click', Romo.proxy(this.onPopupClose, this));
 }
 
 RomoModal.prototype.doLoadBodyStart = function() {
-  this.bodyElem.html('');
+  Romo.updateHtml(this.bodyElem, '');
   this.doInitBody();
   this.doPlacePopupElem();
-  this.elem.trigger('modal:loadBodyStart', [this]);
+  Romo.trigger(this.elem, 'romoModal:loadBodyStart', [this]);
 }
 
 RomoModal.prototype.doLoadBodySuccess = function(data) {
-  Romo.initHtml(this.bodyElem, data);
+  Romo.initUpdateHtml(this.bodyElem, data);
   this.doInitBody();
   this.doPlacePopupElem();
-  this.elem.trigger('modal:loadBodySuccess', [data, this]);
+  Romo.trigger(this.elem, 'romoModal:loadBodySuccess', [data, this]);
 }
 
 RomoModal.prototype.doLoadBodyError = function(xhr) {
-  this.elem.trigger('modal:loadBodyError', [xhr, this]);
+  Romo.trigger(this.elem, 'romoModal:loadBodyError', [xhr, this]);
 }
 
 RomoModal.prototype.onToggleClick = function(e) {
@@ -132,22 +133,22 @@ RomoModal.prototype.onToggleClick = function(e) {
     e.preventDefault();
   }
 
-  if (this.elem.hasClass('disabled') === false) {
+  if (Romo.hasClass(this.elem, 'disabled') === false) {
     this.doToggle();
   }
 }
 
 RomoModal.prototype.doToggle = function() {
-  if (this.popupElem.hasClass('romo-modal-open')) {
-    setTimeout($.proxy(function() {
+  if (Romo.hasClass(this.popupElem, 'romo-modal-open')) {
+    setTimeout(Romo.proxy(function() {
       this.doPopupClose();
     }, this), 100);
   } else {
-    setTimeout($.proxy(function() {
+    setTimeout(Romo.proxy(function() {
       this.doPopupOpen();
     }, this), 100);
   }
-  this.elem.trigger('modal:toggle', [this]);
+  Romo.trigger(this.elem, 'romoModal:toggle', [this]);
 }
 
 RomoModal.prototype.onPopupOpen = function(e) {
@@ -155,22 +156,23 @@ RomoModal.prototype.onPopupOpen = function(e) {
     e.preventDefault();
   }
 
-  if ((this.elem.hasClass('disabled') === false) &&
-      (this.popupElem.hasClass('romo-modal-open') === false)) {
-    setTimeout($.proxy(function() {
+  if ((Romo.hasClass(this.elem, 'disabled') === false) &&
+      (Romo.hasClass(this.popupElem, 'romo-modal-open') === false)) {
+    setTimeout(Romo.proxy(function() {
       this.doPopupOpen();
     }, this), 100);
   }
 }
 
 RomoModal.prototype.doPopupOpen = function() {
-  if (this.elem.data('romo-modal-content-elem') !== undefined) {
-    this.doLoadBodySuccess($(this.elem.data('romo-modal-content-elem')).html())
+  if (Romo.data(this.elem, 'romo-modal-content-elem') !== undefined) {
+    var contentElem = Romo.elems(Romo.data(this.elem, 'romo-modal-content-elem'))[0];
+    this.doLoadBodySuccess(contentElem.outerHTML);
   } else {
     this.romoAjax.doInvoke();
   }
 
-  this.popupElem.addClass('romo-modal-open');
+  Romo.addClass(this.popupElem, 'romo-modal-open');
   this.doPlacePopupElem();
 
   // bind an event to close the popup when clicking away from the
@@ -178,7 +180,7 @@ RomoModal.prototype.doPopupOpen = function() {
   // click event to propagate.  If no timeout, we'll bind this
   // event, then the toggle click will propagate which will call
   // this event and immediately close the popup.
-  setTimeout($.proxy(function() {
+  setTimeout(Romo.proxy(function() {
     this.doBindWindowBodyClick();
   }, this), 100);
 
@@ -186,9 +188,9 @@ RomoModal.prototype.doPopupOpen = function() {
   this.doBindWindowBodyKeyUp();
 
   // bind window resizes reposition modal
-  $(window).on('resize', $.proxy(this.onResizeWindow, this));
+  Romo.on(window, 'resize', Romo.proxy(this.onResizeWindow, this));
 
-  this.elem.trigger('modal:popupOpen', [this]);
+  Romo.trigger(this.elem, 'romoModal:popupOpen', [this]);
 }
 
 RomoModal.prototype.onPopupClose = function(e) {
@@ -196,16 +198,16 @@ RomoModal.prototype.onPopupClose = function(e) {
     e.preventDefault();
   }
 
-  if (this.elem.hasClass('disabled') === false) {
-    setTimeout($.proxy(function() {
+  if (Romo.hasClass(this.elem, 'disabled') === false) {
+    setTimeout(Romo.proxy(function() {
       this.doPopupClose();
     }, this), 100);
   }
 }
 
 RomoModal.prototype.doPopupClose = function() {
-  $('body').trigger('modal:popupclose');
-  this.popupElem.removeClass('romo-modal-open');
+  Romo.trigger(Romo.f('body')[0], 'romoModal:popupclose');
+  Romo.removeClass(this.popupElem, 'romo-modal-open');
 
   // unbind any event to close the popup when clicking away from it
   this.doUnBindWindowBodyClick();
@@ -214,14 +216,14 @@ RomoModal.prototype.doPopupClose = function() {
   this.doUnBindWindowBodyKeyUp();
 
   // unbind window resizes reposition modal
-  $(window).off('resize', $.proxy(this.onResizeWindow, this));
+  Romo.off(window, 'resize', Romo.proxy(this.onResizeWindow, this));
 
   // clear the content elem markup if configured to
-  if (this.elem.data('romo-modal-clear-content') === true) {
-    this.contentElem.html('');
+  if (Romo.data(this.elem, 'romo-modal-clear-content') === true) {
+    Romo.updateHtml(this.contentElem, '');
   }
 
-  this.elem.trigger('modal:popupClose', [this]);
+  Romo.trigger(this.elem, 'romoModal:popupClose', [this]);
 }
 
 RomoModal.prototype.onMouseDown = function(e) {
@@ -240,14 +242,14 @@ RomoModal.prototype.doDragStart = function(e) {
 
   this._dragDiffX = e.clientX - this.popupElem[0].offsetLeft;
   this._dragDiffY = e.clientY - this.popupElem[0].offsetTop;
-  $(window).on('mousemove', $.proxy(this.onMouseMove, this));
-  $(window).on('mouseup',   $.proxy(this.onMouseUp, this));
+  $(window).on('mousemove', Romo.proxy(this.onMouseMove, this));
+  $(window).on('mouseup',   Romo.proxy(this.onMouseUp, this));
 
-  this.elem.trigger("modal:dragStart", [this]);
+  this.elem.trigger("romoModal:dragStart", [this]);
 }
 
 RomoModal.prototype.onMouseMove = function(e) {
-  $('body').trigger('modal:mousemove');
+  Romo.trigger(Romo.f('body'), 'romoModal:mousemove');
   e.preventDefault();
   e.stopPropagation();
   this.doDragMove(e.clientX, e.clientY);
@@ -257,9 +259,10 @@ RomoModal.prototype.onMouseMove = function(e) {
 RomoModal.prototype.doDragMove = function(clientX, clientY) {
   var placeX = clientX - this._dragDiffX;
   var placeY = clientY - this._dragDiffY;
-  this.popupElem.css({ left: placeX+'px' , top: placeY+'px' });
+  Romo.setStyle(this.popupElem, 'left', placeX+'px');
+  Romo.setStyle(this.popupElem, 'top',  placeY+'px');
 
-  this.elem.trigger("modal:dragMove", [placeX, placeY, this]);
+  Romo.trigger(this.elem, "romoModal:dragMove", [placeX, placeY, this]);
 }
 
 RomoModal.prototype.onMouseUp = function(e) {
@@ -270,32 +273,32 @@ RomoModal.prototype.onMouseUp = function(e) {
 }
 
 RomoModal.prototype.doDragStop = function(e) {
-  this.dragElem.addClass('romo-modal-grab');
-  this.dragElem.removeClass('romo-modal-grabbing');
-  this.popupElem.css('width', '');
-  this.popupElem.css('height', '');
+  Romo.addClass(this.dragElem, 'romo-modal-grab');
+  Romo.removeClass(this.dragElem, 'romo-modal-grabbing');
+  Romo.setStyle(this.popupElem, 'width',  '');
+  Romo.setStyle(this.popupElem, 'height', '');
 
-  $(window).off('mousemove', $.proxy(this.onMouseMove, this));
-  $(window).off('mouseup',   $.proxy(this.onMouseUp, this));
+  Romo.off(window, 'mousemove', Romo.proxy(this.onMouseMove, this));
+  Romo.off(window, 'mouseup',   Romo.proxy(this.onMouseUp, this));
   delete this._dragDiffX;
   delete this._dragDiffY;
 
-  this.elem.trigger("modal:dragStop", [this]);
+  Romo.trigger(this.elem, "romoModal:dragStop", [this]);
 }
 
 RomoModal.prototype.doBindElemKeyUp = function() {
-  this.elem.on('keyup', $.proxy(this.onElemKeyUp, this));
-  this.popupElem.on('keyup', $.proxy(this.onElemKeyUp, this));
+  Romo.on(this.elem,      'keyup', Romo.proxy(this.onElemKeyUp, this));
+  Romo.on(this.popupElem, 'keyup', Romo.proxy(this.onElemKeyUp, this));
 }
 
 RomoModal.prototype.doUnBindElemKeyUp = function() {
-  this.elem.off('keyup', $.proxy(this.onElemKeyUp, this));
-  this.popupElem.off('keyup', $.proxy(this.onElemKeyUp, this));
+  Romo.off(this.elem,      'keyup', Romo.proxy(this.onElemKeyUp, this));
+  Romo.off(this.popupElem, 'keyup', Romo.proxy(this.onElemKeyUp, this));
 }
 
 RomoModal.prototype.onElemKeyUp = function(e) {
-  if (this.elem.hasClass('disabled') === false) {
-    if (this.popupElem.hasClass('romo-modal-open')) {
+  if (Romo.hasClass(this.elem, 'disabled') === false) {
+    if (Romo.hasClass(this.popupElem, 'romo-modal-open')) {
       if(e.keyCode === 27 /* Esc */ ) {
         this.doPopupClose();
         return false;
@@ -310,27 +313,27 @@ RomoModal.prototype.onElemKeyUp = function(e) {
 }
 
 RomoModal.prototype.doBindWindowBodyClick = function() {
-  $('body').on('click', $.proxy(this.onWindowBodyClick, this));
+  Romo.on(Romo.f('body')[0], 'click', Romo.proxy(this.onWindowBodyClick, this));
 }
 
 RomoModal.prototype.doUnBindWindowBodyClick = function() {
-  $('body').off('click', $.proxy(this.onWindowBodyClick, this));
+  Romo.off(Romo.f('body')[0], 'click', Romo.proxy(this.onWindowBodyClick, this));
 }
 
 RomoModal.prototype.onWindowBodyClick = function(e) {
   // if not clicked on the popup elem
-  if (e !== undefined && $(e.target).parents('.romo-modal-popup').size() === 0) {
+  if (e !== undefined && Romo.parents(e.target, '.romo-modal-popup').length === 0) {
     this.doPopupClose();
   }
   return true;
 }
 
 RomoModal.prototype.doBindWindowBodyKeyUp = function() {
-  $('body').on('keyup', $.proxy(this.onWindowBodyKeyUp, this));
+  Romo.on(Romo.f('body')[0], 'keyup', Romo.proxy(this.onWindowBodyKeyUp, this));
 }
 
 RomoModal.prototype.doUnBindWindowBodyKeyUp = function() {
-  $('body').off('keyup', $.proxy(this.onWindowBodyKeyUp, this));
+  Romo.off(Romo.f('body')[0], 'keyup', Romo.proxy(this.onWindowBodyKeyUp, this));
 }
 
 RomoModal.prototype.onWindowBodyKeyUp = function(e) {
@@ -346,31 +349,32 @@ RomoModal.prototype.onResizeWindow = function(e) {
 }
 
 RomoModal.prototype.doPlacePopupElem = function() {
-  var w = this.popupElem[0].offsetWidth;
-  var h = this.popupElem[0].offsetHeight;
+  var w = this.popupElem.offsetWidth;
+  var h = this.popupElem.offsetHeight;
   var min = 75;
-  var centerTop  = $(window).height() / 2 - h / 2;
-  var centerLeft = $(window).width()  / 2 - w / 2;
+  var centerTop  = window.innerHeight / 2 - h / 2;
+  var centerLeft = window.innerWidth  / 2 - w / 2;
   var css = {};
 
-  css.top = $(window).height() * 0.15;
+  css.top = window.innerHeight * 0.15;
   if (centerTop < css.top) { css.top = centerTop; }
   if (css.top < min) { css.top = min; }
 
   css.left = centerLeft;
   if (css.left < min) { css.left = min; }
 
-  this.popupElem.css(css);
+  Romo.setStyle(this.popupElem, 'top',  css.top);
+  Romo.setStyle(this.popupElem, 'left', css.left);
 
-  if (this.elem.data('romo-modal-max-height') === 'detect') {
-    var pad = this.elem.data('romo-modal-max-height-detect-pad') || 10;
-    var contentTop = this.contentElem[0].getBoundingClientRect().top;
-    var contentBottom = this.contentElem[0].getBoundingClientRect().bottom;
-    var bodyBottom = this.bodyElem[0].getBoundingClientRect().bottom;
+  if (Romo.data(this.elem, 'romo-modal-max-height') === 'detect') {
+    var pad = Romo.data(this.elem, 'romo-modal-max-height-detect-pad') || 10;
+    var contentTop = this.contentElem.getBoundingClientRect().top;
+    var contentBottom = this.contentElem.getBoundingClientRect().bottom;
+    var bodyBottom = this.bodyElem.getBoundingClientRect().bottom;
     var padBottom = bodyBottom - contentBottom;
 
-    var maxHeight = $(window).height() - contentTop - padBottom - pad;
-    this.contentElem.css({'max-height': maxHeight.toString() + 'px'});
+    var maxHeight = window.innerHeight - contentTop - padBottom - pad;
+    Romo.setStyle(this.contentElem, 'max-height', maxHeight.toString() + 'px');
   }
 }
 

--- a/assets/js/romo/modal_form.js
+++ b/assets/js/romo/modal_form.js
@@ -1,7 +1,7 @@
 var RomoModalForm = function(element) {
   this.elem = $(element);
 
-  this.modal = this.elem.romoModal()[0];
+  this.romoModal = new RomoModal(this.elem);
   this.doBindModal();
 
   this.form = undefined;
@@ -11,7 +11,7 @@ var RomoModalForm = function(element) {
     }
   }, this));
   this.doBindForm();
-  this.elem.on('modal:loadBodySuccess', $.proxy(function(e, data, modal) {
+  this.elem.on('romoModal:loadBodySuccess', $.proxy(function(e, data, romoModal) {
     this.doBindForm();
     this.elem.trigger('modalForm:formReady', [this.form, this]);
   }, this));
@@ -29,43 +29,43 @@ RomoModalForm.prototype.doBindModal = function() {
     this.elem.attr('data-romo-modal-clear-content', 'true');
   }
 
-  this.elem.on('modal:ready', $.proxy(function(e, modal) {
-    this.elem.trigger('modalForm:modal:ready', [modal, this]);
+  this.elem.on('romoModal:ready', $.proxy(function(e, romoModal) {
+    this.elem.trigger('modalForm:romoModal:ready', [romoModal, this]);
   }, this));
-  this.elem.on('modal:toggle', $.proxy(function(e, modal) {
-    this.elem.trigger('modalForm:modal:toggle', [modal, this]);
+  this.elem.on('romoModal:toggle', $.proxy(function(e, romoModal) {
+    this.elem.trigger('modalForm:romoModal:toggle', [romoModal, this]);
   }, this));
-  this.elem.on('modal:popupOpen', $.proxy(function(e, modal) {
-    this.elem.trigger('modalForm:modal:popupOpen', [modal, this]);
+  this.elem.on('romoModal:popupOpen', $.proxy(function(e, romoModal) {
+    this.elem.trigger('modalForm:romoModal:popupOpen', [romoModal, this]);
   }, this));
-  this.elem.on('modal:popupClose', $.proxy(function(e, modal) {
-    this.elem.trigger('modalForm:modal:popupClose', [modal, this]);
+  this.elem.on('romoModal:popupClose', $.proxy(function(e, romoModal) {
+    this.elem.trigger('modalForm:romoModal:popupClose', [romoModal, this]);
   }, this));
-  this.elem.on('modal:dragStart', $.proxy(function(e, modal) {
-    this.elem.trigger('modalForm:modal:dragStart', [modal, this]);
+  this.elem.on('romoModal:dragStart', $.proxy(function(e, romoModal) {
+    this.elem.trigger('modalForm:romoModal:dragStart', [romoModal, this]);
   }, this));
-  this.elem.on('modal:dragMove', $.proxy(function(e, placeX, placeY, modal) {
-    this.elem.trigger('modalForm:modal:dragMove', [placeX, placeY, modal, this]);
+  this.elem.on('romoModal:dragMove', $.proxy(function(e, placeX, placeY, romoModal) {
+    this.elem.trigger('modalForm:romoModal:dragMove', [placeX, placeY, romoModal, this]);
   }, this));
-  this.elem.on('modal:dragStop', $.proxy(function(e, modal) {
-    this.elem.trigger('modalForm:modal:dragStop', [modal, this]);
+  this.elem.on('romoModal:dragStop', $.proxy(function(e, romoModal) {
+    this.elem.trigger('modalForm:romoModal:dragStop', [romoModal, this]);
   }, this));
-  this.elem.on('modal:loadBodyStart', $.proxy(function(e, modal) {
-    this.elem.trigger('modalForm:modal:loadBodyStart', [modal, this]);
+  this.elem.on('romoModal:loadBodyStart', $.proxy(function(e, romoModal) {
+    this.elem.trigger('modalForm:romoModal:loadBodyStart', [romoModal, this]);
   }, this));
-  this.elem.on('modal:loadBodySuccess', $.proxy(function(e, data, modal) {
-    this.elem.trigger('modalForm:modal:loadBodySuccess', [data, modal, this]);
+  this.elem.on('romoModal:loadBodySuccess', $.proxy(function(e, data, romoModal) {
+    this.elem.trigger('modalForm:romoModal:loadBodySuccess', [data, romoModal, this]);
   }, this));
-  this.elem.on('modal:loadBodyError', $.proxy(function(e, xhr, modal) {
-    this.elem.trigger('modalForm:modal:loadBodyError', [xhr, modal, this]);
+  this.elem.on('romoModal:loadBodyError', $.proxy(function(e, xhr, romoModal) {
+    this.elem.trigger('modalForm:romoModal:loadBodyError', [xhr, romoModal, this]);
   }, this));
-  this.elem.on('modal:dismiss', $.proxy(function(e, modal) {
-    this.elem.trigger('modalForm:modal:dismiss', [modal, this]);
+  this.elem.on('romoModal:dismiss', $.proxy(function(e, romoModal) {
+    this.elem.trigger('modalForm:romoModal:dismiss', [romoModal, this]);
   }, this));
 }
 
 RomoModalForm.prototype.doBindForm = function() {
-  var formElem = this.modal.popupElem.find('[data-romo-form-auto="modalForm"]');
+  var formElem = this.romoModal.popupElem.find('[data-romo-form-auto="modalForm"]');
 
   formElem.on('form:clearMsgs', $.proxy(function(e, form) {
     this.elem.trigger('modalForm:form:clearMsgs', [form, this]);
@@ -95,8 +95,8 @@ RomoModalForm.prototype.doBindForm = function() {
     this.elem.trigger('modalForm:form:browserSubmit', [form, this]);
   }, this));
 
-  var submitElement = this.modal.popupElem.find('[data-romo-form-submit]')[0];
-  var indicatorElements = this.modal.popupElem.find('[data-romo-indicator-auto="true"]');
+  var submitElement = this.romoModal.popupElem.find('[data-romo-form-submit]')[0];
+  var indicatorElements = this.romoModal.popupElem.find('[data-romo-indicator-auto="true"]');
   this.form = formElem.romoForm(submitElement, indicatorElements)[0];
 }
 

--- a/assets/js/romo/tooltip.js
+++ b/assets/js/romo/tooltip.js
@@ -198,8 +198,8 @@ RomoTooltip.prototype.doPopupOpen = function() {
   this.doPlacePopupElem();
 
   if (this.elem.parents('.romo-modal-popup').size() !== 0) {
-    $('body').on('modal:mousemove',  $.proxy(this.onModalPopupChange, this));
-    $('body').on('modal:popupclose', $.proxy(this.onModalPopupChange, this));
+    $('body').on('romoModal:mousemove',  $.proxy(this.onModalPopupChange, this));
+    $('body').on('romoModal:popupclose', $.proxy(this.onModalPopupChange, this));
   }
   $(window).on('resize', $.proxy(this.onResizeWindow, this));
 
@@ -220,8 +220,8 @@ RomoTooltip.prototype.doPopupClose = function() {
   this.popupElem.removeClass('romo-tooltip-open');
 
   if (this.elem.parents('.romo-modal-popup').size() !== 0) {
-    $('body').off('modal:mousemove',  $.proxy(this.onModalPopupChange, this));
-    $('body').off('modal:popupclose', $.proxy(this.onModalPopupChange, this));
+    $('body').off('romoModal:mousemove',  $.proxy(this.onModalPopupChange, this));
+    $('body').off('romoModal:popupclose', $.proxy(this.onModalPopupChange, this));
   }
   $(window).off('resize', $.proxy(this.onResizeWindow, this));
 


### PR DESCRIPTION
This updates the `RomoModal` component to not use jquery. This
is part of the effort to no longer require jquery to use Romo.
This removes all of the jquery usage within the `RomoModal`
component and also updates the modal form to not use the jquery
method for initializing a romo modal component.

This removes using jquery's `unbind` to remove all event handlers
from elems. The `Romo.off` doesn't support unbinding all event
handlers but we also decided that Romo doesn't need to be this
aggressive with its components elems. This allows users to bind
event handlers to the same events that romo dropdown does (though
it's not recommended).

This also updates the event names to be prefixed with `romoModal`
instead of just `modal` and renames variables as well. This is
part of having everything properly namespaced in romo and ensuring
it should work without issue with other javascript libraries.

This also updates the `RomoDropdown` to not set `innerHTML` and
fixes a couple of its event bindings. These were missed in PR 151.

See #151

@kellyredding - Ready for review.