### PR TITLE
base js: remove `getComputedStyle` method

### DIFF
--- a/assets/js/romo/base.js
+++ b/assets/js/romo/base.js
@@ -224,10 +224,6 @@ Romo.prototype.setScrollLeft = function(elem, value) {
   }
 }
 
-Romo.prototype.getComputedStyle = function(elem, styleName) {
-  return window.getComputedStyle(elem, null).getPropertyValue(styleName);
-}
-
 Romo.prototype.parseZIndex = function(elem) {
   // for the case where z-index is set directly on the elem
   var val = this.parseElemZIndex(elem);
@@ -248,7 +244,7 @@ Romo.prototype.parseZIndex = function(elem) {
 }
 
 Romo.prototype.parseElemZIndex = function(elem) {
-  var val = parseInt(this.getComputedStyle(elem, "z-index"));
+  var val = parseInt(this.css(elem, "z-index"));
   if (!isNaN(val)) {
     return val;
   }

--- a/assets/js/romo/indicator_text_input.js
+++ b/assets/js/romo/indicator_text_input.js
@@ -155,7 +155,7 @@ RomoIndicatorTextInput.prototype._getIndicatorPaddingPx = function() {
 RomoIndicatorTextInput.prototype._getIndicatorWidthPx = function() {
   return (
     Romo.data(this.elem, 'romo-indicator-text-input-indicator-width-px') ||
-    parseInt(Romo.getComputedStyle(this.indicatorElem, "width"), 10)
+    parseInt(Romo.css(this.indicatorElem, "width"), 10)
   );
 }
 


### PR DESCRIPTION
Now that we have the `.css` method (which is the exact same
implementation), we no longer need this method.  `css` is more
succinct and is what we'll be using going forward.

This removes the base js method and its usage in base js and
indicator text input.  The other uses have already been updated
as part of earlier cleanups/reworks in the effort to move off of
using jQuery.

@jcredding ready for review.