### PR TITLE
romoAjax: some cleanups to get up to modern conventions

### DIFF
--- a/assets/js/romo/form.js
+++ b/assets/js/romo/form.js
@@ -28,8 +28,8 @@ var RomoForm = function(formElem, givenSubmitElems, givenSpinnerElems) {
     this.decodeParams = true;
   }
 
-  this._bindFormElem();
   this.doInit();
+  this._bindFormElem();
 
   Romo.trigger(this.elem, 'romoForm:clearMsgs', [this]);
   Romo.trigger(this.elem, 'romoForm:ready',     [this]);


### PR DESCRIPTION
This mostly reorganizes the methods to make the "private" methods
follow our leading-underscore convention.  This also removes event
undefined checks on the event handlers (per latest convention) and
gets the `_trigger` method var names up to convention.

Note: I chose to make `_bindElem` private as it isn't intended to
be called externally.  However, `doUnbindElem` is called by modal,
dropdown, and tooltip to disabled the default invokes on their
ajax components so it needs to remain public.

Note also: this fixes the form js to bind the elem *after* calling
`doInit`.  The `doInit` method is intended to be for custom config
logic and needs to run *before* the elem is bound using the config
logic.  I messed this up in PR 156.

See #156 for reference.

@jcredding ready for review.