### PR TITLE
Update `RomoInline` component to not use jquery

### DIFF
--- a/assets/js/romo/inline.js
+++ b/assets/js/romo/inline.js
@@ -1,29 +1,29 @@
 var RomoInline = function(element) {
-  this.elem        = $(element);
-  this.toggleElem  = $(this.elem.data('romo-inline-toggle'));
+  this.elem        = element;
+  this.toggleElem  = Romo.f(Romo.data(this.elem, 'romo-inline-toggle'))[0];
   this.dismissElem = undefined;
 
-  this.elem.on('inline:triggerDismiss', $.proxy(this.onDismissClick, this));
-  this.elem.on('inline:triggerShow',  $.proxy(function(e) {
+  Romo.on(this.elem, 'romoInline:triggerDismiss', Romo.proxy(this.onDismissClick, this));
+  Romo.on(this.elem, 'romoInline:triggerShow',  Romo.proxy(function(e) {
     this.doShow();
   }, this));
 
-  this.elem.on('romoAjax:callStart', $.proxy(function(e, romoAjax) {
+  Romo.on(this.elem, 'romoAjax:callStart', Romo.proxy(function(e, romoAjax) {
     this.doLoadStart();
     return false;
   }, this));
-  this.elem.on('romoAjax:callSuccess', $.proxy(function(e, data, romoAjax) {
+  Romo.on(this.elem, 'romoAjax:callSuccess', Romo.proxy(function(e, data, romoAjax) {
     this.doLoadSuccess(data);
     return false;
   }, this));
-  this.elem.on('romoAjax:callError', $.proxy(function(e, xhr, romoAjax) {
+  Romo.on(this.elem, 'romoAjax:callError', Romo.proxy(function(e, xhr, romoAjax) {
     this.doLoadError(xhr);
     return false;
   }, this));
 
   this.doBindDismiss();
   this.doInit();
-  this.elem.trigger('inline:ready', [this]);
+  Romo.trigger(this.elem, 'romoInline:ready', [this]);
 }
 
 RomoInline.prototype.doInit = function() {
@@ -31,26 +31,25 @@ RomoInline.prototype.doInit = function() {
 }
 
 RomoInline.prototype.doLoadStart = function() {
-  this.elem.html('');
-  this.elem.trigger('inline:loadStart', [this]);
+  Romo.updateHtml(this.elem, '');
+  Romo.trigger(this.elem, 'romoInline:loadStart', [this]);
 }
 
 RomoInline.prototype.doLoadSuccess = function(data) {
   this.doShow();
   Romo.initHtml(this.elem, data);
   this.doBindDismiss();
-  this.elem.trigger('inline:loadSuccess', [data, this]);
+  Romo.trigger(this.elem, 'romoInline:loadSuccess', [data, this]);
 }
 
 RomoInline.prototype.doLoadError = function(xhr) {
   this.doShow();
-  this.elem.trigger('inline:loadError', [xhr, this]);
+  Romo.trigger(this.elem, 'romoInline:loadError', [xhr, this]);
 }
 
 RomoInline.prototype.doBindDismiss = function() {
-  this.dismissElem = this.elem.find('[data-romo-inline-dismiss]');
-  this.dismissElem.unbind('click');
-  this.dismissElem.on('click', $.proxy(this.onDismissClick, this));
+  this.dismissElem = Romo.find(this.elem, '[data-romo-inline-dismiss]')[0];
+  Romo.on(this.dismissElem, 'click', Romo.proxy(this.onDismissClick, this));
 }
 
 RomoInline.prototype.onDismissClick = function(e) {
@@ -58,23 +57,23 @@ RomoInline.prototype.onDismissClick = function(e) {
     e.preventDefault();
   }
 
-  if (this.dismissElem.data('romo-inline-dismiss') === 'confirm') {
-    this.elem.trigger('inline:confirmDismiss', [this]);
-  } else if (this.dismissElem.hasClass('disabled') === false) {
+  if (Romo.data(this.dismissElem, 'romo-inline-dismiss') === 'confirm') {
+    Romo.trigger(this.elem, 'romoInline:confirmDismiss', [this]);
+  } else if (Romo.hasClass(this.dismissElem, 'disabled') === false) {
     this.doDismiss();
   }
 }
 
 RomoInline.prototype.doDismiss = function() {
-  this.toggleElem.show();
-  this.elem.hide();
-  this.elem.trigger('inline:dismiss', [this]);
+  Romo.show(this.toggleElem);
+  Romo.hide(this.elem);
+  Romo.trigger(this.elem, 'romoInline:dismiss', [this]);
 }
 
 RomoInline.prototype.doShow = function() {
-  this.elem.show();
-  this.toggleElem.hide();
-  this.elem.trigger('inline:show', [this]);
+  Romo.show(this.elem);
+  Romo.hide(this.toggleElem);
+  Romo.trigger(this.elem, 'romoInline:show', [this]);
 }
 
 Romo.onInitUI(function(elem) {

--- a/assets/js/romo/inline_form.js
+++ b/assets/js/romo/inline_form.js
@@ -1,7 +1,7 @@
 var RomoInlineForm = function(element) {
   this.elem = $(element);
 
-  this.inline = this.elem.romoInline()[0];
+  this.romoInline = new RomoInline(this.elem);
   this.doBindInline();
 
   this.form = undefined;
@@ -10,14 +10,14 @@ var RomoInlineForm = function(element) {
       this.form.elem.trigger('form:triggerSubmit', []);
     }
   }, this));
-  this.elem.on('inlineForm:inline:triggerInvoke', $.proxy(function(e) {
-    this.inline.elem.trigger('inline:triggerInvoke', []);
+  this.elem.on('inlineForm:romoInline:triggerInvoke', $.proxy(function(e) {
+    this.romoInline.elem.trigger('romoInline:triggerInvoke', []);
   }, this));
-  this.elem.on('inlineForm:inline:triggerDismiss', $.proxy(function(e) {
-    this.inline.elem.trigger('inline:triggerDismiss', []);
+  this.elem.on('inlineForm:romoInline:triggerDismiss', $.proxy(function(e) {
+    this.romoInline.elem.trigger('romoInline:triggerDismiss', []);
   }, this));
   this.doBindForm();
-  this.elem.on('inline:loadSuccess', $.proxy(function(e, data, inline) {
+  this.elem.on('romoInline:loadSuccess', $.proxy(function(e, data, romoInline) {
     this.doBindForm();
     this.elem.trigger('inlineForm:formReady', [this.form, this]);
   }, this));
@@ -31,26 +31,26 @@ RomoInlineForm.prototype.doInit = function() {
 }
 
 RomoInlineForm.prototype.doBindInline = function() {
-  this.elem.on('inline:ready', $.proxy(function(e, inline) {
-    this.elem.trigger('inlineForm:inline:ready', [inline, this]);
+  this.elem.on('romoInline:ready', $.proxy(function(e, romoInline) {
+    this.elem.trigger('inlineForm:romoInline:ready', [romoInline, this]);
   }, this));
-  this.elem.on('inline:loadStart', $.proxy(function(e, inline) {
-    this.elem.trigger('inlineForm:inline:loadStart', [inline, this]);
+  this.elem.on('romoInline:loadStart', $.proxy(function(e, romoInline) {
+    this.elem.trigger('inlineForm:romoInline:loadStart', [romoInline, this]);
   }, this));
-  this.elem.on('inline:loadSuccess', $.proxy(function(e, data, inline) {
-    this.elem.trigger('inlineForm:inline:loadSuccess', [data, inline, this]);
+  this.elem.on('romoInline:loadSuccess', $.proxy(function(e, data, romoInline) {
+    this.elem.trigger('inlineForm:romoInline:loadSuccess', [data, romoInline, this]);
   }, this));
-  this.elem.on('inline:loadError', $.proxy(function(e, xhr, inline) {
-    this.elem.trigger('inlineForm:inline:loadError', [xhr, inline, this]);
+  this.elem.on('romoInline:loadError', $.proxy(function(e, xhr, romoInline) {
+    this.elem.trigger('inlineForm:romoInline:loadError', [xhr, romoInline, this]);
   }, this));
-  this.elem.on('inline:show', $.proxy(function(e, inline) {
-    this.elem.trigger('inlineForm:inline:show', [inline, this]);
+  this.elem.on('romoInline:show', $.proxy(function(e, romoInline) {
+    this.elem.trigger('inlineForm:romoInline:show', [romoInline, this]);
   }, this));
-  this.elem.on('inline:dismiss', $.proxy(function(e, inline) {
-    this.elem.trigger('inlineForm:inline:dismiss', [inline, this]);
+  this.elem.on('romoInline:dismiss', $.proxy(function(e, romoInline) {
+    this.elem.trigger('inlineForm:romoInline:dismiss', [romoInline, this]);
   }, this));
-  this.elem.on('inline:confirmDismiss', $.proxy(function(e, inline) {
-    this.elem.trigger('inlineForm:inline:confirmDismiss', [inline, this]);
+  this.elem.on('romoInline:confirmDismiss', $.proxy(function(e, romoInline) {
+    this.elem.trigger('inlineForm:romoInline:confirmDismiss', [romoInline, this]);
   }, this));
 }
 


### PR DESCRIPTION
This updates the `RomoInline` component to not use jquery. This
is part of the effort to no longer require jquery to use Romo.
This removes all of the jquery usage within the `RomoInline`
component and also updates the inline form to not use the jquery
method for initializing a romo inline component.

This removes using jquery's `unbind` to remove all event handlers
from elems. The `Romo.off` doesn't support unbinding all event
handlers but we also decided that Romo doesn't need to be this
aggressive with its components elems. This allows users to bind
event handlers to the same events that romo inline does (though
it's not recommended).

This also updates the event names to be prefixed with `romoInline`
instead of just `inline` and renames variables as well. This is
part of having everything properly namespaced in romo and ensuring
it should work without issue with other javascript libraries.

@kellyredding - Ready for review.