### PR TITLE
Update `Romo.array` helper to cast non array-like values to arrays

### DIFF
--- a/assets/js/romo/picker.js
+++ b/assets/js/romo/picker.js
@@ -36,12 +36,7 @@ RomoPicker.prototype.doInit = function() {
 }
 
 RomoPicker.prototype.doSetValue = function(values) {
-  var value = undefined;
-  if (Array.isArray(values)) {
-    value = values.join(this._elemValuesDelim());
-  } else {
-    value = values;
-  }
+  var value = Romo.array(values).join(this._elemValuesDelim());
   $.ajax({
     type:    'GET',
     url:     this.elem.data('romo-picker-url'),
@@ -51,12 +46,7 @@ RomoPicker.prototype.doSetValue = function(values) {
 }
 
 RomoPicker.prototype.doSetValueDatas = function(valueDatas) {
-  var datas = undefined;
-  if (Array.isArray(valueDatas)) {
-    datas = valueDatas;
-  } else {
-    datas = [valueDatas];
-  }
+  var datas        = Romo.array(valueDatas);
   var values       = datas.map(function(data) { return data.value; });
   var displayTexts = datas.map(function(data) { return data.displayText; });
 

--- a/assets/js/romo/select.js
+++ b/assets/js/romo/select.js
@@ -32,13 +32,7 @@ RomoSelect.prototype.doInit = function() {
 }
 
 RomoSelect.prototype.doSetValue = function(value) {
-  var values = undefined;
-  if (Array.isArray(value)) {
-    values = value;
-  } else {
-    values = [value];
-  }
-  values = values.filter($.proxy(function(v) {
+  var values = Romo.array(value).filter($.proxy(function(v) {
     return this.elem.find('OPTION[value="'+v+'"]')[0] !== undefined;
   }, this));
 


### PR DESCRIPTION
This updates the `Romo.array` helper to cast non array-like values
to arrays. This is to avoid manually checking for arrays and
manually converting them to arrays if not.

The `Romo.array` helper now checks the value its passed and see
if it has a `length` property. If it has a length and can be
accessed like an array (via `[]`) then the object is array like
and is converted to an array. The helper also includes some
checks to avoid functions, strings, and the `window` object being
seen as an array like object because otherwise the helper would
try to convert them to an array. If the object is not array like
it is added as the single item in an array. Finally, if the value
is a `NodeList` or `HTMLCollection` then the helper includes a
short circuit to immediately convert them to an array. This
ensures the `Romo.f`, `Romo.find`, and `Romo.elems` helpers all
remain as fast as possible.

This also updates the select, picker, and the `Romo.triggerInitUI`
logic to no longer manually check for arrays and instead use the
`Romo.array` helper. This allows them to properly cast values to
arrays as needed.

@kellyredding - Ready for review.