### PR TITLE
update modal/dropdown/inline form components to latest conventions

### DIFF
--- a/assets/js/romo/dropdown_form.js
+++ b/assets/js/romo/dropdown_form.js
@@ -1,22 +1,9 @@
 var RomoDropdownForm = function(elem) {
   this.elem = elem;
 
-  this.romoDropdown = new RomoDropdown(this.elem);
-  this.doBindDropdown();
-
-  this.romoForm = undefined;
-  Romo.on(this.elem, 'romoDropdownForm:romoForm:triggerSubmit', Romo.proxy(function(e) {
-    if (this.romoForm != undefined) {
-      Romo.trigger(this.romoForm.elem, 'romoForm:triggerSubmit', []);
-    }
-  }, this));
-  this.doBindForm();
-  Romo.on(this.elem, 'romoDropdown:loadBodySuccess', Romo.proxy(function(e, data, romoDropdown) {
-    this.doBindForm();
-    Romo.trigger(this.elem, 'romoDropdownForm:formReady', [this.romoForm, this]);
-  }, this));
-
   this.doInit();
+  this._bindElem()
+
   Romo.trigger(this.elem, 'romoDropdownForm:ready', [this]);
 }
 
@@ -24,8 +11,27 @@ RomoDropdownForm.prototype.doInit = function() {
   // override as needed
 }
 
-RomoDropdownForm.prototype.doBindDropdown = function() {
-if (Romo.data(this.elem, 'romo-dropdown-clear-content') === undefined) {
+// private
+
+RomoDropdownForm.prototype._bindElem = function() {
+  Romo.on(this.elem, 'romoDropdownForm:romoForm:triggerSubmit', Romo.proxy(function(e) {
+    if (this.romoForm !== undefined) {
+      Romo.trigger(this.romoForm.elem, 'romoForm:triggerSubmit', []);
+    }
+  }, this));
+  Romo.on(this.elem, 'romoDropdown:loadBodySuccess', Romo.proxy(function(e, data, romoDropdown) {
+    this._bindForm();
+    Romo.trigger(this.elem, 'romoDropdownForm:formReady', [this.romoForm, this]);
+  }, this));
+
+  this._bindDropdown();
+  this._bindForm();
+}
+
+RomoDropdownForm.prototype._bindDropdown = function() {
+  this.romoDropdown = new RomoDropdown(this.elem);
+
+  if (Romo.data(this.elem, 'romo-dropdown-clear-content') === undefined) {
     Romo.setData(this.elem, 'romo-dropdown-clear-content', 'true');
   }
 
@@ -55,40 +61,44 @@ if (Romo.data(this.elem, 'romo-dropdown-clear-content') === undefined) {
   }, this));
 }
 
