### PR TITLE
onkey: add a delay feature; cleanup form and opt list dropdown usage

### DIFF
--- a/assets/js/romo/form.js
+++ b/assets/js/romo/form.js
@@ -61,14 +61,7 @@ RomoForm.prototype._bindFormElem = function() {
 
   this.onkeySubmitElems.forEach(Romo.proxy(function(onkeySubmitElem) {
     Romo.on(onkeySubmitElem, 'romoOnkey:trigger', Romo.proxy(function(e, triggerEvent, romoOnkey) {
-      // TODO: move this delay logic into onkey component
-      clearTimeout(this.onkeySubmitTimeout);
-      this.onkeySubmitTimeout = setTimeout(
-        Romo.proxy(function() {
-          Romo.trigger(this.elem, 'romoForm:triggerSubmit');
-        }, this),
-        Romo.data(romoOnkey.elem, 'romo-form-onkey-submit-delay') || this.onkeyDefaultSubmitDelay
-      );
+      Romo.trigger(this.elem, 'romoForm:triggerSubmit');
     }, this));
   }, this));
 

--- a/assets/js/romo/onkey.js
+++ b/assets/js/romo/onkey.js
@@ -1,11 +1,14 @@
-var RomoOnkey = function(element) {
-  this.elem = element;
+var RomoOnkey = function(elem) {
+  this.elem = elem;
+
   this.defaultTriggerOn = 'keydown';
+  this.defaultDelayMs   = 0;
+  this.delayTimeout     = undefined;
 
   this.doInit();
 
   this.triggerOn = Romo.data(this.elem, 'romo-onkey-on') || this.defaultTriggerOn;
-  Romo.on(this.elem, this.triggerOn, Romo.proxy(this.onTrigger, this));
+  Romo.on(this.elem, this.triggerOn, Romo.proxy(this._onTrigger, this));
 
   this.elem.trigger('romoOnkey:ready', [this]);
 }
@@ -14,14 +17,22 @@ RomoOnkey.prototype.doInit = function() {
   // override as needed
 }
 
-RomoOnkey.prototype.onTrigger = function(e) {
+// private
+
+RomoOnkey.prototype._onTrigger = function(e) {
   if (Romo.hasClass(this.elem, 'disabled') === false) {
-    this.doTrigger(e);
+    this._doTrigger(e);
   }
 }
 
-RomoOnkey.prototype.doTrigger = function(triggerEvent) {
-  Romo.trigger(this.elem, 'romoOnkey:trigger', [triggerEvent, this]);
+RomoOnkey.prototype._doTrigger = function(triggerEvent) {
+  clearTimeout(this.delayTimeout);
+  this.delayTimeout = setTimeout(
+    Romo.proxy(function() {
+      Romo.trigger(this.elem, 'romoOnkey:trigger', [triggerEvent, this]);
+    }, this),
+    Romo.data(romoOnkey.elem, 'romo-onkey-delay-ms') || this.defaultDelayMs
+  );
 }
 
 Romo.onInitUI(function(elem) {

--- a/assets/js/romo/option_list_dropdown.js
+++ b/assets/js/romo/option_list_dropdown.js
@@ -338,17 +338,10 @@ RomoOptionListDropdown.prototype._bindDropdownOptionFilter = function() {
     this.optionFilterElem.focus();
   }, this));
 
-  this.onkeySearchTimeout = undefined;
-  this.onkeySearchDelay   = 100; // 0.1 secs, want it to be really responsive
-
+  // 0.1 secs, want it to be really responsive
+  this.optionFilterElem.attr('data-onkey-delay-ms', 100);
   this.optionFilterElem.on('romoOnkey:trigger', $.proxy(function(e, triggerEvent, romoOnkey) {
-    // TODO: incorp this timeout logic into the onkey component so don't have to repeat it
-    clearTimeout(this.onkeySearchTimeout);
-    this.onkeySearchTimeout = setTimeout($.proxy(function() {
-      if (Romo.nonInputTextKeyCodes().indexOf(triggerEvent.keyCode) === -1 /* Input Text */) {
-        this._filterOptionElems();
-      }
-    }, this), this.onkeySearchDelay);
+    this._filterOptionElems();
   }, this));
 }
 


### PR DESCRIPTION
This adds an optional delay feature to onkey.  If a delay data
attr is specified, onkey will delay for that many millisecs before
triggering the onkey event.  If another trigger happens before the
delay period is over, the delay is reset.  So this means the delay
will always be N secs after the *last* onkey trigger event.

This also cleans up the form and option list dropdown js to use
the new feature instead of doing this manually.

Finally, this cleans up a few style things to be up to our latest
conventions.  This includes making methods the should be
considered "private" to have the leading underscore convention.

@jcredding ready for review.