### PR TITLE
Update `RomoSortable` component to not use jquery

### DIFF
--- a/assets/js/romo/sortable.js
+++ b/assets/js/romo/sortable.js
@@ -1,5 +1,5 @@
 var RomoSortable = function(element) {
-  this.elem = $(element);
+  this.elem = element;
 
   this.draggableSelector = '[data-romo-sortable-item="true"]';
   this.handleSelector = '[data-romo-sortable-handle="true"]';
@@ -12,7 +12,7 @@ var RomoSortable = function(element) {
   this.doInitPlaceholder();
   this._resetGrabClasses();
 
-  this.elem.trigger('sortable:ready', [this]);
+  Romo.trigger(this.elem, 'romoSortable:ready', [this]);
 }
 
 RomoSortable.prototype.doInit = function() {
@@ -20,21 +20,21 @@ RomoSortable.prototype.doInit = function() {
 }
 
 RomoSortable.prototype.doBindDrag = function() {
-  this.draggingClass    = this.elem.data('romo-sortable-dragging-class') || '';
-  this.dragOverClass    = this.elem.data('romo-sortable-dragover-class') || '';
-  this.placeholderClass = this.elem.data('romo-sortable-placeholder-class') || '';
+  this.draggingClass    = Romo.data(this.elem, 'romo-sortable-dragging-class') || '';
+  this.dragOverClass    = Romo.data(this.elem, 'romo-sortable-dragover-class') || '';
+  this.placeholderClass = Romo.data(this.elem, 'romo-sortable-placeholder-class') || '';
 
-  this.draggableElems = $();
-  this.doBindDraggableElems(this.elem.find(this.draggableSelector));
+  this.draggableElems = [];
+  this.doBindDraggableElems(Romo.find(this.elem, this.draggableSelector));
 
-  this.elem.on('sortable:bindDraggableElems', $.proxy(this.onBindDraggableElems, this));
+  Romo.on(this.elem, 'romoSortable:bindDraggableElems', Romo.proxy(this.onBindDraggableElems, this));
 
-  this.elem.on('dragenter', $.proxy(this.onDragEnter, this));
-  this.elem.on('dragover',  $.proxy(this.onDragOver,  this));
-  this.elem.on('dragend',   $.proxy(this.onDragEnd,   this));
-  this.elem.on('drop',      $.proxy(this.onDragDrop,  this));
+  Romo.on(this.elem, 'dragenter', Romo.proxy(this.onDragEnter, this));
+  Romo.on(this.elem, 'dragover',  Romo.proxy(this.onDragOver,  this));
+  Romo.on(this.elem, 'dragend',   Romo.proxy(this.onDragEnd,   this));
+  Romo.on(this.elem, 'drop',      Romo.proxy(this.onDragDrop,  this));
 
-  $('body').on('mouseup', $.proxy(this.onWindowBodyMouseUp, this));
+  Romo.on(Romo.f('body')[0], 'mouseup', Romo.proxy(this.onWindowBodyMouseUp, this));
 }
 
 RomoSortable.prototype.onBindDraggableElems = function(e, draggableElems) {
@@ -42,50 +42,52 @@ RomoSortable.prototype.onBindDraggableElems = function(e, draggableElems) {
 }
 
 RomoSortable.prototype.doBindDraggableElems = function(draggableElems) {
-  draggableElems.prop('draggable', 'true');
+  draggableElems.forEach(Romo.proxy(function(draggableElem) {
+    draggableElem.draggable = true;
+  }, this));
 
-  draggableElems.on('dragstart',  $.proxy(this.onDragStart,          this));
-  draggableElems.on('dragenter',  $.proxy(this.onDragEnter,          this));
-  draggableElems.on('dragover',   $.proxy(this.onDragOver,           this));
-  draggableElems.on('dragend',    $.proxy(this.onDragEnd,            this));
-  draggableElems.on('drop',       $.proxy(this.onDragDrop,           this));
-  draggableElems.on('mousedown',  $.proxy(this.onDraggableMouseDown, this));
+  Romo.on(draggableElems, 'dragstart',  Romo.proxy(this.onDragStart,          this));
+  Romo.on(draggableElems, 'dragenter',  Romo.proxy(this.onDragEnter,          this));
+  Romo.on(draggableElems, 'dragover',   Romo.proxy(this.onDragOver,           this));
+  Romo.on(draggableElems, 'dragend',    Romo.proxy(this.onDragEnd,            this));
+  Romo.on(draggableElems, 'drop',       Romo.proxy(this.onDragDrop,           this));
+  Romo.on(draggableElems, 'mousedown',  Romo.proxy(this.onDraggableMouseDown, this));
 
-  var handleElems = draggableElems.find(this.handleSelector);
-  handleElems.on('mousedown', $.proxy(this.onHandleMouseDown, this));
+  var handleElems = Romo.find(draggableElems, this.handleSelector);
+  Romo.on(handleElems, 'mousedown', Romo.proxy(this.onHandleMouseDown, this));
 
-  this.draggableElems = this.draggableElems.add(draggableElems);
+  this.draggableElems = this.draggableElems.concat(draggableElems);
   this._resetGrabClasses();
 }
 
 RomoSortable.prototype.doInitPlaceholder = function() {
   var tag;
   try {
-    tag = this.draggableElems.get(0).tagName;
+    tag = this.draggableElems[0].tagName;
   } catch(e) {
     tag = /^ul|ol$/i.test(this.elem.tagName) ? 'li' : 'div';
   }
-  this.placeholderElem = $('<' + tag + '/>');
-  this.placeholderElem.addClass(this.placeholderClass);
+  this.placeholderElem = Romo.elems('<' + tag + '/>')[0];
+  Romo.addClass(this.placeholderElem, this.placeholderClass);
 
-  this.placeholderElem.on('dragover', $.proxy(this.onDragOver, this));
-  this.placeholderElem.on('drop',     $.proxy(this.onDragDrop, this));
+  Romo.on(this.placeholderElem, 'dragover', Romo.proxy(this.onDragOver, this));
+  Romo.on(this.placeholderElem, 'drop',     Romo.proxy(this.onDragDrop, this));
 }
 
 RomoSortable.prototype.onDragStart = function(e) {
   if(!this.draggableSelected){ return false; }
 
   e.stopPropagation();
-  e.originalEvent.dataTransfer.effectAllowed = 'move';
+  e.dataTransfer.effectAllowed = 'move';
 
   // IE fix
   try {
     // FF fix, it won't drag without some data being set
-    e.originalEvent.dataTransfer.setData('text/plain', null);
+    e.dataTransfer.setData('text/plain', null);
   } catch(e) {}
 
-  this.draggedElem = $(e.target);
-  this.draggedElem.addClass(this.draggingClass);
+  this.draggedElem = e.target;
+  Romo.addClass(this.draggedElem, this.draggingClass);
 
   // we need to disable Romo's parentRemovedObserver mutation
   // observer which would remove any child elems (ie modal,
@@ -96,13 +98,14 @@ RomoSortable.prototype.onDragStart = function(e) {
   // the drag is finished.
   // we manually enable the mutation observer for the dragged
   // elem below after we do the `insertBefore` call.
-  this.draggedElem.data('romo-parent-removed-observer-disabled', true);
+  Romo.setData(this.draggedElem, 'romo-parent-removed-observer-disabled', true);
 
-  this.draggedIndex = this.draggedElem.index();
+  var elems = Romo.children(Romo.parent(this.draggedElem));
+  this.draggedIndex = elems.indexOf(this.draggedElem);
 
-  this.placeholderElem.css({ 'height': this.draggedElem.height() });
+  Romo.setStyle(this.placeholderElem, 'height', Romo.css(this.draggedElem, 'height'));
 
-  this.elem.trigger('sortable:dragStart', [this.draggedElem, this]);
+  Romo.trigger(this.elem, 'romoSortable:dragStart', [this.draggedElem, this]);
 }
 
 RomoSortable.prototype.onDragEnter = function(e) {
@@ -110,40 +113,44 @@ RomoSortable.prototype.onDragEnter = function(e) {
   e.stopPropagation();
 
   // return if event is fired on the placeholder
-  if(this.placeholderElem.get(0) === e.currentTarget){ return; }
+  if(this.placeholderElem === e.currentTarget){ return; }
 
-  this.placeholderElem.show();
-  this.draggedElem.hide();
+  Romo.show(this.placeholderElem);
+  Romo.hide(this.draggedElem);
 
   // if event is not fired on the sortable
-  var overSortableElem = this.elem.get(0) === e.currentTarget;
-  var clientX = e.originalEvent.clientX;
-  var clientY = e.originalEvent.clientY;
+  var overSortableElem = this.elem === e.currentTarget;
+  var clientX = e.clientX;
+  var clientY = e.clientY;
   if (!overSortableElem) {
     // if we are in the same elem and moving the same direction, exit out
     var overSameElem = this.draggedOverElem &&
-                       this.draggedOverElem.get(0) === e.currentTarget;
+                       this.draggedOverElem === e.currentTarget;
     var sameDirection = (this.dragDirection === 'down' && clientY > this.lastY) ||
                         (this.dragDirection === 'up'   && clientY < this.lastY);
     if(overSameElem && sameDirection){ return; }
 
     // remove dragged over classes from previous elem
-    if(this.draggedOverElem){ this.draggedOverElem.removeClass(this.dragOverClass); }
-    this.draggedOverElem = $(e.currentTarget);
+    if(this.draggedOverElem){ Romo.removeClass(this.draggedOverElem, this.dragOverClass); }
+    this.draggedOverElem = e.currentTarget;
     this.lastY = clientY;
-    this.draggedOverElem.addClass(this.dragOverClass);
+    Romo.addClass(this.draggedOverElem, this.dragOverClass);
 
     // insert the placeholder according to the dragging direction
-    if (this.placeholderElem.index() < this.draggedOverElem.index()) {
+    var elems = Romo.children(Romo.parent(this.placeholderElem));
+    var placeholderIndex = elems.indexOf(this.placeholderElem);
+    elems = Romo.children(Romo.parent(this.draggedOverElem));
+    var draggedOverIndex = elems.indexOf(this.draggedOverElem);
+    if (placeholderIndex < draggedOverIndex) {
       this.dragDirection = 'down';
     } else {
       this.dragDirection = 'up';
     }
     var insertMethod = this.dragDirection === 'down' ? 'after' : 'before';
-    this.draggedOverElem[insertMethod](this.placeholderElem);
+    Romo[insertMethod](this.draggedOverElem, this.placeholderElem);
   }
 
-  this.elem.trigger('sortable:dragMove', [clientX, clientY, this.draggedElem, this]);
+  Romo.trigger(this.elem, 'romoSortable:dragMove', [clientX, clientY, this.draggedElem, this]);
 }
 
 RomoSortable.prototype.onDragOver = function(e) {
@@ -158,13 +165,15 @@ RomoSortable.prototype.onDragEnd = function(e) {
 
   if(!this.draggedElem){ return; }
 
-  this.draggableElems.removeClass(this.dragOverClass);
-  this.draggedElem.removeClass(this.draggingClass);
-  this.draggedElem.show();
-  this.placeholderElem.hide();
+  this.draggableElems.forEach(Romo.proxy(function(draggableElem) {
+    Romo.removeClass(draggableElem, this.dragOverClass);
+  }, this));
+  Romo.removeClass(this.draggedElem, this.draggingClass);
+  Romo.show(this.draggedElem);
+  Romo.hide(this.placeholderElem);
   this._resetGrabClasses();
 
-  this.elem.trigger('sortable:dragStop', [this.draggedElem, this]);
+  Romo.trigger(this.elem, 'romoSortable:dragStop', [this.draggedElem, this]);
 
   this.draggedElem = this.draggedIndex = this.draggableSelected = null;
   this.draggedOverElem = this.dragDirection = this.lastY = null;
@@ -176,40 +185,41 @@ RomoSortable.prototype.onDragDrop = function(e) {
 
   if(!this.draggedElem){ return; }
 
-  this.draggedElem.insertBefore(this.placeholderElem);
-  this.draggedElem.show();
+  Romo.before(this.draggedElem, this.placeholderElem);
+  Romo.show(this.draggedElem);
 
   // manually enable Romo's parentRemovedObserver mutation
   // observer which resumes removing any child elems (ie modal,
   // dropdown, tooltip popups) like normal.
   // we have to put this in a timeout so the reactor loop has a
   // chance to run the mutation observer before we re-enable
-  setTimeout($.proxy(function() {
-    this.draggedElem.data('romo-parent-removed-observer-disabled', false);
+  setTimeout(Romo.proxy(function() {
+    Romo.setData(this.draggedElem, 'romo-parent-removed-observer-disabled', false);
   }, this), 1);
 
-  var newIndex = this.draggedElem.index();
+  var elems = Romo.children(Romo.parent(this.draggedElem));
+  var newIndex = elems.indexOf(this.draggedElem);
   if (newIndex !== this.draggedIndex) {
-    this.elem.trigger('sortable:change', [this.draggedElem, this]);
+    Romo.trigger(this.elem, 'romoSortable:change', [this.draggedElem, this]);
   }
-  this.elem.trigger('sortable:dragDrop', [this.draggedElem, this]);
+  Romo.trigger(this.elem, 'romoSortable:dragDrop', [this.draggedElem, this]);
 }
 
 RomoSortable.prototype.onDraggableMouseDown = function(e) {
   // if our draggable elem doesn't have a handle then it's draggable
-  var draggableElem = $(e.currentTarget);
-  if(draggableElem.find(this.handleSelector).size() === 0) {
-    draggableElem.removeClass('romo-sortable-grab');
-    draggableElem.addClass('romo-sortable-grabbing');
+  var draggableElem = e.currentTarget;
+  if(Romo.find(draggableElem, this.handleSelector).length === 0) {
+    Romo.removeClass(draggableElem, 'romo-sortable-grab');
+    Romo.addClass(draggableElem, 'romo-sortable-grabbing');
     this.draggableSelected = true;
   }
 }
 
 RomoSortable.prototype.onHandleMouseDown = function(e) {
   this.draggableSelected = true;
-  var handleElem = $(e.currentTarget);
-  handleElem.removeClass('romo-sortable-grab');
-  handleElem.addClass('romo-sortable-grabbing');
+  var handleElem = e.currentTarget;
+  Romo.removeClass(handleElem, 'romo-sortable-grab');
+  Romo.addClass(handleElem, 'romo-sortable-grabbing');
 }
 
 RomoSortable.prototype.onWindowBodyMouseUp = function(e) {
@@ -218,12 +228,11 @@ RomoSortable.prototype.onWindowBodyMouseUp = function(e) {
 }
 
 RomoSortable.prototype._resetGrabClasses = function() {
-  this.draggableElems.each($.proxy(function(index, item) {
-    draggableElem = $(item);
-    handleElem = draggableElem.find(this.handleSelector);
-    if(handleElem.size() === 0){ handleElem = draggableElem; }
-    handleElem.addClass('romo-sortable-grab');
-    handleElem.removeClass('romo-sortable-grabbing');
+  this.draggableElems.forEach(Romo.proxy(function(index, draggableElem) {
+    handleElem = Romo.find(draggableElem, this.handleSelector)[0];
+    if(handleElem === undefined){ handleElem = draggableElem; }
+    Romo.addClass(handleElem, 'romo-sortable-grab');
+    Romo.removeClass(handleElem, 'romo-sortable-grabbing');
   }, this));
 }
 


### PR DESCRIPTION
This updates the `RomoSortable` component to not use jquery. This
is part of the effort to no longer require jquery to use Romo.
This removes all of the jquery usage within the `RomoSortable`
component. None of the other components initialize or use the
romo sortable component.

This also updates the event names to be prefixed with
`romoSortable` instead of just `sortable`. This is part of having
everything properly namespaced in romo and ensuring it should work
without issue with other javascript libraries.

@kellyredding - Ready for review.