-RomoDropdownForm.prototype.doBindForm = function() {
+RomoDropdownForm.prototype._bindForm = function() {
+  this.romoForm = undefined;
   var formElem = Romo.find(this.romoDropdown.popupElem, '[data-romo-form-auto="dropdownForm"]')[0];
 
-  Romo.on(formElem, 'romoForm:clearMsgs', Romo.proxy(function(e, romoForm) {
-    Romo.trigger(this.elem, 'romoDropdownForm:romoForm:clearMsgs', [romoForm, this]);
-  }, this));
-  Romo.on(formElem, 'romoForm:ready', Romo.proxy(function(e, romoForm) {
-    Romo.trigger(this.elem, 'romoDropdownForm:romoForm:ready', [romoForm, this]);
-  }, this));
-  Romo.on(formElem, 'romoForm:confirmSubmit', Romo.proxy(function(e, romoForm) {
-    Romo.trigger(this.elem, 'romoDropdownForm:romoForm:confirmSubmit', [romoForm, this]);
-  }, this));
-  Romo.on(formElem, 'romoForm:beforeSubmit', Romo.proxy(function(e, romoForm) {
-    Romo.trigger(this.elem, 'romoDropdownForm:romoForm:beforeSubmit', [romoForm, this]);
-  }, this));
-  Romo.on(formElem, 'romoForm:submitSuccess', Romo.proxy(function(e, data, romoForm) {
-    Romo.trigger(this.elem, 'romoDropdownForm:romoForm:submitSuccess', [data, romoForm, this]);
-  }, this));
-  Romo.on(formElem, 'romoForm:submitInvalidMsgs', Romo.proxy(function(e, msgs, xhr, romoForm) {
-    Romo.trigger(this.elem, 'romoDropdownForm:romoForm:submitInvalidMsgs', [msgs, xhr, romoForm, this]);
-  }, this));
-  Romo.on(formElem, 'romoForm:submitXhrError', Romo.proxy(function(e, xhr, romoForm) {
-    Romo.trigger(this.elem, 'romoDropdownForm:romoForm:submitXhrError', [xhr, romoForm, this]);
-  }, this));
-  Romo.on(formElem, 'romoForm:submitError', Romo.proxy(function(e, xhr, romoForm) {
-    Romo.trigger(this.elem, 'romoDropdownForm:romoForm:submitError', [xhr, romoForm, this]);
-  }, this));
-  Romo.on(formElem, 'romoForm:browserSubmit', Romo.proxy(function(e, romoForm) {
-    Romo.trigger(this.elem, 'romoDropdownForm:romoForm:browserSubmit', [romoForm, this]);
-  }, this));
+  if (formElem !== undefined) {
+    Romo.on(formElem, 'romoForm:clearMsgs', Romo.proxy(function(e, romoForm) {
+      Romo.trigger(this.elem, 'romoDropdownForm:romoForm:clearMsgs', [romoForm, this]);
+    }, this));
+    Romo.on(formElem, 'romoForm:ready', Romo.proxy(function(e, romoForm) {
+      Romo.trigger(this.elem, 'romoDropdownForm:romoForm:ready', [romoForm, this]);
+    }, this));
+    Romo.on(formElem, 'romoForm:confirmSubmit', Romo.proxy(function(e, romoForm) {
+      Romo.trigger(this.elem, 'romoDropdownForm:romoForm:confirmSubmit', [romoForm, this]);
+    }, this));
+    Romo.on(formElem, 'romoForm:beforeSubmit', Romo.proxy(function(e, romoForm) {
+      Romo.trigger(this.elem, 'romoDropdownForm:romoForm:beforeSubmit', [romoForm, this]);
+    }, this));
+    Romo.on(formElem, 'romoForm:submitSuccess', Romo.proxy(function(e, data, romoForm) {
+      Romo.trigger(this.elem, 'romoDropdownForm:romoForm:submitSuccess', [data, romoForm, this]);
+    }, this));
+    Romo.on(formElem, 'romoForm:submitInvalidMsgs', Romo.proxy(function(e, msgs, xhr, romoForm) {
+      Romo.trigger(this.elem, 'romoDropdownForm:romoForm:submitInvalidMsgs', [msgs, xhr, romoForm, this]);
+    }, this));
+    Romo.on(formElem, 'romoForm:submitXhrError', Romo.proxy(function(e, xhr, romoForm) {
+      Romo.trigger(this.elem, 'romoDropdownForm:romoForm:submitXhrError', [xhr, romoForm, this]);
+    }, this));
+    Romo.on(formElem, 'romoForm:submitError', Romo.proxy(function(e, xhr, romoForm) {
+      Romo.trigger(this.elem, 'romoDropdownForm:romoForm:submitError', [xhr, romoForm, this]);
+    }, this));
+    Romo.on(formElem, 'romoForm:browserSubmit', Romo.proxy(function(e, romoForm) {
+      Romo.trigger(this.elem, 'romoDropdownForm:romoForm:browserSubmit', [romoForm, this]);
+    }, this));
 
-  var submitElem   = Romo.find(this.romoDropdown.popupElem, '[data-romo-form-submit]')[0];
-  var spinnerElems = Romo.find(this.romoDropdown.popupElem, '[data-romo-spinner-auto="true"]');
-  this.romoForm = new RomoForm(formElem, submitElem, spinnerElems);
+    var submitElem   = Romo.find(this.romoDropdown.popupElem, '[data-romo-form-submit]')[0];
+    var spinnerElems = Romo.find(this.romoDropdown.popupElem, '[data-romo-spinner-auto="true"]');
+
+    this.romoForm = new RomoForm(formElem, submitElem, spinnerElems);
+  }
 }
 
 Romo.onInitUI(function(elem) {

--- a/assets/js/romo/inline_form.js
+++ b/assets/js/romo/inline_form.js
@@ -1,12 +1,21 @@
 var RomoInlineForm = function(elem) {
   this.elem = elem;
 
-  this.romoInline = new RomoInline(this.elem);
-  this.doBindInline();
+  this.doInit();
+  this._bindElem();
 
-  this.romoForm = undefined;
+  Romo.trigger(this.elem, 'romoInlineForm:ready', [this]);
+}
+
+RomoInlineForm.prototype.doInit = function() {
+  // override as needed
+}
+
+// private
+
+RomoDropdownForm.prototype._bindElem = function() {
   Romo.on(this.elem, 'romoInlineForm:romoForm:triggerSubmit', Romo.proxy(function(e) {
-    if (this.romoForm != undefined) {
+    if (this.romoForm !== undefined) {
       Romo.trigger(this.romoForm.elem, 'romoForm:triggerSubmit', []);
     }
   }, this));
@@ -16,21 +25,18 @@ var RomoInlineForm = function(elem) {
   Romo.on(this.elem, 'romoInlineForm:romoInline:triggerDismiss', Romo.proxy(function(e) {
     Romo.trigger(this.romoInline.elem, 'romoInline:triggerDismiss', []);
   }, this));
-  this.doBindForm();
   Romo.on(this.elem, 'romoInline:loadSuccess', Romo.proxy(function(e, data, romoInline) {
-    this.doBindForm();
+    this._bindForm();
     Romo.trigger(this.elem, 'romoInlineForm:formReady', [this.romoForm, this]);
   }, this));
 
-  this.doInit();
-  Romo.trigger(this.elem, 'romoInlineForm:ready', [this]);
+  this._bindInline();
+  this._bindForm();
 }
 
-RomoInlineForm.prototype.doInit = function() {
-  // override as needed
-}
+RomoInlineForm.prototype._bindInline = function() {
+  this.romoInline = new RomoInline(this.elem);
 
-RomoInlineForm.prototype.doBindInline = function() {
   Romo.on(this.elem, 'romoInline:ready', Romo.proxy(function(e, romoInline) {
     Romo.trigger(this.elem, 'romoInlineForm:romoInline:ready', [romoInline, this]);
   }, this));
@@ -54,37 +60,41 @@ RomoInlineForm.prototype.doBindInline = function() {
   }, this));
 }
 
-RomoInlineForm.prototype.doBindForm = function() {
+RomoInlineForm.prototype._bindForm = function() {
+  this.romoForm = undefined;
   var formElem = Romo.find(this.elem, '[data-romo-form-auto="inlineForm"]')[0];
 
-  Romo.on(formElem, 'romoForm:clearMsgs', Romo.proxy(function(e, romoForm) {
-    Romo.trigger(this.elem, 'romoInlineForm:romoForm:clearMsgs', [romoForm, this]);
-  }, this));
-  Romo.on(formElem, 'romoForm:ready', Romo.proxy(function(e, romoForm) {
-    Romo.trigger(this.elem, 'romoInlineForm:romoForm:ready', [romoForm, this]);
-  }, this));
-  Romo.on(formElem, 'romoForm:confirmSubmit', Romo.proxy(function(e, form) {
-    Romo.trigger(this.elem, 'romoInlineForm:romoForm:confirmSubmit', [romoForm, this]);
-  }, this));
-  Romo.on(formElem, 'romoForm:beforeSubmit', Romo.proxy(function(e, romoForm) {
-    Romo.trigger(this.elem, 'romoInlineForm:romoForm:beforeSubmit', [romoForm, this]);
-  }, this));
-  Romo.on(formElem, 'romoForm:submitSuccess', Romo.proxy(function(e, data, romoForm) {
-    Romo.trigger(this.elem, 'romoInlineForm:romoForm:submitSuccess', [data, romoForm, this]);
-  }, this));
-  Romo.on(formElem, 'romoForm:submitInvalidMsgs', Romo.proxy(function(e, msgs, xhr, romoForm) {
-    Romo.trigger(this.elem, 'romoInlineForm:romoForm:submitInvalidMsgs', [msgs, xhr, romoForm, this]);
-  }, this));
-  Romo.on(formElem, 'romoForm:submitXhrError', Romo.proxy(function(e, xhr, romoForm) {
-    Romo.trigger(this.elem, 'romoInlineForm:romoForm:submitXhrError', [xhr, romoForm, this]);
-  }, this));
-  Romo.on(formElem, 'romoForm:submitError', Romo.proxy(function(e, xhr, romoForm) {
-    Romo.trigger(this.elem, 'romoInlineForm:romoForm:submitError', [xhr, romoForm, this]);
-  }, this));
+  if (formElem !== undefined) {
+    Romo.on(formElem, 'romoForm:clearMsgs', Romo.proxy(function(e, romoForm) {
+      Romo.trigger(this.elem, 'romoInlineForm:romoForm:clearMsgs', [romoForm, this]);
+    }, this));
+    Romo.on(formElem, 'romoForm:ready', Romo.proxy(function(e, romoForm) {
+      Romo.trigger(this.elem, 'romoInlineForm:romoForm:ready', [romoForm, this]);
+    }, this));
+    Romo.on(formElem, 'romoForm:confirmSubmit', Romo.proxy(function(e, form) {
+      Romo.trigger(this.elem, 'romoInlineForm:romoForm:confirmSubmit', [romoForm, this]);
+    }, this));
+    Romo.on(formElem, 'romoForm:beforeSubmit', Romo.proxy(function(e, romoForm) {
+      Romo.trigger(this.elem, 'romoInlineForm:romoForm:beforeSubmit', [romoForm, this]);
+    }, this));
+    Romo.on(formElem, 'romoForm:submitSuccess', Romo.proxy(function(e, data, romoForm) {
+      Romo.trigger(this.elem, 'romoInlineForm:romoForm:submitSuccess', [data, romoForm, this]);
+    }, this));
+    Romo.on(formElem, 'romoForm:submitInvalidMsgs', Romo.proxy(function(e, msgs, xhr, romoForm) {
+      Romo.trigger(this.elem, 'romoInlineForm:romoForm:submitInvalidMsgs', [msgs, xhr, romoForm, this]);
+    }, this));
+    Romo.on(formElem, 'romoForm:submitXhrError', Romo.proxy(function(e, xhr, romoForm) {
+      Romo.trigger(this.elem, 'romoInlineForm:romoForm:submitXhrError', [xhr, romoForm, this]);
+    }, this));
+    Romo.on(formElem, 'romoForm:submitError', Romo.proxy(function(e, xhr, romoForm) {
+      Romo.trigger(this.elem, 'romoInlineForm:romoForm:submitError', [xhr, romoForm, this]);
+    }, this));
 
-  var submitElem   = Romo.find(this.elem, '[data-romo-form-submit]')[0];
-  var spinnerElems = Romo.find(this.elem, '[data-romo-spinner-auto="true"]');
-  this.romoForm = new RomoForm(formElem, submitElem, spinnerElems);
+    var submitElem   = Romo.find(this.elem, '[data-romo-form-submit]')[0];
+    var spinnerElems = Romo.find(this.elem, '[data-romo-spinner-auto="true"]');
+
+    this.romoForm = new RomoForm(formElem, submitElem, spinnerElems);
+  }
 }
 
 Romo.onInitUI(function(elem) {

--- a/assets/js/romo/modal_form.js
+++ b/assets/js/romo/modal_form.js
@@ -1,22 +1,9 @@
 var RomoModalForm = function(elem) {
   this.elem = elem;
 
-  this.romoModal = new RomoModal(this.elem);
-  this.doBindModal();
-
-  this.romoForm = undefined;
-  Romo.on(this.elem, 'romoModalForm:romoForm:triggerSubmit', Romo.proxy(function(e) {
-    if (this.romoForm != undefined) {
-      Romo.trigger(this.romoForm.elem, 'romoForm:triggerSubmit', []);
-    }
-  }, this));
-  this.doBindForm();
-  Romo.on(this.elem, 'romoModal:loadBodySuccess', Romo.proxy(function(e, data, romoModal) {
-    this.doBindForm();
-    Romo.trigger(this.elem, 'romoModalForm:formReady', [this.romoForm, this]);
-  }, this));
-
   this.doInit();
+  this._bindElem();
+
   Romo.trigger(this.elem, 'romoModalForm:ready', [this]);
 }
 
@@ -24,7 +11,26 @@ RomoModalForm.prototype.doInit = function() {
   // override as needed
 }
 
-RomoModalForm.prototype.doBindModal = function() {
+// private
+
+RomoDropdownForm.prototype._bindElem = function() {
+  Romo.on(this.elem, 'romoModalForm:romoForm:triggerSubmit', Romo.proxy(function(e) {
+    if (this.romoForm !== undefined) {
+      Romo.trigger(this.romoForm.elem, 'romoForm:triggerSubmit', []);
+    }
+  }, this));
+  Romo.on(this.elem, 'romoModal:loadBodySuccess', Romo.proxy(function(e, data, romoModal) {
+    this._bindForm();
+    Romo.trigger(this.elem, 'romoModalForm:formReady', [this.romoForm, this]);
+  }, this));
+
+  this._bindModal();
+  this._bindForm();
+}
+
+RomoModalForm.prototype._bindModal = function() {
+  this.romoModal = new RomoModal(this.elem);
+
   if (Romo.data(this.elem, 'romo-modal-clear-content') === undefined) {
     Romo.setData(this.elem, 'romo-modal-clear-content', 'true');
   }
@@ -65,39 +71,43 @@ RomoModalForm.prototype.doBindModal = function() {
 }
 
 RomoModalForm.prototype.doBindForm = function() {
+  this.romoForm = undefined;
   var formElem = Romo.find(this.romoModal.popupElem, '[data-romo-form-auto="modalForm"]')[0];
 
-  Romo.on(formElem, 'romoForm:clearMsgs', Romo.proxy(function(e, romoForm) {
-    Romo.trigger(this.elem, 'romoModalForm:romoForm:clearMsgs', [romoForm, this]);
-  }, this));
-  Romo.on(formElem, 'romoForm:ready', Romo.proxy(function(e, romoForm) {
-    Romo.trigger(this.elem, 'romoModalForm:romoForm:ready', [romoForm, this]);
-  }, this));
-  Romo.on(formElem, 'romoForm:confirmSubmit', Romo.proxy(function(e, romoForm) {
-    Romo.trigger(this.elem, 'romoModalForm:romoForm:confirmSubmit', [romoForm, this]);
-  }, this));
-  Romo.on(formElem, 'romoForm:beforeSubmit', Romo.proxy(function(e, romoForm) {
-    Romo.trigger(this.elem, 'romoModalForm:romoForm:beforeSubmit', [romoForm, this]);
-  }, this));
-  Romo.on(formElem, 'romoForm:submitSuccess', Romo.proxy(function(e, data, romoForm) {
-    Romo.trigger(this.elem, 'romoModalForm:romoForm:submitSuccess', [data, romoForm, this]);
-  }, this));
-  Romo.on(formElem, 'romoForm:submitInvalidMsgs', Romo.proxy(function(e, msgs, xhr, romoForm) {
-    Romo.trigger(this.elem, 'romoModalForm:romoForm:submitInvalidMsgs', [msgs, xhr, romoForm, this]);
-  }, this));
-  Romo.on(formElem, 'romoForm:submitXhrError', Romo.proxy(function(e, xhr, romoForm) {
-    Romo.trigger(this.elem, 'romoModalForm:romoForm:submitXhrError', [xhr, romoForm, this]);
-  }, this));
-  Romo.on(formElem, 'romoForm:submitError', Romo.proxy(function(e, xhr, romoForm) {
-    Romo.trigger(this.elem, 'romoModalForm:romoForm:submitError', [xhr, romoForm, this]);
-  }, this));
-  Romo.on(formElem, 'romoForm:browserSubmit', Romo.proxy(function(e, romoForm) {
-    Romo.trigger(this.elem, 'romoModalForm:romoForm:browserSubmit', [romoForm, this]);
-  }, this));
+  if (formElem !== undefined) {
+    Romo.on(formElem, 'romoForm:clearMsgs', Romo.proxy(function(e, romoForm) {
+      Romo.trigger(this.elem, 'romoModalForm:romoForm:clearMsgs', [romoForm, this]);
+    }, this));
+    Romo.on(formElem, 'romoForm:ready', Romo.proxy(function(e, romoForm) {
+      Romo.trigger(this.elem, 'romoModalForm:romoForm:ready', [romoForm, this]);
+    }, this));
+    Romo.on(formElem, 'romoForm:confirmSubmit', Romo.proxy(function(e, romoForm) {
+      Romo.trigger(this.elem, 'romoModalForm:romoForm:confirmSubmit', [romoForm, this]);
+    }, this));
+    Romo.on(formElem, 'romoForm:beforeSubmit', Romo.proxy(function(e, romoForm) {
+      Romo.trigger(this.elem, 'romoModalForm:romoForm:beforeSubmit', [romoForm, this]);
+    }, this));
+    Romo.on(formElem, 'romoForm:submitSuccess', Romo.proxy(function(e, data, romoForm) {
+      Romo.trigger(this.elem, 'romoModalForm:romoForm:submitSuccess', [data, romoForm, this]);
+    }, this));
+    Romo.on(formElem, 'romoForm:submitInvalidMsgs', Romo.proxy(function(e, msgs, xhr, romoForm) {
+      Romo.trigger(this.elem, 'romoModalForm:romoForm:submitInvalidMsgs', [msgs, xhr, romoForm, this]);
+    }, this));
+    Romo.on(formElem, 'romoForm:submitXhrError', Romo.proxy(function(e, xhr, romoForm) {
+      Romo.trigger(this.elem, 'romoModalForm:romoForm:submitXhrError', [xhr, romoForm, this]);
+    }, this));
+    Romo.on(formElem, 'romoForm:submitError', Romo.proxy(function(e, xhr, romoForm) {
+      Romo.trigger(this.elem, 'romoModalForm:romoForm:submitError', [xhr, romoForm, this]);
+    }, this));
+    Romo.on(formElem, 'romoForm:browserSubmit', Romo.proxy(function(e, romoForm) {
+      Romo.trigger(this.elem, 'romoModalForm:romoForm:browserSubmit', [romoForm, this]);
+    }, this));
 
-  var submitElem   = Romo.find(this.romoModal.popupElem, '[data-romo-form-submit]')[0];
-  var spinnerElems = Romo.find(this.romoModal.popupElem, '[data-romo-spinner-auto="true"]');
-  this.romoForm = new RomoForm(formElem, submitElem, spinnerElems);
+    var submitElem   = Romo.find(this.romoModal.popupElem, '[data-romo-form-submit]')[0];
+    var spinnerElems = Romo.find(this.romoModal.popupElem, '[data-romo-spinner-auto="true"]');
+
+    this.romoForm = new RomoForm(formElem, submitElem, spinnerElems);
+  }
 }
 
 Romo.onInitUI(function(elem) {


### PR DESCRIPTION
This updates these form components to reorg their methods so that
the "private" methods all have the leading underscor convention
and follow the `_bindElem` pattern that our other compoenents use.

This also fixes an error from when these were converted to Romo
js syntax and off of jQuery syntax in previous efforts.  The form
elem isn't available on initial load b/c it is, most typically,
loaded via ajax "load success" events.  So the initial `_bindForm`
call won't find a form elem and the `.romoForm` property will be
undefined unitl the "load success" events happen.  This means we
need to alter the `_bindForm` logic to only do its stuff if there
is a form elem.  Previously jQuery would return a "collection"
whether a form elem existed or not so the event binding were safe
whether a form elem existed or not.  Not so anymore.

@jcredding ready for review.