### PR TITLE
romoDropdown: cleanups to get up to modern conventions

### DIFF
--- a/assets/js/romo/dropdown.js
+++ b/assets/js/romo/dropdown.js
@@ -1,32 +1,8 @@
-var RomoDropdown = function(element) {
-  this.elem = element;
-  this.doInitPopup();
-  this.romoAjax = new RomoAjax(this.elem);
-  this.romoAjax.doUnbindElem(); // disable auto invoke on click
-
-  if (Romo.data(this.elem, 'romo-dropdown-disable-click-invoke') !== true) {
-    Romo.on(this.elem, 'click', Romo.proxy(this.onToggleClick, this));
-  }
-  Romo.on(this.elem, 'romoDropdown:triggerToggle', Romo.proxy(this.onToggleClick, this));
-  Romo.on(this.elem, 'romoDropdown:triggerPopupOpen', Romo.proxy(this.onPopupOpen, this));
-  Romo.on(this.elem, 'romoDropdown:triggerPopupClose', Romo.proxy(this.onPopupClose, this));
-  Romo.on(this.elem, 'romoAjax:callStart', Romo.proxy(function(e, romoAjax) {
-    this.doLoadBodyStart();
-    return false;
-  }, this));
-  Romo.on(this.elem, 'romoAjax:callSuccess', Romo.proxy(function(e, data, romoAjax) {
-    this.doLoadBodySuccess(data);
-    return false;
-  }, this));
-  Romo.on(this.elem, 'romoAjax:callError', Romo.proxy(function(e, xhr, romoAjax) {
-    this.doLoadBodyError(xhr);
-    return false;
-  }, this));
-
-  this.doBindElemKeyUp();
+var RomoDropdown = function(elem) {
+  this.elem = elem;
 
   this.doInit();
-  this.doInitBody();
+  this._bindElem();
 
   Romo.trigger(this.elem, 'romoDropdown:ready', [this]);
 }
@@ -43,130 +19,6 @@ RomoDropdown.prototype.doInit = function() {
   // override as needed
 }
 
-RomoDropdown.prototype.doInitPopup = function() {
-  this.popupElem = Romo.elems('<div class="romo-dropdown-popup"><div class="romo-dropdown-body"></div></div>')[0];
-  var popupParentElem = Romo.closest(this.elem, Romo.data(this.elem, 'romo-dropdown-append-to-closest') || 'body');
-  Romo.append(popupParentElem, this.popupElem);
-
-  Romo.on(this.popupElem, 'romoModal:popupOpen', Romo.proxy(function(e) {
-    this.doUnBindWindowBodyClick();
-    this.doUnBindWindowBodyKeyUp();
-    this.doUnBindElemKeyUp();
-  }, this));
-  Romo.on(this.popupElem, 'romoModal:popupClose', Romo.proxy(function(e) {
-    this.doBindWindowBodyClick();
-    this.doBindWindowBodyKeyUp();
-    this.doBindElemKeyUp();
-  }, this));
-
-  this.bodyElem = Romo.find(this.popupElem, '> .romo-dropdown-body')[0];
-  if (Romo.data(this.elem, 'romo-dropdown-style-class') !== undefined) {
-    Romo.addClass(this.bodyElem, Romo.data(this.elem, 'romo-dropdown-style-class'));
-  }
-
-  this.contentElem = undefined;
-
-  var positionData = this._parsePositionData(Romo.data(this.elem, 'romo-dropdown-position'));
-  this.popupPosition  = positionData.position  || 'bottom';
-  this.popupAlignment = positionData.alignment || 'left';
-  Romo.setData(this.popupElem, 'romo-dropdown-position',  this.popupPosition);
-  Romo.setData(this.popupElem, 'romo-dropdown-alignment', this.popupAlignment);
-
-  this.doSetPopupZIndex(this.elem);
-
-  // don't propagate click events on the popup elem.  this prevents the popup
-  // from closing when clicked (see body click event bind on popup open)
-  Romo.on(this.popupElem, 'click', function(e) {
-    if (e !== undefined) {
-      e.stopPropagation();
-    }
-  })
-
-  // the popup should be treated like a child elem.  add it to Romo's
-  // parent-child elems so it will be removed when the elem is removed.
-  // delay adding it b/c other components may `append` generated dropdowns
-  // meaning the dropdown is removed and then re-added.  if added immediately
-  // the "remove" part will incorrectly remove the popup.
-  setTimeout(Romo.proxy(function() {
-    Romo.parentChildElems.add(this.elem, [this.popupElem]);
-  }, this), 1);
-}
-
-RomoDropdown.prototype.doInitBody = function() {
-  this.doResetBody();
-
-  var contentElems = Romo.find(this.bodyElem, '.romo-dropdown-content');
-  this.contentElem = contentElems[contentElems.length - 1];
-  if (this.contentElem === undefined) {
-    this.contentElem = this.bodyElem;
-  }
-
-  this.closeElem = Romo.find(this.popupElem, '[data-romo-dropdown-close="true"]')[0];
-  Romo.on(this.closeElem, 'click', Romo.proxy(this.onPopupClose, this));
-
-  Romo.setStyle(this.contentElem, 'min-height', Romo.data(this.elem, 'romo-dropdown-min-height'));
-  Romo.setStyle(this.contentElem, 'height',     Romo.data(this.elem, 'romo-dropdown-height'));
-  Romo.setStyle(this.contentElem, 'overflow-x', Romo.data(this.elem, 'romo-dropdown-overflow-x') || 'auto');
-  Romo.setStyle(this.contentElem, 'overflow-y', Romo.data(this.elem, 'romo-dropdown-overflow-y') || 'auto');
-
-  if (Romo.data(this.elem, 'romo-dropdown-max-height') === undefined) {
-    Romo.setData(this.elem, 'romo-dropdown-max-height', 'detect');
-  }
-  if (Romo.data(this.elem, 'romo-dropdown-max-height') !== 'detect') {
-    Romo.setStyle(this.contentElem, 'max-height', Romo.data(this.elem, 'romo-dropdown-max-height'));
-  }
-
-  if (Romo.data(this.elem, 'romo-dropdown-width') === 'elem') {
-    Romo.setStyle(this.popupElem, 'width', Romo.css(this.elem, 'width'));
-  } else {
-    Romo.setStyle(this.contentElem, 'min-width', Romo.data(this.elem, 'romo-dropdown-min-width'));
-    Romo.setStyle(this.contentElem, 'max-width', Romo.data(this.elem, 'romo-dropdown-max-width'));
-    Romo.setStyle(this.contentElem, 'width',     Romo.data(this.elem, 'romo-dropdown-width'));
-  }
-}
-
-RomoDropdown.prototype.doResetBody = function() {
-  Romo.setStyle(this.contentElem, 'min-width',  '');
-  Romo.setStyle(this.contentElem, 'max-width',  '');
-  Romo.setStyle(this.contentElem, 'width',      '');
-  Romo.setStyle(this.contentElem, 'min-height', '');
-  Romo.setStyle(this.contentElem, 'max-height', '');
-  Romo.setStyle(this.contentElem, 'height',     '');
-  Romo.setStyle(this.contentElem, 'overflow-x', '');
-  Romo.setStyle(this.contentElem, 'overflow-y', '');
-}
-
-RomoDropdown.prototype.doLoadBodyStart = function() {
-  Romo.updateHtml(this.bodyElem, '');
-  this.doInitBody();
-  this.doPlacePopupElem();
-  Romo.trigger(this.elem, 'romoDropdown:loadBodyStart', [this]);
-}
-
-RomoDropdown.prototype.doLoadBodySuccess = function(data) {
-  Romo.initUpdateHtml(this.bodyElem, data);
-  this.doInitBody();
-  this.doPlacePopupElem();
-  Romo.trigger(this.elem, 'romoDropdown:loadBodySuccess', [data, this]);
-}
-
-RomoDropdown.prototype.doLoadBodyError = function(xhr) {
-  Romo.trigger(this.elem, 'romoDropdown:loadBodyError', [xhr, this]);
-}
-
-RomoDropdown.prototype.onToggleClick = function(e) {
-  if (e !== undefined) {
-    e.preventDefault();
-  }
-
-  if (Romo.hasClass(this.elem, 'disabled') === false &&
-      Romo.data(this.elem, 'romo-dropdown-disable-toggle') !== true) {
-    this.doToggle();
-    return true;
-  }
-  return false;
-}
-
 RomoDropdown.prototype.doToggle = function() {
   if (this.popupOpen()) {
     setTimeout(Romo.proxy(function() {
@@ -180,22 +32,10 @@ RomoDropdown.prototype.doToggle = function() {
   Romo.trigger(this.elem, 'romoDropdown:toggle', [this]);
 }
 
-RomoDropdown.prototype.onPopupOpen = function(e) {
-  if (e !== undefined) {
-    e.preventDefault();
-  }
-
-  if (Romo.hasClass(this.elem, 'disabled') === false && this.popupClosed()) {
-    setTimeout(Romo.proxy(function() {
-      this.doPopupOpen();
-    }, this), 100);
-  }
-}
-
 RomoDropdown.prototype.doPopupOpen = function() {
   if (Romo.data(this.elem, 'romo-dropdown-content-elem') !== undefined) {
     var contentElem = Romo.elems(Romo.data(this.elem, 'romo-dropdown-content-elem'))[0];
-    this.doLoadBodySuccess(contentElem.outerHTML);
+    this._loadBodySuccess(contentElem.outerHTML);
   } else {
     this.romoAjax.doInvoke();
   }
@@ -209,41 +49,29 @@ RomoDropdown.prototype.doPopupOpen = function() {
   // event, then the toggle click will propagate which will call
   // this event and immediately close the popup.
   setTimeout(Romo.proxy(function() {
-    this.doBindWindowBodyClick();
-  }, this), 100);
+    this._bindWindowBodyClick();
+  }, this), 1);
 
   // bind "esc" keystroke to toggle close
-  this.doBindWindowBodyKeyUp();
+  this._bindWindowBodyKeyUp();
 
   // bind window resizes reposition dropdown
-  Romo.on(window, 'resize', Romo.proxy(this.onResizeWindow, this));
+  Romo.on(window, 'resize', Romo.proxy(this._onResizeWindow, this));
 
   Romo.trigger(this.elem, 'romoDropdown:popupOpen', [this]);
-}
-
-RomoDropdown.prototype.onPopupClose = function(e) {
-  if (e !== undefined) {
-    e.preventDefault();
-  }
-
-  if (Romo.hasClass(this.elem, 'disabled') === false && this.popupOpen()) {
-    setTimeout(Romo.proxy(function() {
-      this.doPopupClose();
-    }, this), 100);
-  }
 }
 
 RomoDropdown.prototype.doPopupClose = function() {
   Romo.removeClass(this.popupElem, 'romo-dropdown-open');
 
   // unbind any event to close the popup when clicking away from it
-  this.doUnBindWindowBodyClick();
+  this._unBindWindowBodyClick();
 
   // unbind "esc" keystroke to toggle close
-  this.doUnBindWindowBodyKeyUp();
+  this._unBindWindowBodyKeyUp();
 
   // unbind window resizes reposition dropdown
-  Romo.off(window, 'resize', Romo.proxy(this.onResizeWindow, this));
+  Romo.off(window, 'resize', Romo.proxy(this._onResizeWindow, this));
 
   // clear the content elem markup if configured to
   if (Romo.data(this.elem, 'romo-dropdown-clear-content') === true) {
@@ -253,102 +81,23 @@ RomoDropdown.prototype.doPopupClose = function() {
   Romo.trigger(this.elem, 'romoDropdown:popupClose', [this]);
 }
 
-RomoDropdown.prototype.doBindElemKeyUp = function() {
-  Romo.on(this.elem, 'keyup', Romo.proxy(this.onElemKeyUp, this));
-  Romo.on(this.popupElem, 'keyup', Romo.proxy(this.onElemKeyUp, this));
-}
-
-RomoDropdown.prototype.doUnBindElemKeyUp = function() {
-  Romo.off(this.elem, 'keyup', Romo.proxy(this.onElemKeyUp, this));
-  Romo.off(this.popupElem, 'keyup', Romo.proxy(this.onElemKeyUp, this));
-}
-
-RomoDropdown.prototype.onElemKeyUp = function(e) {
-  if (Romo.hasClass(this.elem, 'disabled') === false) {
-    if (this.popupOpen()) {
-      if(e.keyCode === 27 /* Esc */ ) {
-        this.doPopupClose();
-        Romo.trigger(this.elem, 'romoDropdown:popupClosedByEsc', [this]);
-        return false;
-      } else {
-        return true;
-      }
-    } else {
-      return true;
-    }
-  }
-  return true;
-}
-
-RomoDropdown.prototype.doBindWindowBodyClick = function() {
-  var bodyElem = Romo.f('body')[0];
-  Romo.on(bodyElem, 'click', Romo.proxy(this.onWindowBodyClick, this));
-  Romo.on(bodyElem, 'romoModal:mousemove', Romo.proxy(this.onWindowBodyClick, this));
-}
-
-RomoDropdown.prototype.doUnBindWindowBodyClick = function() {
-  var bodyElem = Romo.f('body')[0];
-  Romo.off(bodyElem, 'click', Romo.proxy(this.onWindowBodyClick, this));
-  Romo.off(bodyElem, 'romoModal:mousemove', Romo.proxy(this.onWindowBodyClick, this));
-}
-
-RomoDropdown.prototype.onWindowBodyClick = function(e) {
-  // if not clicked on the popup elem or the elem
-  if (e !== undefined) {
-    var parentPopupElems = Romo.parents(e.target, '.romo-dropdown-popup');
-
-    var elemIsParentOfTarget = false;
-    Romo.parents(e.target).forEach(Romo.proxy(function(parentElem) {
-      if(elemIsParentOfTarget){ return; }
-      elemIsParentOfTarget = parentElem == this.elem;
-    }, this));
-
-    if (parentPopupElems.length === 0 && elemIsParentOfTarget === false) {
-      this.doPopupClose();
-    }
-  }
-  return true;
-}
-
-RomoDropdown.prototype.doBindWindowBodyKeyUp = function() {
-  var bodyElem = Romo.f('body')[0];
-  Romo.on(bodyElem, 'keyup', Romo.proxy(this.onWindowBodyKeyUp, this));
-}
-
-RomoDropdown.prototype.doUnBindWindowBodyKeyUp = function() {
-  var bodyElem = Romo.f('body')[0];
-  Romo.off(bodyElem, 'keyup', Romo.proxy(this.onWindowBodyKeyUp, this));
-}
-
-RomoDropdown.prototype.onWindowBodyKeyUp = function(e) {
-  if (e.keyCode === 27 /* Esc */) {
-    this.doPopupClose();
-    Romo.trigger(this.elem, 'romoDropdown:popupClosedByEsc', [this]);
-  }
-  return true;
-}
-
-RomoDropdown.prototype.onResizeWindow = function(e) {
-  this.doPlacePopupElem();
-  return true;
-}
-
 RomoDropdown.prototype.doPlacePopupElem = function() {
   if (Romo.parents(this.elem, '.romo-modal-popup').length !== 0) {
     Romo.setStyle(this.popupElem, 'position', 'fixed');
   }
 
-  var pos = Romo.assign({}, this.elem.getBoundingClientRect(), Romo.offset(this.elem));
-  var w = this.popupElem.offsetWidth;
-  var h = this.popupElem.offsetHeight;
+  var pos    = Romo.assign({}, this.elem.getBoundingClientRect(), Romo.offset(this.elem));
+  var w      = this.popupElem.offsetWidth;
+  var h      = this.popupElem.offsetHeight;
   var offset = {};
 
-  var configHeight = Romo.data(this.elem, 'romo-dropdown-height') || Romo.data(this.elem, 'romo-dropdown-max-height');
+  var configHeight = Romo.data(this.elem, 'romo-dropdown-height') ||
+                     Romo.data(this.elem, 'romo-dropdown-max-height');
   var configPosition = this.popupPosition;
 
   if (configHeight === 'detect') {
-    var popupHeight = parseInt(Romo.css(this.popupElem, 'height'));
-    var topAvailHeight = this._getPopupMaxAvailableHeight('top');
+    var popupHeight       = parseInt(Romo.css(this.popupElem, 'height'));
+    var topAvailHeight    = this._getPopupMaxAvailableHeight('top');
     var bottomAvailHeight = this._getPopupMaxAvailableHeight('bottom');
 
     if (popupHeight < topAvailHeight && popupHeight < bottomAvailHeight) {
@@ -395,7 +144,258 @@ RomoDropdown.prototype.doPlacePopupElem = function() {
   Romo.setStyle(this.popupElem, 'left', this._roundPosOffsetVal(offset.left));
 }
 
-RomoDropdown.prototype.doSetPopupZIndex = function(relativeElem) {
+// private
+
+RomoDropdown.prototype._bindElem = function() {
+  this._bindPopup();
+  this._bindAjax();
+  this._bindBody();
+  this._bindElemKeyUp();
+
+  if (Romo.data(this.elem, 'romo-dropdown-disable-click-invoke') !== true) {
+    Romo.on(this.elem, 'click', Romo.proxy(this._onToggle, this));
+  }
+  Romo.on(this.elem, 'romoDropdown:triggerToggle',     Romo.proxy(this._onToggle,     this));
+  Romo.on(this.elem, 'romoDropdown:triggerPopupOpen',  Romo.proxy(this._onPopupOpen,  this));
+  Romo.on(this.elem, 'romoDropdown:triggerPopupClose', Romo.proxy(this._onPopupClose, this));
+}
+
+RomoDropdown.prototype._bindPopup = function() {
+  this.popupElem = Romo.elems('<div class="romo-dropdown-popup"><div class="romo-dropdown-body"></div></div>')[0];
+  var popupParentElem = Romo.closest(this.elem, Romo.data(this.elem, 'romo-dropdown-append-to-closest') || 'body');
+  Romo.append(popupParentElem, this.popupElem);
+
+  Romo.on(this.popupElem, 'romoModal:popupOpen', Romo.proxy(function(e) {
+    this._unBindWindowBodyClick();
+    this._unBindWindowBodyKeyUp();
+    this._unBindElemKeyUp();
+  }, this));
+  Romo.on(this.popupElem, 'romoModal:popupClose', Romo.proxy(function(e) {
+    this._bindWindowBodyClick();
+    this._bindWindowBodyKeyUp();
+    this._bindElemKeyUp();
+  }, this));
+
+  this.bodyElem = Romo.find(this.popupElem, '> .romo-dropdown-body')[0];
+  if (Romo.data(this.elem, 'romo-dropdown-style-class') !== undefined) {
+    Romo.addClass(this.bodyElem, Romo.data(this.elem, 'romo-dropdown-style-class'));
+  }
+
+  this.contentElem = undefined;
+
+  var positionData = this._parsePositionData(Romo.data(this.elem, 'romo-dropdown-position'));
+  this.popupPosition  = positionData.position  || 'bottom';
+  this.popupAlignment = positionData.alignment || 'left';
+  Romo.setData(this.popupElem, 'romo-dropdown-position',  this.popupPosition);
+  Romo.setData(this.popupElem, 'romo-dropdown-alignment', this.popupAlignment);
+
+  this._setPopupZIndex(this.elem);
+
+  // don't propagate click events on the popup elem.  this prevents the popup
+  // from closing when clicked (see body click event bind on popup open)
+  Romo.on(this.popupElem, 'click', function(e) {
+    e.stopPropagation();
+  })
+
+  // the popup should be treated like a child elem.  add it to Romo's
+  // parent-child elems so it will be removed when the elem is removed.
+  // delay adding it b/c other components may `append` generated dropdowns
+  // meaning the dropdown is removed and then re-added.  if added immediately
+  // the "remove" part will incorrectly remove the popup.
+  setTimeout(Romo.proxy(function() {
+    Romo.parentChildElems.add(this.elem, [this.popupElem]);
+  }, this), 1);
+}
+
+RomoDropdown.prototype._bindAjax = function() {
+  this.romoAjax = new RomoAjax(this.elem);
+  this.romoAjax.doUnbindElem(); // disable auto invoke on click
+
+  Romo.on(this.elem, 'romoAjax:callStart', Romo.proxy(function(e, romoAjax) {
+    this._loadBodyStart();
+    return false;
+  }, this));
+  Romo.on(this.elem, 'romoAjax:callSuccess', Romo.proxy(function(e, data, romoAjax) {
+    this._loadBodySuccess(data);
+    return false;
+  }, this));
+  Romo.on(this.elem, 'romoAjax:callError', Romo.proxy(function(e, xhr, romoAjax) {
+    this._loadBodyError(xhr);
+    return false;
+  }, this));
+}
+
+RomoDropdown.prototype._bindBody = function() {
+  this._resetBody();
+
+  var contentElems = Romo.find(this.bodyElem, '.romo-dropdown-content');
+  this.contentElem = contentElems[contentElems.length - 1];
+  if (this.contentElem === undefined) {
+    this.contentElem = this.bodyElem;
+  }
+
+  this.closeElem = Romo.find(this.popupElem, '[data-romo-dropdown-close="true"]')[0];
+  Romo.on(this.closeElem, 'click', Romo.proxy(this.onPopupClose, this));
+
+  Romo.setStyle(this.contentElem, 'min-height', Romo.data(this.elem, 'romo-dropdown-min-height'));
+  Romo.setStyle(this.contentElem, 'height',     Romo.data(this.elem, 'romo-dropdown-height'));
+  Romo.setStyle(this.contentElem, 'overflow-x', Romo.data(this.elem, 'romo-dropdown-overflow-x') || 'auto');
+  Romo.setStyle(this.contentElem, 'overflow-y', Romo.data(this.elem, 'romo-dropdown-overflow-y') || 'auto');
+
+  if (Romo.data(this.elem, 'romo-dropdown-max-height') === undefined) {
+    Romo.setData(this.elem, 'romo-dropdown-max-height', 'detect');
+  }
+  if (Romo.data(this.elem, 'romo-dropdown-max-height') !== 'detect') {
+    Romo.setStyle(this.contentElem, 'max-height', Romo.data(this.elem, 'romo-dropdown-max-height'));
+  }
+
+  if (Romo.data(this.elem, 'romo-dropdown-width') === 'elem') {
+    Romo.setStyle(this.popupElem, 'width', Romo.css(this.elem, 'width'));
+  } else {
+    Romo.setStyle(this.contentElem, 'min-width', Romo.data(this.elem, 'romo-dropdown-min-width'));
+    Romo.setStyle(this.contentElem, 'max-width', Romo.data(this.elem, 'romo-dropdown-max-width'));
+    Romo.setStyle(this.contentElem, 'width',     Romo.data(this.elem, 'romo-dropdown-width'));
+  }
+}
+
+RomoDropdown.prototype._resetBody = function() {
+  Romo.setStyle(this.contentElem, 'min-width',  '');
+  Romo.setStyle(this.contentElem, 'max-width',  '');
+  Romo.setStyle(this.contentElem, 'width',      '');
+  Romo.setStyle(this.contentElem, 'min-height', '');
+  Romo.setStyle(this.contentElem, 'max-height', '');
+  Romo.setStyle(this.contentElem, 'height',     '');
+  Romo.setStyle(this.contentElem, 'overflow-x', '');
+  Romo.setStyle(this.contentElem, 'overflow-y', '');
+}
+
+RomoDropdown.prototype._loadBodyStart = function() {
+  Romo.updateHtml(this.bodyElem, '');
+  this._bindBody();
+  this.doPlacePopupElem();
+  Romo.trigger(this.elem, 'romoDropdown:loadBodyStart', [this]);
+}
+
+RomoDropdown.prototype._loadBodySuccess = function(data) {
+  Romo.initUpdateHtml(this.bodyElem, data);
+  this._bindBody();
+  this.doPlacePopupElem();
+  Romo.trigger(this.elem, 'romoDropdown:loadBodySuccess', [data, this]);
+}
+
+RomoDropdown.prototype._loadBodyError = function(xhr) {
+  Romo.trigger(this.elem, 'romoDropdown:loadBodyError', [xhr, this]);
+}
+
+RomoDropdown.prototype._onToggle = function(e) {
+  if (
+    Romo.hasClass(this.elem, 'disabled') === false &&
+    Romo.data(this.elem, 'romo-dropdown-disable-toggle') !== true
+  ) {
+    this.doToggle();
+  }
+
+  return false;
+}
+
+RomoDropdown.prototype._onPopupOpen = function(e) {
+  if (Romo.hasClass(this.elem, 'disabled') === false && this.popupClosed()) {
+    setTimeout(Romo.proxy(function() {
+      this.doPopupOpen();
+    }, this), 1);
+  }
+}
+
+RomoDropdown.prototype._onPopupClose = function(e) {
+  if (Romo.hasClass(this.elem, 'disabled') === false && this.popupOpen()) {
+    setTimeout(Romo.proxy(function() {
+      this.doPopupClose();
+    }, this), 1;
+  }
+}
+
+RomoDropdown.prototype._bindElemKeyUp = function() {
+  Romo.on(this.elem,      'keyup', Romo.proxy(this._onElemKeyUp, this));
+  Romo.on(this.popupElem, 'keyup', Romo.proxy(this._onElemKeyUp, this));
+}
+
+RomoDropdown.prototype._unBindElemKeyUp = function() {
+  Romo.off(this.elem,      'keyup', Romo.proxy(this._onElemKeyUp, this));
+  Romo.off(this.popupElem, 'keyup', Romo.proxy(this._onElemKeyUp, this));
+}
+
+RomoDropdown.prototype._onElemKeyUp = function(e) {
+  if (Romo.hasClass(this.elem, 'disabled') === false) {
+    if (this.popupOpen()) {
+      if(e.keyCode === 27 /* Esc */ ) {
+        this.doPopupClose();
+        Romo.trigger(this.elem, 'romoDropdown:popupClosedByEsc', [this]);
+        return false;
+      } else {
+        return true;
+      }
+    } else {
+      return true;
+    }
+  }
+  return true;
+}
+
+RomoDropdown.prototype._bindWindowBodyClick = function() {
+  var bodyElem = Romo.f('body')[0];
+  Romo.on(bodyElem, 'click',               Romo.proxy(this._onWindowBodyClick, this));
+  Romo.on(bodyElem, 'romoModal:mousemove', Romo.proxy(this._onWindowBodyClick, this));
+}
+
+RomoDropdown.prototype._unBindWindowBodyClick = function() {
+  var bodyElem = Romo.f('body')[0];
+  Romo.off(bodyElem, 'click',               Romo.proxy(this._onWindowBodyClick, this));
+  Romo.off(bodyElem, 'romoModal:mousemove', Romo.proxy(this._onWindowBodyClick, this));
+}
+
+RomoDropdown.prototype._onWindowBodyClick = function(e) {
+  // if not clicked on the popup elem or the elem
+  if (e !== undefined) {
+    var parentPopupElems = Romo.parents(e.target, '.romo-dropdown-popup');
+
+    var elemIsParentOfTarget = Romo.parents(e.target).reduce(
+      Romo.proxy(function(isParent, parentElem) {
+        return isParent || (parentElem == this.elem);
+      }, this),
+      false
+    );
+
+    if (parentPopupElems.length === 0 && elemIsParentOfTarget === false) {
+      this.doPopupClose();
+    }
+  }
+  return true;
+}
+
+RomoDropdown.prototype._bindWindowBodyKeyUp = function() {
+  var bodyElem = Romo.f('body')[0];
+  Romo.on(bodyElem, 'keyup', Romo.proxy(this._onWindowBodyKeyUp, this));
+}
+
+RomoDropdown.prototype._nBindWindowBodyKeyUp = function() {
+  var bodyElem = Romo.f('body')[0];
+  Romo.off(bodyElem, 'keyup', Romo.proxy(this._onWindowBodyKeyUp, this));
+}
+
+RomoDropdown.prototype._onWindowBodyKeyUp = function(e) {
+  if (e.keyCode === 27 /* Esc */) {
+    this.doPopupClose();
+    Romo.trigger(this.elem, 'romoDropdown:popupClosedByEsc', [this]);
+  }
+  return true;
+}
+
+RomoDropdown.prototype._onResizeWindow = function(e) {
+  this.doPlacePopupElem();
+  return true;
+}
+
+RomoDropdown.prototype._setPopupZIndex = function(relativeElem) {
   var relativeZIndex = Romo.parseZIndex(relativeElem);
   Romo.setStyle(this.popupElem, 'z-index', relativeZIndex + 1200); // see z-index.css
 }


### PR DESCRIPTION
This mostly reorganizes the methods to make the "private" methods
follow our leading-underscore convention. This also removes event
undefined checks on the event handlers (per latest convention).

There are a few smaller tweaks here too:

* I reorganized the bind logic to make sure `doInit` was being
  called (to set any config logic) before binding the elem, etc.
* I updated the `setTimeout` calls to just user `1` for the
  timeout value as this was just intended to "kick" the reactor
  (not actually delay 100ms).
* I updated the parent check to use a `reduce` statement to find
  if `elemIsParentOfTarget`.  This seemed more appropriate than
  the prev manual implementation.

@jcredding ready for review.