### PR TITLE
rework romo form js to not use jquery

### DIFF
--- a/assets/js/romo/form.js
+++ b/assets/js/romo/form.js
@@ -1,86 +1,42 @@
-var RomoForm = function(element, givenSubmitElement, givenIndicatorElements) {
-  this.elem = $(element);
-  this.defaultSubmitElem = this.elem.find('button[type="submit"], input[type="submit"], [data-romo-form-submit]');
-  this.submitElem = $(givenSubmitElement || this.defaultSubmitElem);
-  this.defaultIndicatorElems = this.elem.find('[data-romo-indicator-auto="true"]');
-  this.indicatorElems = $(givenIndicatorElements || this.defaultIndicatorElems);
-  this.changeSubmitElems = this.elem.find('[data-romo-form-change-submit="true"]');
-  this.onkeySubmitElems = this.elem.find('[data-romo-form-onkey-submit="true"]');
+var RomoForm = function(formElem, givenSubmitElems, givenSpinnerElems) {
+  this.elem = formElem;
 
-  this.defaultListValuesDelim = ',';
+  var defaultSubmitElems = Romo.find(
+    this.elem,
+    'button[type="submit"], input[type="submit"], [data-romo-form-submit]'
+  );
+  this.submitElems = (givenSubmitElems || []).concat(defaultSubmitElems || []);
+
+  var defaultSpinnerElems = Romo.find(this.elem, '[data-romo-indicator-auto="true"]');
+  this.spinnerElems = (givenSpinnerElems || []).concat(defaultSpinnerElems || []);
+
+  this.changeSubmitElems = Romo.find(this.elem, '[data-romo-form-change-submit="true"]');
+  this.onkeySubmitElems  = Romo.find(this.elem, '[data-romo-form-onkey-submit="true"]');
+
+  this.defaultListValuesDelim  = ',';
   this.onkeyDefaultSubmitDelay = 300;  // 0.3 secs
-  this.submitQueued  = false;
-  this.submitRunning = false;
+  this.submitQueued            = false;
+  this.submitRunning           = false;
 
-  this.removeEmptyGetParams = this.elem.data('romo-form-remove-empty-get-params')
+  this.removeEmptyGetParams = Romo.data(this.elem, 'romo-form-remove-empty-get-params');
   if (this.removeEmptyGetParams === undefined) {
     this.removeEmptyGetParams = true;
   }
 
-  this.decodeParams = this.elem.data('romo-form-decode-params')
+  this.decodeParams = Romo.data(this.elem, 'romo-form-decode-params');
   if (this.decodeParams === undefined) {
     this.decodeParams = true;
   }
 
+  this._bindFormElem();
   this.doInit();
-  this.doBindForm();
-  this.elem.trigger('form:clearMsgs', [this]);
-  this.elem.trigger('form:ready', [this]);
+
+  Romo.trigger(this.elem, 'romoForm:clearMsgs', [this]);
+  Romo.trigger(this.elem, 'romoForm:ready',     [this]);
 }
 
 RomoForm.prototype.doInit = function() {
   // override as needed
-}
-
-RomoForm.prototype.doBindForm = function() {
-  this.defaultSubmitElem.unbind('click');
-  this.submitElem.unbind('click');
-  this.submitElem.on('click', $.proxy(this.onSubmitClick, this));
-
-  this.changeSubmitElems.on('change', $.proxy(function(e) {
-    this.elem.trigger('form:triggerSubmit');
-  }, this));
-  this.onkeySubmitElems.on('onkey:trigger', $.proxy(function(e, triggerEvent, onkey) {
-    clearTimeout(this.onkeySubmitTimeout);
-    this.onkeySubmitTimeout = setTimeout($.proxy(function() {
-      this.elem.trigger('form:triggerSubmit');
-    }, this), onkey.elem.data('romo-form-onkey-submit-delay') || this.onkeyDefaultSubmitDelay);
-  }, this));
-  this.elem.on('form:triggerSubmit', $.proxy(this.onSubmitClick, this));
-
-  this.elem.on('keypress', $.proxy(this.onFormKeyPress, this));
-
-  if (this.elem.data('romo-form-reload-page') === true) {
-    this.elem.on('form:submitSuccess', function(e, data, form) {
-      Romo.reloadPage();
-    })
-  }
-
-}
-
-RomoForm.prototype.onFormKeyPress = function(e) {
-  if (this.elem.data('romo-form-disable-keypress') !== true) {
-    var targetElem = $(e.target);
-    if (targetElem.is(':not(TEXTAREA)') && e.keyCode === 13 /* Enter */) {
-      e.preventDefault();
-      if (this.elem.data('romo-form-disable-enter-submit') !== true &&
-          targetElem.data('romo-form-disable-enter-submit') !== true) {
-        this.onSubmitClick();
-      }
-    }
-  }
-}
-
-RomoForm.prototype.onSubmitClick = function(e) {
-  if (e !== undefined) {
-    e.preventDefault();
-  }
-
-  if (this.submitElem.data('romo-form-submit') === 'confirm') {
-    this.elem.trigger('form:confirmSubmit', [this]);
-  } else if (this.submitElem.hasClass('disabled') === false) {
-    this.doSubmit();
-  }
 }
 
 RomoForm.prototype.doSubmit = function() {
@@ -90,45 +46,96 @@ RomoForm.prototype.doSubmit = function() {
   }
 }
 
-RomoForm.prototype.onSubmitSuccess = function(data, status, xhr) {
-  this.elem.trigger('form:clearMsgs');
-  this.elem.trigger('form:submitSuccess', [data, this]);
-  this._doCompleteSubmit();
-}
-
-RomoForm.prototype.onSubmitError = function(xhr, errorType, error) {
-  this.elem.trigger('form:clearMsgs');
-
-  if(xhr.status === 422) {
-    this.elem.trigger('form:submitInvalidMsgs', [$.parseJSON(xhr.responseText), xhr, this]);
-  } else {
-    this.elem.trigger('form:submitXhrError', [xhr, this]);
-  }
-  this.elem.trigger('form:submitError', [xhr, this]);
-  this.indicatorElems.trigger('indicator:triggerStop');
-  this._doCompleteSubmit();
-}
-
 // private
 
-RomoForm.prototype._doCompleteSubmit = function() {
-  this.elem.trigger('form:submitComplete', [this]);
-  if (this.submitQueued === true) {
-    this._doSubmit();
-  } else {
-    this.submitRunning = false;
+RomoForm.prototype._bindFormElem = function() {
+  this.submitElems.forEach(Romo.proxy(function(submitElem) {
+    Romo.on(submitElem, 'click', Romo.proxy(this._onSubmitClick, this));
+  }, this));
+
+  this.changeSubmitElems.forEach(Romo.proxy(function(changeSubmitElem) {
+    Romo.on(changeSubmitElem, 'change', Romo.proxy(function(e) {
+      Romo.trigger(this.elem, 'romoForm:triggerSubmit');
+    }, this));
+  }, this));
+
+  this.onkeySubmitElems.forEach(Romo.proxy(function(onkeySubmitElem) {
+    Romo.on(onkeySubmitElem, 'onkey:trigger', Romo.proxy(function(e, triggerEvent, onkey) {
+      // TODO: move this delay logic into onkey component
+      clearTimeout(this.onkeySubmitTimeout);
+      this.onkeySubmitTimeout = setTimeout(
+        Romo.proxy(function() {
+          Romo.trigger(this.elem, 'romoForm:triggerSubmit');
+        }, this),
+        Romo.data(onkey.elem, 'romo-form-onkey-submit-delay') || this.onkeyDefaultSubmitDelay
+      );
+    }, this));
+  }, this));
+
+  Romo.on(this.elem, 'romoForm:triggerSubmit', Romo.proxy(this._onTriggerSubmit, this));
+  Romo.on(this.elem, 'keypress',               Romo.proxy(this._onFormKeyPress,  this));
+
+  if (Romo.data(this.elem, 'romo-form-reload-page') === true) {
+    Romo.on(this.elem, 'romoForm:submitSuccess', function(e, data, romoForm) {
+      Romo.reloadPage();
+    });
+  }
+}
+
+RomoForm.prototype._onSubmitClick = function(e) {
+  e.preventDefault();
+
+  var submitElem = e.target;
+  if (!Romo.hasClass(submitElem, 'disabled')) {
+    if (Romo.data(submitElem, 'romo-form-submit') === 'confirm') {
+      Romo.trigger(this.elem, 'romoForm:confirmSubmit', [this]);
+    } else
+      this.doSubmit();
+    }
+  }
+}
+
+RomoForm.prototype._onTriggerSubmit = function() {
+  var disabled = this.submitElems.reduce(function(disabled, submitElem) {
+    return disabled || Romo.hasClass(submitElem, 'disabled');
+  }, false);
+  if (!disabled) {
+    var confirm = this.submitElems.reduce(function(confirm, submitElem) {
+      return confirm || Romo.data(submitElem, 'romo-form-submit') === 'confirm';
+    }, false);
+    if (confirm) {
+      Romo.trigger(this.elem, 'romoForm:confirmSubmit', [this]);
+    } else {
+      this.doSubmit();
+    }
+  }
+}
+
+RomoForm.prototype._onFormKeyPress = function(e) {
+  if (Romo.data(this.elem, 'romo-form-disable-keypress') !== true) {
+    var targetElem = e.target;
+    if (targetElem.nodeName.toLowerCase() !== 'textarea' && e.keyCode === 13 /* Enter */) {
+      e.preventDefault();
+      if (Romo.data(this.elem,  'romo-form-disable-enter-submit') !== true &&
+          Romo.data(targetElem, 'romo-form-disable-enter-submit') !== true) {
+        this._onTriggerSubmit();
+      }
+    }
   }
 }
 
 RomoForm.prototype._doSubmit = function() {
   this.submitQueued  = false;
   this.submitRunning = true;
-  this.indicatorElems.trigger('indicator:triggerStart');
-  this.elem.trigger('form:beforeSubmit', [this]);
 
-  if(this.elem.data('romo-form-browser-submit') === true) {
+  this.spinnerElems.forEach(function(spinnerElem) {
+    Romo.trigger(spinnerElem, 'indicator:triggerStart');
+  });
+  Romo.trigger(this.elem, 'romoForm:beforeSubmit', [this]);
+
+  if(Romo.data(this.elem, 'romo-form-browser-submit') === true) {
     this._doBrowserSubmit();
-  } else if (this.elem.attr('method').toUpperCase() === 'GET') {
+  } else if (Romo.attr(this.elem, 'method').toUpperCase() === 'GET') {
     this._doNonBrowserGetSubmit();
   } else {
     this._doNonBrowserNonGetSubmit();
@@ -137,86 +144,163 @@ RomoForm.prototype._doSubmit = function() {
 
 RomoForm.prototype._doBrowserSubmit = function() {
   this.elem.submit();
-  this.elem.trigger('form:browserSubmit', [this]);
+  Romo.trigger(this.elem, 'romoForm:browserSubmit', [this]);
 }
 
 RomoForm.prototype._doNonBrowserGetSubmit = function() {
-  var data = this._getSerializeObj();
+  var formData = this._getFormData(this._getFormValues({ includeFiles: false }));
 
-  if (this.elem.data('romo-form-redirect-page') === true) {
-    var paramString = Romo.param(data, {
+  if (Romo.data(this.elem, 'romo-form-redirect-page') === true) {
+    var paramString = Romo.param(formData, {
       removeEmpty:  this.removeEmptyGetParams,
       decodeValues: this.decodeParams
     });
     if (paramString !== '') {
-      Romo.redirectPage(this.elem.attr('action') + '?' + paramString);
+      Romo.redirectPage(Romo.attr(this.elem, 'action')+'?'+paramString);
     } else {
-      Romo.redirectPage(this.elem.attr('action'));
+      Romo.redirectPage(Romo.attr(this.elem, 'action'));
     }
-
   } else {
-    this._doAjaxSubmit(data, true);
+    this._doAjaxSubmit(formData);
   }
 }
 
 RomoForm.prototype._doNonBrowserNonGetSubmit = function() {
-  this._doAjaxSubmit(this._getFormData(), false);
+  var formData = this._getFormData(this._getFormValues({ includeFiles: true }));
+
+  this._doAjaxSubmit(formData);
 }
 
-RomoForm.prototype._doAjaxSubmit = function(data, process) {
-  $.ajax({
-    url:         this.elem.attr('action'),
-    type:        this.elem.attr('method'),
-    dataType:    this._getXhrDataType(),
-    data:        data,
-    processData: process,
-    contentType: false,
-    success:     $.proxy(this.onSubmitSuccess, this),
-    error:       $.proxy(this.onSubmitError, this)
+RomoForm.prototype._doAjaxSubmit = function(formData) {
+  Romo.ajax({
+    url:     Romo.attr(this.elem, 'action'),
+    type:    Romo.attr(this.elem, 'method'),
+    data:    formData,
+    success: Romo.proxy(this._onSubmitSuccess, this),
+    error:   Romo.proxy(this._onSubmitError,   this)
   });
 }
 
-RomoForm.prototype._getFormData = function() {
-  var formData = new FormData();
 
-  $.each(this._getSerializeObj(), function(k, v){ formData.append(k, v) });
-  $.each(this.elem.find('INPUT[type="file"]'), function(i, fileInput) {
-    var attrName = $(fileInput).attr('name')
-    $.each(fileInput.files, function(i, file) { formData.append(attrName, file) });
+RomoForm.prototype._onSubmitSuccess = function(response, status, xhr) {
+  Romo.trigger(this.elem, 'romoForm:clearMsgs');
+
+  var dataType = this._getXhrDataType(),
+  Romo.trigger(
+    this.elem,
+    'romoForm:submitSuccess',
+    [(dataType === 'json' ? JSON.parse(response) : response), this]
+  );
+
+  this._completeSubmit();
+}
+
+RomoForm.prototype._onSubmitError = function(statusText, status, xhr) {
+  Romo.trigger(this.elem, 'romoForm:clearMsgs');
+
+  if(status === 422) {
+    var dataType = this._getXhrDataType(),
+    Romo.trigger(
+      this.elem,
+      'romoForm:submitInvalidMsgs',
+      [(dataType === 'json' ? JSON.parse(xhr.responseText) : xhr.responseText), xhr, this]
+    );
+  } else {
+    Romo.trigger(this.elem, 'romoForm:submitXhrError', [xhr, this]);
+  }
+  Romo.trigger(this.elem, 'romoForm:submitError', [xhr, this]);
+  this.spinnerElems.forEach(function(spinnerElem) {
+    Romo.trigger(spinnerElem, 'indicator:triggerStop');
   });
+
+  this._completeSubmit();
+}
+
+RomoForm.prototype._completeSubmit = function() {
+  Romo.trigger(this.elem, 'romoForm:submitComplete', [this]);
+  if (this.submitQueued === true) {
+    this._doSubmit();
+  } else {
+    this.submitRunning = false;
+  }
+}
+
+RomoForm.prototype._getFormData = function(formValues) {
+  var formData = new FormData;
+  for (var name in formValues) {
+    formValues[name].forEach(function(value){ formData.append(name, value) });
+  }
 
   return formData;
 }
 
-RomoForm.prototype._getSerializeObj = function() {
-  var listNamesDelims = this._getListValueInputNamesDelims();
+RomoForm.prototype._getFormValues = function(opts) {
+  if (opts === undefined) {
+    opts = { includeFiles: false };
+  }
+  var formValues = {};
 
-  return this.elem.serializeArray().reduce(function(prev, curr) {
-    if (listNamesDelims[curr.name] !== undefined) {
-      prev[curr.name] = $.map([prev[curr.name], curr.value], function(v) {
-        return v; // $.map removes null/undefined vals, this acts like a compact function
-      }).join(listNamesDelims[curr.name])
-    } else {
-      prev[curr.name] = curr.value;
+  // build formValues from the form elements
+  // { "inputName1": ["inputValue1"],
+  //   "inputName2": ["inputValue1", "inputValue2"],
+  //   ...
+  // }
+  Romo.array(this.elem.elements).forEach(function(inputElem) {
+    if ( inputElem.nodeName.toLowerCase() !== 'fieldset' &&
+         inputElem.name              &&
+         !inputElem.disabled         &&
+         inputElem.type !== 'submit' &&
+         inputElem.type !== 'reset'  &&
+         inputElem.type !== 'button' &&
+         (opts.includeFiles || inputElem.type  !== 'file') &&
+         (inputElem.checked || (inputElem.type !== 'radio' && inputElem.type !== 'checkbox'))
+       ) {
+      if (formValues[inputElem.name] === undefined) {
+        formValues[inputElem.name] = [];
+      }
+      if (inputElem.nodeName.toLowerCase() === 'select') {
+        Romo.find(inputElem, 'option').filter(function(optElem){
+          return optElem.selected;
+        }).forEach(function(selectedOptElem) {
+          formValues[inputElem.name].push(selectedOptElem.value);
+        });
+      } else if (inputElem.type === 'file') {
+        Array.prototype.forEach.call(inputElem.files, function(file) {
+          formValues[inputElem.name].push(file);
+        });
+      } else {
+        formValues[inputElem.name].push(inputElem.value);
+      }
     }
+  });
 
-    return prev;
-  }, {});
-}
+  // process any list value inputs (if any)
+  // { inputName1: ["inputValue1"],
+  //   inputName2: ["inputValue1,inputValue2"],
+  //   ...
+  // }
+  var listDelims = Romo.find(this.elem, '[data-romo-form-list-values="true"]').reduce(
+    function(delims, inputElem) {
+      delims[Romo.attr(inputElem, 'name')] = (
+        Romo.data(currElem, 'romo-form-list-values-delim') ||
+        this.defaultListValuesDelim
+      );
+      return delims;
+    },
+    {}
+  );
+  for (var name in listDelims) {
+    if (formValues[name]) {
+      formValues[name] = [formValues[name].join(listDelims[name])];
+    }
+  }
 
-RomoForm.prototype._getListValueInputNamesDelims = function() {
-  return Romo.toArray(this.elem.find('[data-romo-form-list-values="true"]')).reduce($.proxy(function(prev, curr) {
-    prev[$(curr).attr('name')] = $(curr).data('romo-form-list-values-delim') || this.defaultListValuesDelim;
-    return prev;
-  }, this), {});
+  return formValues;
 }
 
 RomoForm.prototype._getXhrDataType = function() {
-  if(this.elem.data('romo-form-xhr-data-type') !== undefined) {
-    return this.elem.data('romo-form-xhr-data-type');
-  } else {
-    return 'json';
-  }
+  var dataType = Romo.data(this.elem, 'romo-form-xhr-data-type');
+  return ((dataType === undefined) ? 'json' : dataType);
 }
 
 Romo.onInitUI(function(elem) {


### PR DESCRIPTION
This is part of switching off of jQuery and on to vanilla Romo js.
This involved a number of changes in addition to the expected
syntax changes.  The diff is a little rugged b/c I chose to
reorder the methods.

* first off, I'm trying to make the only public methods be things
  that should be public.  This means no event handler methods and
  no methods not intended to be called externally.  For the form,
  this means only the standard `doInit` method and the `daSubmit`
  method remain public.  All other methods were converted to
  private methods.
* I renamed the vars tracking the form's indicator elems to
  "spinner" since we plan on renaming that component.  However, I
  didn't rename the event names.  I expect whoever reworks that
  component will do that part.
* I chose to remove the e undefined checks around calling
  prevent default and/or stop propagation.  I think it is safe to
  count on these being events since we have moved to only calling
  event handlers with events.  I'd like the code to error if not
  so we can trace what's up.
* I broke out an `_onTriggerSubmit` handler to handle just the
  trigger submit event. This differs from the `_onSubmitClick`
  handler in that it has to reduce its disabled/confirm checks
  to determine those values (where the submit click can just check
  disabled/confirm on the single target elem.  For both of these
  handlers, I switched to checking disabled before checking
  confirm - you shouldn't get to confirm if the elem is disabled.
* I had to rewrite the functions to get the form values and build
  the form data.  jQuery previously took care of this for us.
* I updated the non browser get submit to go ahead and build
  form data (no files) and call `Romo.param` on the form data to
  build the get query string.  I'm assuming this works since
  form data is an object but this needs testing.  This matches the
  `Romo.param` call the `Romo.ajax` method does for ajax get
  requests so I wanted to be consistent.
* since `Romo.ajax` doesn't support a `dataType` opt where we can
  set the data type (typically 'json'), I had to update the submit
  success/error handlers to parse json as needed.

@jcredding sorry the diff is so gnarly.  ready for review.  Check me on this stuff - it is kinda complex and we'll need to test carefully with examples on the edge-case stuff here.