### PR TITLE
romoDatepicker: cleanups to get up to modern conventions

### DIFF
--- a/assets/js/romo/dropdown.js
+++ b/assets/js/romo/dropdown.js
@@ -144,6 +144,11 @@ RomoDropdown.prototype.doPlacePopupElem = function() {
   Romo.setStyle(this.popupElem, 'left', this._roundPosOffsetVal(offset.left));
 }
 
+RomoDropdown.prototype.doSetPopupZIndex = function(relativeElem) {
+  var relativeZIndex = Romo.parseZIndex(relativeElem);
+  Romo.setStyle(this.popupElem, 'z-index', relativeZIndex + 1200); // see z-index.css
+}
+
 // private
 
 RomoDropdown.prototype._bindElem = function() {
@@ -189,7 +194,7 @@ RomoDropdown.prototype._bindPopup = function() {
   Romo.setData(this.popupElem, 'romo-dropdown-position',  this.popupPosition);
   Romo.setData(this.popupElem, 'romo-dropdown-alignment', this.popupAlignment);
 
-  this._setPopupZIndex(this.elem);
+  this.doSetPopupZIndex(this.elem);
 
   // don't propagate click events on the popup elem.  this prevents the popup
   // from closing when clicked (see body click event bind on popup open)
@@ -393,11 +398,6 @@ RomoDropdown.prototype._onWindowBodyKeyUp = function(e) {
 RomoDropdown.prototype._onResizeWindow = function(e) {
   this.doPlacePopupElem();
   return true;
-}
-
-RomoDropdown.prototype._setPopupZIndex = function(relativeElem) {
-  var relativeZIndex = Romo.parseZIndex(relativeElem);
-  Romo.setStyle(this.popupElem, 'z-index', relativeZIndex + 1200); // see z-index.css
 }
 
 RomoDropdown.prototype._parsePositionData = function(posString) {

--- a/assets/js/romo/tooltip.js
+++ b/assets/js/romo/tooltip.js
@@ -118,6 +118,11 @@ RomoTooltip.prototype.doSetContent = function(value) {
   this.doPlacePopupElem();
 }
 
+RomoTooltip.prototype.doSetPopupZIndex = function(relativeElem) {
+  var relativeZIndex = Romo.parseZIndex(relativeElem);
+  Romo.setStyle(this.popupElem, 'z-index', relativeZIndex + 1100); // see z-index.css
+}
+
 // private
 
 RomoDropdown.prototype._bindElem = function() {
@@ -167,7 +172,7 @@ RomoDropdown.prototype._bindPopup = function() {
   this.popupAlignment = Romo.data(this.elem, 'romo-tooltip-alignment') || 'center';
   Romo.setData(this.popupElem, 'romo-tooltip-alignment', this.popupAlignment);
 
-  this._setPopupZIndex(this.elem);
+  this.doSetPopupZIndex(this.elem);
 
   // don't propagate click events on the popup elem.  this prevents the popup
   // from closing when clicked (see body click event bind on popup open)
@@ -295,11 +300,6 @@ RomoTooltip.prototype._onSetContent = function(e, value) {
 
 RomoTooltip.prototype._onResizeWindow = function(e) {
   this.doPlacePopupElem();
-}
-
-RomoTooltip.prototype._setPopupZIndex = function(relativeElem) {
-  var relativeZIndex = Romo.parseZIndex(relativeElem);
-  Romo.setStyle(this.popupElem, 'z-index', relativeZIndex + 1100); // see z-index.css
 }
 
 RomoTooltip.prototype._getPopupMaxAvailableHeight = function(position) {


### PR DESCRIPTION
This mostly reorganizes the methods to make the "private" methods
follow our leading-underscore convention.  It also does a few
style cleanups and removes event checks before calling event
"stop" methods.

I noticed some goof ups in the new romo change html methods that
I cleaned up.  I also switched some manual `append` calls passing
in elems using the `elems` method, to just call `appendHtml` and
pass in the raw html instead.

Finally, I chose to removet he `doSetFormat()` method and the
`romoDatepicker:triggerSetFormat` event bind.  Instead, I made
`formatString()` a lazy property method which removes the need
for both of those calls as the format string is always looked
up live and never needs to be "set".

Note: this also update the dropdown/tooltip `doSetPopupZIndex`
methods to be public.  I got too aggressive making these methods
private in earlier cleanup efforts.  The datepicker expects to
call this method on its dropdown.  I made the tooltip's public
to keep it consistent with the dropdown.

@jcredding ready for review.  Check me and make sure those `append` changes make sense.  Thanks.