### PR TITLE
Update `RomoOnkey` component to not use jquery

### DIFF
--- a/assets/js/romo/form.js
+++ b/assets/js/romo/form.js
@@ -60,14 +60,14 @@ RomoForm.prototype._bindFormElem = function() {
   }, this));
 
   this.onkeySubmitElems.forEach(Romo.proxy(function(onkeySubmitElem) {
-    Romo.on(onkeySubmitElem, 'onkey:trigger', Romo.proxy(function(e, triggerEvent, onkey) {
+    Romo.on(onkeySubmitElem, 'romoOnkey:trigger', Romo.proxy(function(e, triggerEvent, romoOnkey) {
       // TODO: move this delay logic into onkey component
       clearTimeout(this.onkeySubmitTimeout);
       this.onkeySubmitTimeout = setTimeout(
         Romo.proxy(function() {
           Romo.trigger(this.elem, 'romoForm:triggerSubmit');
         }, this),
-        Romo.data(onkey.elem, 'romo-form-onkey-submit-delay') || this.onkeyDefaultSubmitDelay
+        Romo.data(romoOnkey.elem, 'romo-form-onkey-submit-delay') || this.onkeyDefaultSubmitDelay
       );
     }, this));
   }, this));

--- a/assets/js/romo/onkey.js
+++ b/assets/js/romo/onkey.js
@@ -1,13 +1,13 @@
 var RomoOnkey = function(element) {
-  this.elem = $(element);
+  this.elem = element;
   this.defaultTriggerOn = 'keydown';
 
   this.doInit();
 
-  this.triggerOn = this.elem.data('romo-onkey-on') || this.defaultTriggerOn;
-  this.elem.on(this.triggerOn, $.proxy(this.onTrigger, this));
+  this.triggerOn = Romo.data(this.elem, 'romo-onkey-on') || this.defaultTriggerOn;
+  Romo.on(this.elem, this.triggerOn, Romo.proxy(this.onTrigger, this));
 
-  this.elem.trigger('onkey:ready', [this]);
+  this.elem.trigger('romoOnkey:ready', [this]);
 }
 
 RomoOnkey.prototype.doInit = function() {
@@ -15,13 +15,13 @@ RomoOnkey.prototype.doInit = function() {
 }
 
 RomoOnkey.prototype.onTrigger = function(e) {
-  if (this.elem.hasClass('disabled') === false) {
+  if (Romo.hasClass(this.elem, 'disabled') === false) {
     this.doTrigger(e);
   }
 }
 
 RomoOnkey.prototype.doTrigger = function(triggerEvent) {
-  this.elem.trigger('onkey:trigger', [triggerEvent, this]);
+  Romo.trigger(this.elem, 'romoOnkey:trigger', [triggerEvent, this]);
 }
 
 Romo.onInitUI(function(elem) {

--- a/assets/js/romo/option_list_dropdown.js
+++ b/assets/js/romo/option_list_dropdown.js
@@ -341,7 +341,7 @@ RomoOptionListDropdown.prototype._bindDropdownOptionFilter = function() {
   this.onkeySearchTimeout = undefined;
   this.onkeySearchDelay   = 100; // 0.1 secs, want it to be really responsive
 
-  this.optionFilterElem.on('onkey:trigger', $.proxy(function(e, triggerEvent, onkey) {
+  this.optionFilterElem.on('romoOnkey:trigger', $.proxy(function(e, triggerEvent, romoOnkey) {
     // TODO: incorp this timeout logic into the onkey component so don't have to repeat it
     clearTimeout(this.onkeySearchTimeout);
     this.onkeySearchTimeout = setTimeout($.proxy(function() {


### PR DESCRIPTION
This updates the `RomoOnkey` component to not use jquery. This
is part of the effort to no longer require jquery to use Romo.
This removes all of the jquery usage within the `RomoOnkey`.

This also updates the event names to be prefixed with `romoOnkey`
instead of just `onkey` and renames variables as well. This is
part of having everything properly namespaced in romo and ensuring
it should work without issue with other javascript libraries.

@kellyredding - Ready for review.