### PR TITLE
Update `RomoIndicatorTextInput` component to not use jquery

### DIFF
--- a/assets/js/romo/currency_text_input.js
+++ b/assets/js/romo/currency_text_input.js
@@ -87,27 +87,27 @@ RomoCurrencyTextInput.prototype.doBindIndicatorTextInput = function() {
     );
   }
 
-  this.elem.on('indicatorTextInput:indicatorClick', $.proxy(function(e) {
+  this.elem.on('romoIndicatorTextInput:indicatorClick', $.proxy(function(e) {
     this.elem.trigger('romoCurrencyTextInput:indicatorClick', []);
   }, this));
 
   this.elem.on('romoCurrencyTextInput:triggerPlaceIndicator', $.proxy(function(e) {
-    this.elem.trigger('indicatorTextInput:triggerPlaceIndicator', []);
+    this.elem.trigger('romoIndicatorTextInput:triggerPlaceIndicator', []);
   }, this));
   this.elem.on('romoCurrencyTextInput:triggerEnable', $.proxy(function(e) {
-    this.elem.trigger('indicatorTextInput:triggerEnable', []);
+    this.elem.trigger('romoIndicatorTextInput:triggerEnable', []);
   }, this));
   this.elem.on('romoCurrencyTextInput:triggerDisable', $.proxy(function(e) {
-    this.elem.trigger('indicatorTextInput:triggerDisable', []);
+    this.elem.trigger('romoIndicatorTextInput:triggerDisable', []);
   }, this));
   this.elem.on('romoCurrencyTextInput:triggerShow', $.proxy(function(e) {
-    this.elem.trigger('indicatorTextInput:triggerShow', []);
+    this.elem.trigger('romoIndicatorTextInput:triggerShow', []);
   }, this));
   this.elem.on('romoCurrencyTextInput:triggerHide', $.proxy(function(e) {
-    this.elem.trigger('indicatorTextInput:triggerHide', []);
+    this.elem.trigger('romoIndicatorTextInput:triggerHide', []);
   }, this));
 
-  this.elem.romoIndicatorTextInput();
+  this.romoIndicatorTextInput = new RomoIndicatorTextInput(this.elem);
 }
 
 // private

--- a/assets/js/romo/datepicker.js
+++ b/assets/js/romo/datepicker.js
@@ -41,7 +41,7 @@ RomoDatepicker.prototype.doBindElem = function() {
     this.elem.attr('data-romo-indicator-text-input-elem-display', this.elem.data('romo-datepicker-elem-display'));
   }
 
-  this.elem.romoIndicatorTextInput();
+  this.romoIndicatorTextInput = new RomoIndicatorTextInput(this.elem);
 
   this.prevValue = this.elem.val();
   this.elem.on('change', $.proxy(function(e) {
@@ -50,22 +50,22 @@ RomoDatepicker.prototype.doBindElem = function() {
     this.prevValue = newValue;
   }, this));
 
-  this.elem.on('indicatorTextInput:indicatorClick', $.proxy(function(e) {
+  this.elem.on('romoIndicatorTextInput:indicatorClick', $.proxy(function(e) {
     this._clearBlurTimeout();
     this.elem.trigger('datepicker:triggerPopupOpen');
   }, this));
 
   this.elem.on('datepicker:triggerEnable', $.proxy(function(e) {
-    this.elem.trigger('indicatorTextInput:triggerEnable', []);
+    this.elem.trigger('romoIndicatorTextInput:triggerEnable', []);
   }, this));
   this.elem.on('datepicker:triggerDisable', $.proxy(function(e) {
-    this.elem.trigger('indicatorTextInput:triggerDisable', []);
+    this.elem.trigger('romoIndicatorTextInput:triggerDisable', []);
   }, this));
   this.elem.on('datepicker:triggerShow', $.proxy(function(e) {
-    this.elem.trigger('indicatorTextInput:triggerShow', []);
+    this.elem.trigger('romoIndicatorTextInput:triggerShow', []);
   }, this));
   this.elem.on('datepicker:triggerHide', $.proxy(function(e) {
-    this.elem.trigger('indicatorTextInput:triggerHide', []);
+    this.elem.trigger('romoIndicatorTextInput:triggerHide', []);
   }, this));
 
   this.elem.on('datepicker:triggerSetFormat', $.proxy(function(e) {

--- a/assets/js/romo/indicator_text_input.js
+++ b/assets/js/romo/indicator_text_input.js
@@ -1,5 +1,5 @@
 var RomoIndicatorTextInput = function(element) {
-  this.elem = $(element);
+  this.elem = element;
 
   this.defaultIndicatorClass     = undefined;
   this.defaultIndicatorPaddingPx = 5;
@@ -8,7 +8,7 @@ var RomoIndicatorTextInput = function(element) {
   this.doInit();
   this._bindElem();
 
-  this.elem.trigger('indicatorTextInput:ready', [this]);
+  Romo.trigger(this.elem, 'romoIndicatorTextInput:ready', [this]);
 }
 
 RomoIndicatorTextInput.prototype.doInit = function() {
@@ -16,15 +16,15 @@ RomoIndicatorTextInput.prototype.doInit = function() {
 }
 
 RomoIndicatorTextInput.prototype.doEnable = function() {
-  this.elem.prop('disabled', false);
-  this.elem.removeClass('disabled');
-  this.indicatorElem.removeClass('disabled');
+  this.elem.disabled = false;
+  Romo.removeClass(this.elem, 'disabled');
+  Romo.removeClass(this.indicatorElem, 'disabled');
 }
 
 RomoIndicatorTextInput.prototype.doDisable = function() {
-  this.elem.prop('disabled', true);
-  this.elem.addClass('disabled');
-  this.indicatorElem.addClass('disabled');
+  this.elem.disabled = true;
+  Romo.addClass(this.elem, 'disabled');
+  Romo.addClass(this.indicatorElem, 'disabled');
 }
 
 RomoIndicatorTextInput.prototype.doShow = function() {
@@ -41,73 +41,74 @@ RomoIndicatorTextInput.prototype.doHide = function() {
 /* private */
 
 RomoIndicatorTextInput.prototype._bindElem = function() {
-  var elemWrapper = $('<div class="romo-indicator-text-input-wrapper"></div>');
-  elemWrapper.css({'display': (this.elem.data('romo-indicator-text-input-elem-display') || 'inline-block')});
-  if (this.elem.data('romo-indicator-text-input-btn-group') === true) {
-    elemWrapper.addClass('romo-btn-group');
+  var elemWrapper = Romo.elems('<div class="romo-indicator-text-input-wrapper"></div>')[0];
+  Romo.setStyle(elemWrapper, 'display', (Romo.data(this.elem, 'romo-indicator-text-input-elem-display') || 'inline-block'));
+  if (Romo.data(this.elem, 'romo-indicator-text-input-btn-group') === true) {
+    Romo.addClass(elemWrapper, 'romo-btn-group');
   }
 
-  this.elem.before(elemWrapper);
-  elemWrapper.append(this.elem);
+  Romo.before(this.elem, elemWrapper);
+  Romo.append(elemWrapper, this.elem);
 
   // the elem wrapper should be treated like a child elem.  add it to Romo's
   // parent-child elems so it will be removed when the elem (input) is removed.
   // delay adding it b/c the `append` statement above is not a "move", it is
   // a "remove" and "add" so if added immediately the "remove" part will
   // incorrectly remove the wrapper.
-  setTimeout($.proxy(function() {
+  setTimeout(Romo.proxy(function() {
     Romo.parentChildElems.add(this.elem, [elemWrapper]);
   }, this), 1);
 
-  this.indicatorElem = $();
-  var indicatorClass = this.elem.data('romo-indicator-text-input-indicator') || this.defaultIndicatorClass;
+  this.indicatorElem = undefined;
+  var indicatorClass = Romo.data(this.elem, 'romo-indicator-text-input-indicator') || this.defaultIndicatorClass;
   if (indicatorClass !== undefined && indicatorClass !== 'none') {
-    this.indicatorElem = $('<div class="romo-indicator-text-input-indicator"><div><i class="'+indicatorClass+'"></i></div></div>');
-    this.elem.after(this.indicatorElem);
-    this.indicatorElem.on('click', $.proxy(this._onIndicatorClick, this));
+    this.indicatorElem = Romo.elems('<div class="romo-indicator-text-input-indicator"><div><i class="'+indicatorClass+'"></i></div></div>')[0];
+    Romo.after(this.elem, this.indicatorElem);
+    Romo.on(this.indicatorElem, 'click', Romo.proxy(this._onIndicatorClick, this));
     this._placeIndicatorElem();
 
-    this.indicatorIconContainerElem = this.indicatorElem.find('div');
-    if (this.elem.data('romo-indicator-text-input-indicator-basis-size') !== undefined) {
-      this.indicatorIconContainerElem.attr(
-        'data-romo-indicator-basis-size',
-        this.elem.data('romo-indicator-text-input-indicator-basis-size')
+    this.indicatorIconContainerElem = Romo.find(this.indicatorElem, 'div')[0];
+    if (Romo.data(this.elem, 'romo-indicator-text-input-indicator-basis-size') !== undefined) {
+      Romo.setData(
+        this.indicatorIconContainerElem,
+        'romo-indicator-basis-size',
+        Romo.data(this.elem, 'romo-indicator-text-input-indicator-basis-size')
       )
     }
-    this.indicatorIconContainerElem.romoIndicator();
+    $(this.indicatorIconContainerElem).romoIndicator();
 
-    this.elem.on('indicatorTextInput:triggerPlaceIndicator', $.proxy(function(e) {
+    Romo.on(this.elem, 'romoIndicatorTextInput:triggerPlaceIndicator', Romo.proxy(function(e) {
       this._placeIndicatorElem();
     }, this));
-    this.elem.on('indicatorTextInput:triggerIndicatorStart', $.proxy(function(e, basisSize) {
-      this.indicatorIconContainerElem.trigger('indicator:triggerStart', [basisSize]);
+    Romo.on(this.elem, 'romoIndicatorTextInput:triggerIndicatorStart', Romo.proxy(function(e, basisSize) {
+      Romo.trigger(this.indicatorIconContainerElem, 'indicator:triggerStart', [basisSize]);
     }, this));
-    this.elem.on('indicatorTextInput:triggerIndicatorStop', $.proxy(function(e) {
-      this.indicatorIconContainerElem.trigger('indicator:triggerStop');
+    Romo.on(this.elem, 'romoIndicatorTextInput:triggerIndicatorStop', Romo.proxy(function(e) {
+      Romo.trigger(this.indicatorIconContainerElem, 'indicator:triggerStop');
     }, this));
   }
 
-  this.elem.on('indicatorTextInput:triggerEnable', $.proxy(function(e) {
+  Romo.on(this.elem, 'romoIndicatorTextInput:triggerEnable', Romo.proxy(function(e) {
     this.doEnable();
   }, this));
-  this.elem.on('indicatorTextInput:triggerDisable', $.proxy(function(e) {
+  Romo.on(this.elem, 'romoIndicatorTextInput:triggerDisable', Romo.proxy(function(e) {
     this.doDisable();
   }, this));
-  this.elem.on('indicatorTextInput:triggerShow', $.proxy(function(e) {
+  Romo.on(this.elem, 'romoIndicatorTextInput:triggerShow', Romo.proxy(function(e) {
     this.doShow();
   }, this));
-  this.elem.on('indicatorTextInput:triggerHide', $.proxy(function(e) {
+  Romo.on(this.elem, 'romoIndicatorTextInput:triggerHide', Romo.proxy(function(e) {
     this.doHide();
   }, this));
 }
 
 RomoIndicatorTextInput.prototype._placeIndicatorElem = function() {
   if (this.indicatorElem !== undefined) {
-    this.indicatorElem.css({'line-height': this.elem.css('height')});
-    if (this.elem.prop('disabled') === true) {
-      this.indicatorElem.addClass('disabled');
+    Romo.setStyle(this.indicatorElem, 'line-height', Romo.css(this.elem, 'height'));
+    if (this.elem.disabled === true) {
+      Romo.addClass(this.indicatorElem, 'disabled');
     }
-    if (this.elem.css('display') === 'none') {
+    if (Romo.css(this.elem, 'display') === 'none') {
       this._hide(this.indicatorElem);
     }
 
@@ -116,13 +117,13 @@ RomoIndicatorTextInput.prototype._placeIndicatorElem = function() {
     var indicatorPosition  = this._getIndicatorPosition();
 
     // add a pixel to account for the default input border
-    this.indicatorElem.css(indicatorPosition, indicatorPaddingPx+1);
+    Romo.setStyle(this.indicatorElem, indicatorPosition, indicatorPaddingPx+1);
 
     // left-side padding
     // + indicator width
     // + right-side padding
     var inputPaddingPx = indicatorPaddingPx + indicatorWidthPx + indicatorPaddingPx;
-    this.elem.css('padding-'+indicatorPosition, inputPaddingPx+'px');
+    Romo.setStyle(this.elem, 'padding-'+indicatorPosition, inputPaddingPx+'px');
   }
 }
 
@@ -131,39 +132,39 @@ RomoIndicatorTextInput.prototype._onIndicatorClick = function(e) {
     e.preventDefault();
     e.stopPropagation();
   }
-  if (this.elem.prop('disabled') === false) {
+  if (this.elem.disabled === false) {
     this.elem.focus();
-    this.elem.trigger('indicatorTextInput:indicatorClick');
+    Romo.trigger(this.elem, 'romoIndicatorTextInput:indicatorClick');
   }
 }
 
 // private
 
 RomoIndicatorTextInput.prototype._show = function(elem) {
-  elem.css('display', '');
+  Romo.show(elem);
 }
 
 RomoIndicatorTextInput.prototype._hide = function(elem) {
-  elem.css('display', 'none');
+  Romo.hide(elem);
 }
 
 RomoIndicatorTextInput.prototype._getIndicatorPaddingPx = function() {
   return (
-    this.elem.data('romo-indicator-text-input-indicator-padding-px') ||
+    Romo.data(this.elem, 'romo-indicator-text-input-indicator-padding-px') ||
     this.defaultIndicatorPaddingPx
   );
 }
 
 RomoIndicatorTextInput.prototype._getIndicatorWidthPx = function() {
   return (
-    this.elem.data('romo-indicator-text-input-indicator-width-px') ||
-    parseInt(Romo.getComputedStyle(this.indicatorElem[0], "width"), 10)
+    Romo.data(this.elem, 'romo-indicator-text-input-indicator-width-px') ||
+    parseInt(Romo.getComputedStyle(this.indicatorElem, "width"), 10)
   );
 }
 
 RomoIndicatorTextInput.prototype._getIndicatorPosition = function() {
   return (
-    this.elem.data('romo-indicator-text-input-indicator-position') ||
+    Romo.data(this.elem, 'romo-indicator-text-input-indicator-position') ||
     this.defaultIndicatorPosition
   );
 }

--- a/assets/js/romo/option_list_dropdown.js
+++ b/assets/js/romo/option_list_dropdown.js
@@ -175,12 +175,12 @@ RomoOptionListDropdown.prototype._bindElem = function() {
   Romo.on(this.elem, 'romoOptionListDropdown:triggerFilterIndicatorStart', Romo.proxy(function(e) {
     Romo.trigger(
       this.optionFilterElem,
-      'indicatorTextInput:triggerIndicatorStart',
+      'romoIndicatorTextInput:triggerIndicatorStart',
       [Romo.css(this.optionFilterElem, "height")]
     );
   }, this));
   Romo.on(this.elem, 'romoOptionListDropdown:triggerFilterIndicatorStop', Romo.proxy(function(e) {
-    Romo.trigger(this.optionFilterElem, 'indicatorTextInput:triggerIndicatorStop', []);
+    Romo.trigger(this.optionFilterElem, 'romoIndicatorTextInput:triggerIndicatorStop', []);
   }, this));
 
   this.romoDropdown = new RomoDropdown(this.elem);
@@ -275,7 +275,7 @@ RomoOptionListDropdown.prototype._buildOptionFilter = function() {
 }
 
 RomoOptionListDropdown.prototype._bindDropdownOptionFilter = function() {
-  $(this.optionFilterElem).romoIndicatorTextInput();
+  this.romoIndicatorTextInput = new RomoIndicatorTextInput(this.optionFilterElem);
   new RomoOnkey(this.optionFilterElem);
 
   Romo.on(this.romoDropdown.elem, 'focus', Romo.proxy(function(e) {
@@ -320,7 +320,7 @@ RomoOptionListDropdown.prototype._bindDropdownOptionFilter = function() {
   }, this));
 
   Romo.on(this.romoDropdown.elem, 'romoDropdown:popupOpen', Romo.proxy(function(e, romoDropdown) {
-    Romo.trigger(this.optionFilterElem, 'indicatorTextInput:triggerPlaceIndicator');
+    Romo.trigger(this.optionFilterElem, 'romoIndicatorTextInput:triggerPlaceIndicator');
     this.optionFilterElem.focus();
     this._filterOptionElems();
     this.openOnFocus = false;


### PR DESCRIPTION
This updates the `RomoIndicatorTextInput` component to not use
jquery. This is part of the effort to no longer require jquery to
use Romo. This removes all of the jquery usage within the
`RomoIndicatorTextInput` component and also updates the currency
text input, datepicker, and option list dropdown components to
not use the jquery method for initializing a romo indicator text
input component.

This also updates the event names to be prefixed with
`romoIndicatorTextInput` instead of just `indicatorTextInput` and
renames variables as well. This is part of having everything
properly namespaced in romo and ensuring it should work without
issue with other javascript libraries.

@kellyredding - Ready for review.