### PR TITLE
Update `RomoInlineForm` component to not use jquery

### DIFF
--- a/assets/js/romo/inline_form.js
+++ b/assets/js/romo/inline_form.js
@@ -1,29 +1,29 @@
-var RomoInlineForm = function(element) {
-  this.elem = $(element);
+var RomoInlineForm = function(elem) {
+  this.elem = elem;
 
   this.romoInline = new RomoInline(this.elem);
   this.doBindInline();
 
-  this.form = undefined;
-  this.elem.on('inlineForm:form:triggerSubmit', $.proxy(function(e) {
-    if (this.form != undefined) {
-      this.form.elem.trigger('form:triggerSubmit', []);
+  this.romoForm = undefined;
+  Romo.on(this.elem, 'romoInlineForm:romoForm:triggerSubmit', Romo.proxy(function(e) {
+    if (this.romoForm != undefined) {
+      Romo.trigger(this.romoForm.elem, 'romoForm:triggerSubmit', []);
     }
   }, this));
-  this.elem.on('inlineForm:romoInline:triggerInvoke', $.proxy(function(e) {
-    this.romoInline.elem.trigger('romoInline:triggerInvoke', []);
+  Romo.on(this.elem, 'romoInlineForm:romoInline:triggerInvoke', Romo.proxy(function(e) {
+    Romo.trigger(this.romoInline.elem, 'romoInline:triggerInvoke', []);
   }, this));
-  this.elem.on('inlineForm:romoInline:triggerDismiss', $.proxy(function(e) {
-    this.romoInline.elem.trigger('romoInline:triggerDismiss', []);
+  Romo.on(this.elem, 'romoInlineForm:romoInline:triggerDismiss', Romo.proxy(function(e) {
+    Romo.trigger(this.romoInline.elem, 'romoInline:triggerDismiss', []);
   }, this));
   this.doBindForm();
-  this.elem.on('romoInline:loadSuccess', $.proxy(function(e, data, romoInline) {
+  Romo.on(this.elem, 'romoInline:loadSuccess', Romo.proxy(function(e, data, romoInline) {
     this.doBindForm();
-    this.elem.trigger('inlineForm:formReady', [this.form, this]);
+    Romo.trigger(this.elem, 'romoInlineForm:formReady', [this.romoForm, this]);
   }, this));
 
   this.doInit();
-  this.elem.trigger('inlineForm:ready', [this]);
+  Romo.trigger(this.elem, 'romoInlineForm:ready', [this]);
 }
 
 RomoInlineForm.prototype.doInit = function() {
@@ -31,60 +31,60 @@ RomoInlineForm.prototype.doInit = function() {
 }
 
 RomoInlineForm.prototype.doBindInline = function() {
-  this.elem.on('romoInline:ready', $.proxy(function(e, romoInline) {
-    this.elem.trigger('inlineForm:romoInline:ready', [romoInline, this]);
+  Romo.on(this.elem, 'romoInline:ready', Romo.proxy(function(e, romoInline) {
+    Romo.trigger(this.elem, 'romoInlineForm:romoInline:ready', [romoInline, this]);
   }, this));
-  this.elem.on('romoInline:loadStart', $.proxy(function(e, romoInline) {
-    this.elem.trigger('inlineForm:romoInline:loadStart', [romoInline, this]);
+  Romo.on(this.elem, 'romoInline:loadStart', Romo.proxy(function(e, romoInline) {
+    Romo.trigger(this.elem, 'romoInlineForm:romoInline:loadStart', [romoInline, this]);
   }, this));
-  this.elem.on('romoInline:loadSuccess', $.proxy(function(e, data, romoInline) {
-    this.elem.trigger('inlineForm:romoInline:loadSuccess', [data, romoInline, this]);
+  Romo.on(this.elem, 'romoInline:loadSuccess', Romo.proxy(function(e, data, romoInline) {
+    Romo.trigger(this.elem, 'romoInlineForm:romoInline:loadSuccess', [data, romoInline, this]);
   }, this));
-  this.elem.on('romoInline:loadError', $.proxy(function(e, xhr, romoInline) {
-    this.elem.trigger('inlineForm:romoInline:loadError', [xhr, romoInline, this]);
+  Romo.on(this.elem, 'romoInline:loadError', Romo.proxy(function(e, xhr, romoInline) {
+    Romo.trigger(this.elem, 'romoInlineForm:romoInline:loadError', [xhr, romoInline, this]);
   }, this));
-  this.elem.on('romoInline:show', $.proxy(function(e, romoInline) {
-    this.elem.trigger('inlineForm:romoInline:show', [romoInline, this]);
+  Romo.on(this.elem, 'romoInline:show', Romo.proxy(function(e, romoInline) {
+    Romo.trigger(this.elem, 'romoInlineForm:romoInline:show', [romoInline, this]);
   }, this));
-  this.elem.on('romoInline:dismiss', $.proxy(function(e, romoInline) {
-    this.elem.trigger('inlineForm:romoInline:dismiss', [romoInline, this]);
+  Romo.on(this.elem, 'romoInline:dismiss', Romo.proxy(function(e, romoInline) {
+    Romo.trigger(this.elem, 'romoInlineForm:romoInline:dismiss', [romoInline, this]);
   }, this));
-  this.elem.on('romoInline:confirmDismiss', $.proxy(function(e, romoInline) {
-    this.elem.trigger('inlineForm:romoInline:confirmDismiss', [romoInline, this]);
+  Romo.on(this.elem, 'romoInline:confirmDismiss', Romo.proxy(function(e, romoInline) {
+    Romo.trigger(this.elem, 'romoInlineForm:romoInline:confirmDismiss', [romoInline, this]);
   }, this));
 }
 
 RomoInlineForm.prototype.doBindForm = function() {
-  var formElem = this.elem.find('[data-romo-form-auto="inlineForm"]');
+  var formElem = Romo.find(this.elem, '[data-romo-form-auto="inlineForm"]')[0];
 
-  formElem.on('form:clearMsgs', $.proxy(function(e, form) {
-    this.elem.trigger('inlineForm:form:clearMsgs', [form, this]);
+  Romo.on(formElem, 'romoForm:clearMsgs', Romo.proxy(function(e, romoForm) {
+    Romo.trigger(this.elem, 'romoInlineForm:romoForm:clearMsgs', [romoForm, this]);
   }, this));
-  formElem.on('form:ready', $.proxy(function(e, form) {
-    this.elem.trigger('inlineForm:form:ready', [form, this]);
+  Romo.on(formElem, 'romoForm:ready', Romo.proxy(function(e, romoForm) {
+    Romo.trigger(this.elem, 'romoInlineForm:romoForm:ready', [romoForm, this]);
   }, this));
-  formElem.on('form:confirmSubmit', $.proxy(function(e, form) {
-    this.elem.trigger('inlineForm:form:confirmSubmit', [form, this]);
+  Romo.on(formElem, 'romoForm:confirmSubmit', Romo.proxy(function(e, form) {
+    Romo.trigger(this.elem, 'romoInlineForm:romoForm:confirmSubmit', [romoForm, this]);
   }, this));
-  formElem.on('form:beforeSubmit', $.proxy(function(e, form) {
-    this.elem.trigger('inlineForm:form:beforeSubmit', [form, this]);
+  Romo.on(formElem, 'romoForm:beforeSubmit', Romo.proxy(function(e, romoForm) {
+    Romo.trigger(this.elem, 'romoInlineForm:romoForm:beforeSubmit', [romoForm, this]);
   }, this));
-  formElem.on('form:submitSuccess', $.proxy(function(e, data, form) {
-    this.elem.trigger('inlineForm:form:submitSuccess', [data, form, this]);
+  Romo.on(formElem, 'romoForm:submitSuccess', Romo.proxy(function(e, data, romoForm) {
+    Romo.trigger(this.elem, 'romoInlineForm:romoForm:submitSuccess', [data, romoForm, this]);
   }, this));
-  formElem.on('form:submitInvalidMsgs', $.proxy(function(e, msgs, xhr, form) {
-    this.elem.trigger('inlineForm:form:submitInvalidMsgs', [msgs, xhr, form, this]);
+  Romo.on(formElem, 'romoForm:submitInvalidMsgs', Romo.proxy(function(e, msgs, xhr, romoForm) {
+    Romo.trigger(this.elem, 'romoInlineForm:romoForm:submitInvalidMsgs', [msgs, xhr, romoForm, this]);
   }, this));
-  formElem.on('form:submitXhrError', $.proxy(function(e, xhr, form) {
-    this.elem.trigger('inlineForm:form:submitXhrError', [xhr, form, this]);
+  Romo.on(formElem, 'romoForm:submitXhrError', Romo.proxy(function(e, xhr, romoForm) {
+    Romo.trigger(this.elem, 'romoInlineForm:romoForm:submitXhrError', [xhr, romoForm, this]);
   }, this));
-  formElem.on('form:submitError', $.proxy(function(e, xhr, form) {
-    this.elem.trigger('inlineForm:form:submitError', [xhr, form, this]);
+  Romo.on(formElem, 'romoForm:submitError', Romo.proxy(function(e, xhr, romoForm) {
+    Romo.trigger(this.elem, 'romoInlineForm:romoForm:submitError', [xhr, romoForm, this]);
   }, this));
 
-  var submitElement = this.elem.find('[data-romo-form-submit]')[0];
-  var spinnerElements = this.elem.find('[data-romo-spinner-auto="true"]');
-  this.form = formElem.romoForm(submitElement, spinnerElements)[0];
+  var submitElem   = Romo.find(this.elem, '[data-romo-form-submit]')[0];
+  var spinnerElems = Romo.find(this.elem, '[data-romo-spinner-auto="true"]');
+  this.romoForm = new RomoForm(formElem, submitElem, spinnerElems);
 }
 
 Romo.onInitUI(function(elem) {


### PR DESCRIPTION
This updates the `RomoInlineForm` component to not use jquery.
This is part of the effort to no longer require jquery to use
Romo. This removes all of the jquery usage within the
`RomoInlineForm` component. None of the other components
initialize or use the romo inline form component.

This also updates the event names to be prefixed with
`romoInlineForm` instead of just `inlineForm`. This is part of
having everything properly namespaced in romo and ensuring it
should work without issue with other javascript libraries.

This also updates the `RomoForm` initialization, event names, and
variable names to match the updates to the `RomoForm` component.

@kellyredding - Ready for review.