### PR TITLE
romoInline: cleanups to get up to modern conventions

### DIFF
--- a/assets/js/romo/inline.js
+++ b/assets/js/romo/inline.js
@@ -1,28 +1,10 @@
-var RomoInline = function(element) {
-  this.elem        = element;
-  this.toggleElem  = Romo.f(Romo.data(this.elem, 'romo-inline-toggle'))[0];
-  this.dismissElem = undefined;
+var RomoInline = function(elem) {
+  this.elem = elem;
 
-  Romo.on(this.elem, 'romoInline:triggerDismiss', Romo.proxy(this.onDismissClick, this));
-  Romo.on(this.elem, 'romoInline:triggerShow',  Romo.proxy(function(e) {
-    this.doShow();
-  }, this));
-
-  Romo.on(this.elem, 'romoAjax:callStart', Romo.proxy(function(e, romoAjax) {
-    this.doLoadStart();
-    return false;
-  }, this));
-  Romo.on(this.elem, 'romoAjax:callSuccess', Romo.proxy(function(e, data, romoAjax) {
-    this.doLoadSuccess(data);
-    return false;
-  }, this));
-  Romo.on(this.elem, 'romoAjax:callError', Romo.proxy(function(e, xhr, romoAjax) {
-    this.doLoadError(xhr);
-    return false;
-  }, this));
+  this.doInit();
+  this._bindElem();
 
   this.doBindDismiss();
-  this.doInit();
   Romo.trigger(this.elem, 'romoInline:ready', [this]);
 }
 
@@ -30,38 +12,10 @@ RomoInline.prototype.doInit = function() {
   // override as needed
 }
 
-RomoInline.prototype.doLoadStart = function() {
-  Romo.updateHtml(this.elem, '');
-  Romo.trigger(this.elem, 'romoInline:loadStart', [this]);
-}
-
-RomoInline.prototype.doLoadSuccess = function(data) {
-  this.doShow();
-  Romo.initHtml(this.elem, data);
-  this.doBindDismiss();
-  Romo.trigger(this.elem, 'romoInline:loadSuccess', [data, this]);
-}
-
-RomoInline.prototype.doLoadError = function(xhr) {
-  this.doShow();
-  Romo.trigger(this.elem, 'romoInline:loadError', [xhr, this]);
-}
-
-RomoInline.prototype.doBindDismiss = function() {
-  this.dismissElem = Romo.find(this.elem, '[data-romo-inline-dismiss]')[0];
-  Romo.on(this.dismissElem, 'click', Romo.proxy(this.onDismissClick, this));
-}
-
-RomoInline.prototype.onDismissClick = function(e) {
-  if (e !== undefined) {
-    e.preventDefault();
-  }
-
-  if (Romo.data(this.dismissElem, 'romo-inline-dismiss') === 'confirm') {
-    Romo.trigger(this.elem, 'romoInline:confirmDismiss', [this]);
-  } else if (Romo.hasClass(this.dismissElem, 'disabled') === false) {
-    this.doDismiss();
-  }
+RomoInline.prototype.doShow = function() {
+  Romo.show(this.elem);
+  Romo.hide(this.toggleElem);
+  Romo.trigger(this.elem, 'romoInline:show', [this]);
 }
 
 RomoInline.prototype.doDismiss = function() {
@@ -70,10 +24,62 @@ RomoInline.prototype.doDismiss = function() {
   Romo.trigger(this.elem, 'romoInline:dismiss', [this]);
 }
 
-RomoInline.prototype.doShow = function() {
-  Romo.show(this.elem);
-  Romo.hide(this.toggleElem);
-  Romo.trigger(this.elem, 'romoInline:show', [this]);
+// private
+
+RomoDropdown.prototype._bindElem = function() {
+  this._bindDismiss();
+
+  this.toggleElem = Romo.f(Romo.data(this.elem, 'romo-inline-toggle'))[0];
+
+  Romo.on(this.elem, 'romoInline:triggerDismiss', Romo.proxy(this._onDismissClick, this));
+  Romo.on(this.elem, 'romoInline:triggerShow',    Romo.proxy(function(e) {
+    this.doShow();
+  }, this));
+
+  Romo.on(this.elem, 'romoAjax:callStart', Romo.proxy(function(e, romoAjax) {
+    this._loadStart();
+    return false;
+  }, this));
+  Romo.on(this.elem, 'romoAjax:callSuccess', Romo.proxy(function(e, data, romoAjax) {
+    this._loadSuccess(data);
+    return false;
+  }, this));
+  Romo.on(this.elem, 'romoAjax:callError', Romo.proxy(function(e, xhr, romoAjax) {
+    this._loadError(xhr);
+    return false;
+  }, this));
+}
+
+RomoInline.prototype._bindDismiss = function() {
+  this.dismissElem = Romo.find(this.elem, '[data-romo-inline-dismiss]')[0];
+  Romo.on(this.dismissElem, 'click', Romo.proxy(this._onDismissClick, this));
+}
+
+RomoInline.prototype._loadStart = function() {
+  Romo.updateHtml(this.elem, '');
+  Romo.trigger(this.elem, 'romoInline:loadStart', [this]);
+}
+
+RomoInline.prototype._loadSuccess = function(data) {
+  this.doShow();
+  Romo.initUpdateHtml(this.elem, data);
+  this.doBindDismiss();
+  Romo.trigger(this.elem, 'romoInline:loadSuccess', [data, this]);
+}
+
+RomoInline.prototype._loadError = function(xhr) {
+  this.doShow();
+  Romo.trigger(this.elem, 'romoInline:loadError', [xhr, this]);
+}
+
+RomoInline.prototype._onDismissClick = function(e) {
+  e.preventDefault();
+
+  if (Romo.data(this.dismissElem, 'romo-inline-dismiss') === 'confirm') {
+    Romo.trigger(this.elem, 'romoInline:confirmDismiss', [this]);
+  } else if (Romo.hasClass(this.dismissElem, 'disabled') === false) {
+    this.doDismiss();
+  }
 }
 
 Romo.onInitUI(function(elem) {


### PR DESCRIPTION
This mostly reorganizes the methods to make the "private" methods
follow our leading-underscore convention. This also removes event
undefined checks on the event handlers (per latest convention).
I also reorganized the bind logic to make sure `doInit` was being
called (to set any config logic) before binding the elem, etc.

@jcredding ready for review.