### PR TITLE
update select/picker related components to get up to convention

### DIFF
--- a/assets/js/romo/picker.js
+++ b/assets/js/romo/picker.js
@@ -12,23 +12,6 @@ var RomoPicker = function(elem) {
   this.doInit();
   this._bindElem();
 
-  this.doSetValue(this._elemValues());
-
-  if (Romo.attr(this.elem, 'id') !== undefined) {
-    var labelElem = Romo.f('label[for="'+Romo.attr(this.elem, 'id')+'"]')[0];
-    labelElem.on('click', Romo.proxy(function(e) {
-      this.romoOptionListDropdown.doFocus();
-    }, this));
-  }
-
-  Romo.on(window, "pageshow", Romo.proxy(function(e) {
-    this._refreshUI();
-  }, this));
-
-  Romo.on(this.elem, 'romoPicker:triggerSetValue', Romo.proxy(function(e, value) {
-    this.doSetValue(value)
-  }, this));
-
   Romo.trigger(this.elem, 'romoPicker:ready', [this]);
 }
 
@@ -67,7 +50,7 @@ RomoPicker.prototype.doSetValueDatas = function(valueDatas) {
   this._refreshUI();
 }
 
-/* private */
+// private
 
 RomoPicker.prototype._bindElem = function() {
   this._bindOptionListDropdown();
@@ -85,6 +68,23 @@ RomoPicker.prototype._bindElem = function() {
   }, this));
 
   this.romoOptionListDropdown.doSetListItems(this.defaultOptionItems);
+
+  this.doSetValue(this._elemValues());
+
+  if (Romo.attr(this.elem, 'id') !== undefined) {
+    var labelElem = Romo.f('label[for="'+Romo.attr(this.elem, 'id')+'"]')[0];
+    labelElem.on('click', Romo.proxy(function(e) {
+      this.romoOptionListDropdown.doFocus();
+    }, this));
+  }
+
+  Romo.on(window, "pageshow", Romo.proxy(function(e) {
+    this._refreshUI();
+  }, this));
+
+  Romo.on(this.elem, 'romoPicker:triggerSetValue', Romo.proxy(function(e, value) {
+    this.doSetValue(value)
+  }, this));
 }
 
 RomoPicker.prototype._bindSelectedOptionsList = function() {

--- a/assets/js/romo/select.js
+++ b/assets/js/romo/select.js
@@ -8,23 +8,6 @@ var RomoSelect = function(elem) {
   this.doInit();
   this._bindElem();
 
-  this.doSetValue(this._elemValues());
-
-  if (Romo.attr(this.elem, 'id') !== undefined) {
-    var labelElem = Romo.f('label[for="'+Romo.attr(this.elem, 'id')+'"]')[0]
-    labelElem.on('click', Romo.proxy(function(e) {
-      this.romoSelectDropdown.doFocus();
-    }, this));
-  }
-
-  Romo.on(window, "pageshow", Romo.proxy(function(e) {
-    this._refreshUI();
-  }, this));
-
-  Romo.on(this.elem, 'romoSelect:triggerSetValue', Romo.proxy(function(e, value) {
-    this.doSetValue(value)
-  }, this));
-
   Romo.trigger(this.elem, 'romoSelect:ready', [this]);
 }
 
@@ -52,7 +35,7 @@ RomoSelect.prototype.doSetValue = function(value) {
   this._refreshUI();
 }
 
-/* private */
+// private
 
 RomoSelect.prototype._bindElem = function() {
   this._bindSelectDropdown();
@@ -66,6 +49,23 @@ RomoSelect.prototype._bindElem = function() {
   }, this));
   Romo.on(this.elem, 'romoSelect:triggerPopupClose', Romo.proxy(function(e) {
     Romo.trigger(this.romoSelectDropdown.elem, 'romoSelectDropdown:triggerPopupClose', []);
+  }, this));
+
+  this.doSetValue(this._elemValues());
+
+  if (Romo.attr(this.elem, 'id') !== undefined) {
+    var labelElem = Romo.f('label[for="'+Romo.attr(this.elem, 'id')+'"]')[0]
+    labelElem.on('click', Romo.proxy(function(e) {
+      this.romoSelectDropdown.doFocus();
+    }, this));
+  }
+
+  Romo.on(window, "pageshow", Romo.proxy(function(e) {
+    this._refreshUI();
+  }, this));
+
+  Romo.on(this.elem, 'romoSelect:triggerSetValue', Romo.proxy(function(e, value) {
+    this.doSetValue(value)
   }, this));
 }
 

--- a/assets/js/romo/select_dropdown.js
+++ b/assets/js/romo/select_dropdown.js
@@ -8,13 +8,6 @@ var RomoSelectDropdown = function(elem, optionElemsParentElem) {
   this.doInit();
   this._bindElem();
 
-  if (Romo.attr(this.elem, 'id') !== undefined) {
-    var labelElem = Romo.f('label[for="'+Romo.attr(this.elem, 'id')+'"]')[0];
-    Romo.on(labelElem, 'click', Romo.proxy(function(e) {
-      this.elem.focus();
-    }, this));
-  }
-
   Romo.trigger(this.elem, 'romoSelectDropdown:ready', [this]);
 }
 
@@ -70,7 +63,7 @@ RomoSelectDropdown.prototype.doFocus = function(openOnFocus) {
   this.romoOptionListDropdown.doFocus(openOnFocus);
 }
 
-/* private */
+// private
 
 RomoSelectDropdown.prototype._bindElem = function() {
   Romo.setData(this.elem, 'romo-option-list-focus-style-class', 'romo-select-focus');
@@ -163,6 +156,13 @@ RomoSelectDropdown.prototype._bindElem = function() {
   this._sanitizeOptions();
   this._setListItems();
   Romo.trigger(this.elem, 'romoOptionListDropdown:triggerListOptionsUpdate', [this.selectedItemElem()]);
+
+  if (Romo.attr(this.elem, 'id') !== undefined) {
+    var labelElem = Romo.f('label[for="'+Romo.attr(this.elem, 'id')+'"]')[0];
+    Romo.on(labelElem, 'click', Romo.proxy(function(e) {
+      this.elem.focus();
+    }, this));
+  }
 }
 
 RomoSelectDropdown.prototype._sanitizeOptions = function() {

--- a/assets/js/romo/selected_options_list.js
+++ b/assets/js/romo/selected_options_list.js
@@ -103,17 +103,14 @@ RomoSelectedOptionsList.prototype.doRefreshUI = function() {
   }
 }
 
-/* private */
+// private
 
 RomoSelectedOptionsList.prototype._bindElem = function() {
   this.elem = Romo.elems('<div class="romo-selected-options-list"><div class="romo-selected-options-list-items"></div></div>')[0];
 
   Romo.on(this.elem, 'click', Romo.proxy(function(e) {
-    if (e !== undefined) {
-      e.stopPropagation();
-      e.preventDefault();
-    }
     Romo.trigger(this.elem, 'romoSelectedOptionsList:listClick', [this]);
+    return false;
   }, this));
 
   this.doSetItems([]);


### PR DESCRIPTION
This is just a few small tweaks as these components are fairly
recent and were already mostly up to convention.  These components
actually established many of our modern conventions.  This mostly
just gets consistent "private" section comments and moves logic
into `_bindElem` where appropriate (as we've done in the other
components).

@jcredding ready for review.