### PR TITLE
base js: make event handling error if trying to use with elem collections

### DIFF
--- a/assets/js/romo/base.js
+++ b/assets/js/romo/base.js
@@ -550,6 +550,15 @@ Romo.prototype.ajax = function(settings) {
 // events
 
 Romo.prototype.on = function(elem, eventName, fn) {
+  var elemString = Object.prototype.toString.call(elem);
+  if (
+    elemString === '[object NodeList]'       ||
+    elemString === '[object HTMLCollection]' ||
+    Array.isArray(elem)
+  ) {
+    throw new Error('Can only bind events on individual elems, not collections.');
+  }
+
   var proxyFn = function(e) {
     var result = fn.apply(elem, e.detail === undefined ? [e] : [e].concat(e.detail));
     if (result === false) {
@@ -568,6 +577,15 @@ Romo.prototype.on = function(elem, eventName, fn) {
 }
 
 Romo.prototype.off = function(elem, eventName, fn) {
+  var elemString = Object.prototype.toString.call(elem);
+  if (
+    elemString === '[object NodeList]'       ||
+    elemString === '[object HTMLCollection]' ||
+    Array.isArray(elem)
+  ) {
+    throw new Error('Can only unbind events on individual elems, not collections.');
+  }
+
   var key     = this._handlerKey(elem, eventName, fn);
   var proxyFn = this._handlers[key];
   if (proxyFn) {
@@ -577,6 +595,15 @@ Romo.prototype.off = function(elem, eventName, fn) {
 }
 
 Romo.prototype.trigger = function(elem, customEventName, args) {
+  var elemString = Object.prototype.toString.call(elem);
+  if (
+    elemString === '[object NodeList]'       ||
+    elemString === '[object HTMLCollection]' ||
+    Array.isArray(elem)
+  ) {
+    throw new Error('Can only trigger events on individual elems, not collections.');
+  }
+
   var event = undefined;
   if (typeof window.CustomEvent === "function") {
     event = new CustomEvent(customEventName, { detail: args });


### PR DESCRIPTION
This is a protection feature.  Since Romo's js api is so similar
to jQuery's, it is logical that a dev might accidentally think to
call `.on` passing a collection of elems and have it work.  This
won't work.  So this add's a loud error to let you know you are
not using Romo's api correctly.

This should also protect us from mistakes as we port Romo from
jQuery to vanilla js.

@jcredding ready for review.