### PR TITLE
add "rm" methods for removing attr/data/style

### DIFF
--- a/assets/js/romo/base.js
+++ b/assets/js/romo/base.js
@@ -132,12 +132,20 @@ Romo.prototype.setAttr = function(elem, attrName, attrValue) {
   return v;
 }
 
+Romo.prototype.rmAttr = function(elem, attrName) {
+  elem.removeAttribute(attrName);
+}
+
 Romo.prototype.data = function(elem, dataName) {
   return this._deserializeValue(this.attr(elem, "data-"+dataName));
 }
 
 Romo.prototype.setData = function(elem, dataName, dataValue) {
   return this.setAttr(elem, "data-"+dataName, dataValue);
+}
+
+Romo.prototype.rmData = function(elem, dataName) {
+  this.rmAttr(elem, "data-"+dataName);
 }
 
 Romo.prototype.style = function(elem, styleName) {
@@ -147,6 +155,10 @@ Romo.prototype.style = function(elem, styleName) {
 Romo.prototype.setStyle = function(elem, styleName, styleValue) {
   elem.style[styleName] = styleValue;
   return styleValue;
+}
+
+Romo.prototype.rmStyle = function(elem, styleName) {
+  elem.style[styleName] = '';
 }
 
 Romo.prototype.css = function(elem, styleName) {

--- a/assets/js/romo/dropdown.js
+++ b/assets/js/romo/dropdown.js
@@ -264,14 +264,14 @@ RomoDropdown.prototype._bindBody = function() {
 }
 
 RomoDropdown.prototype._resetBody = function() {
-  Romo.setStyle(this.contentElem, 'min-width',  '');
-  Romo.setStyle(this.contentElem, 'max-width',  '');
-  Romo.setStyle(this.contentElem, 'width',      '');
-  Romo.setStyle(this.contentElem, 'min-height', '');
-  Romo.setStyle(this.contentElem, 'max-height', '');
-  Romo.setStyle(this.contentElem, 'height',     '');
-  Romo.setStyle(this.contentElem, 'overflow-x', '');
-  Romo.setStyle(this.contentElem, 'overflow-y', '');
+  Romo.rmStyle(this.contentElem, 'min-width');
+  Romo.rmStyle(this.contentElem, 'max-width');
+  Romo.rmStyle(this.contentElem, 'width');
+  Romo.rmStyle(this.contentElem, 'min-height');
+  Romo.rmStyle(this.contentElem, 'max-height');
+  Romo.rmStyle(this.contentElem, 'height');
+  Romo.rmStyle(this.contentElem, 'overflow-x');
+  Romo.rmStyle(this.contentElem, 'overflow-y');
 }
 
 RomoDropdown.prototype._loadBodyStart = function() {

--- a/assets/js/romo/modal.js
+++ b/assets/js/romo/modal.js
@@ -209,13 +209,13 @@ RomoModal.prototype._bindBody = function() {
 }
 
 RomoModal.prototype._resetBody = function() {
-  Romo.setStyle(this.contentElem, 'min-width',  '');
-  Romo.setStyle(this.contentElem, 'max-width',  '');
-  Romo.setStyle(this.contentElem, 'width',      '');
-  Romo.setStyle(this.contentElem, 'min-height', '');
-  Romo.setStyle(this.contentElem, 'max-height', '');
-  Romo.setStyle(this.contentElem, 'height',     '');
-  Romo.setStyle(this.contentElem, 'overflow',   '');
+  Romo.rmStyle(this.contentElem, 'min-width');
+  Romo.rmStyle(this.contentElem, 'max-width');
+  Romo.rmStyle(this.contentElem, 'width');
+  Romo.rmStyle(this.contentElem, 'min-height');
+  Romo.rmStyle(this.contentElem, 'max-height');
+  Romo.rmStyle(this.contentElem, 'height');
+  Romo.rmStyle(this.contentElem, 'overflow');
 
   Romo.off(this.closeElem, 'click', Romo.proxy(this.onPopupClose, this));
 }
@@ -305,8 +305,8 @@ RomoModal.prototype._dragStop = function(e) {
   Romo.addClass(this.dragElem, 'romo-modal-grab');
   Romo.removeClass(this.dragElem, 'romo-modal-grabbing');
 
-  Romo.setStyle(this.popupElem, 'width',  '');
-  Romo.setStyle(this.popupElem, 'height', '');
+  Romo.rmStyle(this.popupElem, 'width');
+  Romo.rmStyle(this.popupElem, 'height');
 
   Romo.off(window, 'mousemove', Romo.proxy(this.onMouseMove, this));
   Romo.off(window, 'mouseup',   Romo.proxy(this.onMouseUp, this));

--- a/assets/js/romo/option_list_dropdown.js
+++ b/assets/js/romo/option_list_dropdown.js
@@ -249,7 +249,7 @@ RomoOptionListDropdown.prototype._buildOptionFilter = function() {
   var filterElem = Romo.elems('<input type="text" size="1" class="romo-option-list-dropdown-filter"></input>')[0];
 
   if (Romo.data(this.elem, 'romo-option-list-dropdown-filter-placeholder') !== undefined) {
-    filterElem.setAttr('placeholder', Romo.data(this.elem, 'romo-option-list-dropdown-filter-placeholder'));
+    Romo.setAttr(filterElem, 'placeholder', Romo.data(this.elem, 'romo-option-list-dropdown-filter-placeholder'));
   }
   Romo.setData(filterElem, 'romo-indicator-text-input-elem-display',       "block");
   Romo.setData(filterElem, 'romo-indicator-text-input-indicator-position', "right");

--- a/assets/js/romo/selected_options_list.js
+++ b/assets/js/romo/selected_options_list.js
@@ -98,8 +98,8 @@ RomoSelectedOptionsList.prototype.doRefreshUI = function() {
     var lastItemElem = itemElems[itemElems.length-1];
     this._scrollListTopToItem(lastItemElem);
   } else {
-    Romo.setStyle(this.elem, 'height',     String(uiListElemHeight)+'px');
-    Romo.setStyle(this.elem, 'overflow-y', '');
+    Romo.setStyle(this.elem, 'height', String(uiListElemHeight)+'px');
+    Romo.rmStyle(this.elem, 'overflow-y');
   }
 }
 

--- a/assets/js/romo/spinner.js
+++ b/assets/js/romo/spinner.js
@@ -62,9 +62,9 @@ RomoSpinner.prototype.doStop = function() {
   if (this.elemHtml !== undefined) {
     Romo.updateHtml(this.elem, this.elemHtml);
   }
-  Romo.setStyle('position', '');
-  Romo.setStyle('width',    '');
-  Romo.setStyle('height',   '');
+  Romo.rmStyle('position');
+  Romo.rmStyle('width');
+  Romo.rmStyle('height');
 
   if (this.elemStyle !== undefined) {
     Romo.setAttr(this.elem, 'style', this.elemStyle);

--- a/assets/js/romo/tooltip.js
+++ b/assets/js/romo/tooltip.js
@@ -226,12 +226,12 @@ RomoTooltip.prototype._bindBody = function() {
 }
 
 RomoTooltip.prototype._resetBody = function() {
-  Romo.setStyle(this.bodyElem, 'min-width',  '');
-  Romo.setStyle(this.bodyElem, 'max-width',  '');
-  Romo.setStyle(this.bodyElem, 'width',      '');
-  Romo.setStyle(this.bodyElem, 'min-height', '');
-  Romo.setStyle(this.bodyElem, 'max-height', '');
-  Romo.setStyle(this.bodyElem, 'height',     '');
+  Romo.rmStyle(this.bodyElem, 'min-width');
+  Romo.rmStyle(this.bodyElem, 'max-width');
+  Romo.rmStyle(this.bodyElem, 'width');
+  Romo.rmStyle(this.bodyElem, 'min-height');
+  Romo.rmStyle(this.bodyElem, 'max-height');
+  Romo.rmStyle(this.bodyElem, 'height');
 }
 
 RomoTooltip.prototype._loadBodyStart = function() {


### PR DESCRIPTION
This originally came up b/c we found we needed an "remove attr"
method to port the RomoSelect component off of jQuery.  Since we
needed that method anyway, I decided to add similar "rm" methods
for data and style as well.  I backported some existing code to
use the new `rmStyle` method as well.

Note: this also fixes an errant `setAttr` call on the option list
dropdown component.  This was missed when switching it off of
jQuery.

@jcredding ready for review.  This is needed to finish off #173.