### PR TITLE
Cleanups from the switch to no longer use jquery

### DIFF
--- a/assets/js/romo/base.js
+++ b/assets/js/romo/base.js
@@ -244,7 +244,7 @@ Romo.prototype.parseZIndex = function(elem) {
 }
 
 Romo.prototype.parseElemZIndex = function(elem) {
-  var val = parseInt(this.css(elem, "z-index"));
+  var val = parseInt(this.css(elem, "z-index"), 10);
   if (!isNaN(val)) {
     return val;
   }
@@ -741,7 +741,7 @@ Romo.prototype._fid = 1;
 Romo.prototype._el = function(elem) {
   if (!elem._romoeid) {
     if (elem !== window && elem !== document) {
-      elem._romoeid = (this.attr(elem, 'data-romo-eid') || this.setAttr(elem, 'data-romo-eid', this._eid++));
+      elem._romoeid = (this.data(elem, 'romo-eid') || this.setData(elem, 'romo-eid', this._eid++));
     } else {
       elem._romoeid = elem === window ? 'window' : 'document';
     }

--- a/assets/js/romo/date.js
+++ b/assets/js/romo/date.js
@@ -161,7 +161,7 @@ RomoDate.Parser.prototype.date = function() {
   if (dateValues.length === 0) {
     return undefined;
   }
-  var year = parseInt(dateValues[0]);
+  var year = parseInt(dateValues[0], 10);
   if (year < 0) {
     return undefined;
   }
@@ -176,12 +176,12 @@ RomoDate.Parser.prototype.date = function() {
     }
   }
 
-  var month = parseInt(dateValues[1]) - 1;
+  var month = parseInt(dateValues[1], 10) - 1;
   if (month < 0 || month > 11) {
     return undefined;
   }
 
-  var day = parseInt(dateValues[2]);
+  var day = parseInt(dateValues[2], 10);
   var date = RomoDate.for(year, month, day);
   if (date.getMonth() !== month) {
     return undefined;

--- a/assets/js/romo/datepicker.js
+++ b/assets/js/romo/datepicker.js
@@ -81,16 +81,16 @@ RomoDatepicker.prototype._bindElem = function() {
     Romo.trigger(this.elem, 'romoDatepicker:triggerPopupOpen');
   }, this));
 
-  Romo.on(this.elem, 'datepicker:triggerEnable', $.proxy(function(e) {
+  Romo.on(this.elem, 'datepicker:triggerEnable', Romo.proxy(function(e) {
     Romo.trigger(this.elem, 'romoIndicatorTextInput:triggerEnable', []);
   }, this));
-  Romo.on(this.elem, 'datepicker:triggerDisable', $.proxy(function(e) {
+  Romo.on(this.elem, 'datepicker:triggerDisable', Romo.proxy(function(e) {
     Romo.trigger(this.elem, 'romoIndicatorTextInput:triggerDisable', []);
   }, this));
-  Romo.on(this.elem, 'datepicker:triggerShow', $.proxy(function(e) {
+  Romo.on(this.elem, 'datepicker:triggerShow', Romo.proxy(function(e) {
     Romo.trigger(this.elem, 'romoIndicatorTextInput:triggerShow', []);
   }, this));
-  Romo.on(this.elem, 'datepicker:triggerHide', $.proxy(function(e) {
+  Romo.on(this.elem, 'datepicker:triggerHide', Romo.proxy(function(e) {
     Romo.trigger(this.elem, 'romoIndicatorTextInput:triggerHide', []);
   }, this));
 
@@ -106,7 +106,7 @@ RomoDatepicker.prototype._bindDropdown = function() {
   if (Romo.data(this.elem, 'romo-dropdown-width') === undefined) {
     Romo.setData(this.elem, 'romo-dropdown-width', 'elem');
   }
-  if (parseInt(Romo.css(this.elem, 'width')) < 175) {
+  if (parseInt(Romo.css(this.elem, 'width'), 10) < 175) {
     Romo.setData(this.elem, 'romo-dropdown-width', '175px');
   }
   this.romoDropdown = new RomoDropdown(this.elem);
@@ -215,7 +215,7 @@ RomoDatepicker.prototype._onPopupOpen = function(e) {
 }
 
 RomoDatepicker.prototype._onPopupClose = function(e) {
-  this._highlightItem($());
+  this._highlightItem(undefined);
 }
 
 RomoDatepicker.prototype._onItemEnter = function(e) {
@@ -396,7 +396,9 @@ RomoDatepicker.prototype._highlightItem = function(itemElem) {
   if(highlightElem) {
     highlightElem.removeClass('romo-datepicker-highlight');
   }
-  Romo.addClass(itemElem, 'romo-datepicker-highlight');
+  if(itemElem) {
+    Romo.addClass(itemElem, 'romo-datepicker-highlight');
+  }
 }
 
 Romo.onInitUI(function(elem) {

--- a/assets/js/romo/dropdown.js
+++ b/assets/js/romo/dropdown.js
@@ -96,7 +96,7 @@ RomoDropdown.prototype.doPlacePopupElem = function() {
   var configPosition = this.popupPosition;
 
   if (configHeight === 'detect') {
-    var popupHeight       = parseInt(Romo.css(this.popupElem, 'height'));
+    var popupHeight       = parseInt(Romo.css(this.popupElem, 'height'), 10);
     var topAvailHeight    = this._getPopupMaxAvailableHeight('top');
     var bottomAvailHeight = this._getPopupMaxAvailableHeight('bottom');
 
@@ -315,7 +315,7 @@ RomoDropdown.prototype._onPopupClose = function(e) {
   if (Romo.hasClass(this.elem, 'disabled') === false && this.popupOpen()) {
     setTimeout(Romo.proxy(function() {
       this.doPopupClose();
-    }, this), 1;
+    }, this), 1);
   }
 }
 

--- a/assets/js/romo/inline_form.js
+++ b/assets/js/romo/inline_form.js
@@ -13,7 +13,7 @@ RomoInlineForm.prototype.doInit = function() {
 
 // private
 
-RomoDropdownForm.prototype._bindElem = function() {
+RomoInlineForm.prototype._bindElem = function() {
   Romo.on(this.elem, 'romoInlineForm:romoForm:triggerSubmit', Romo.proxy(function(e) {
     if (this.romoForm !== undefined) {
       Romo.trigger(this.romoForm.elem, 'romoForm:triggerSubmit', []);

--- a/assets/js/romo/modal.js
+++ b/assets/js/romo/modal.js
@@ -197,7 +197,7 @@ RomoModal.prototype._bindBody = function() {
   }
 
   if (Romo.data(this.elem, 'romo-modal-max-height') === undefined) {
-    Romo.setAttr(this.elem, 'data-romo-modal-max-height', 'detect');
+    Romo.setData(this.elem, 'romo-modal-max-height', 'detect');
   }
   if (Romo.data(this.elem, 'romo-modal-max-height') !== 'detect') {
     css['max-height'] = Romo.data(this.elem, 'romo-modal-max-height');
@@ -270,8 +270,8 @@ RomoModal.prototype._dragStart = function(e) {
   Romo.addClass(this.dragElem, 'romo-modal-grabbing');
   Romo.removeClass(this.dragElem, 'romo-modal-grab');
 
-  Romo.setStyle(this.popupElem, 'width',  Romo.css(this.popupElem, 'width');
-  Romo.setStyle(this.popupElem, 'height', Romo.css(this.popupElem, 'height');
+  Romo.setStyle(this.popupElem, 'width',  Romo.css(this.popupElem, 'width'));
+  Romo.setStyle(this.popupElem, 'height', Romo.css(this.popupElem, 'height'));
 
   this._dragDiffX = e.clientX - this.popupElem.offsetLeft;
   this._dragDiffY = e.clientY - this.popupElem.offsetTop;

--- a/assets/js/romo/modal_form.js
+++ b/assets/js/romo/modal_form.js
@@ -13,7 +13,7 @@ RomoModalForm.prototype.doInit = function() {
 
 // private
 
-RomoDropdownForm.prototype._bindElem = function() {
+RomoModalForm.prototype._bindElem = function() {
   Romo.on(this.elem, 'romoModalForm:romoForm:triggerSubmit', Romo.proxy(function(e) {
     if (this.romoForm !== undefined) {
       Romo.trigger(this.romoForm.elem, 'romoForm:triggerSubmit', []);

--- a/assets/js/romo/option_list_dropdown.js
+++ b/assets/js/romo/option_list_dropdown.js
@@ -417,7 +417,7 @@ RomoOptionListDropdown.prototype._onPopupOpenBodyKeyDown = function(e) {
 
   var scrollElem   = this.romoDropdown.bodyElem;
   var scrollOffset = Romo.offset(scrollElem);
-  var scrollHeight = parseInt(Romo.css(scrollElem, 'height'));
+  var scrollHeight = parseInt(Romo.css(scrollElem, 'height'), 10);
 
   if (e.keyCode === 38 /* Up */) {
     var prevElem   = this._prevListItem();
@@ -435,7 +435,7 @@ RomoOptionListDropdown.prototype._onPopupOpenBodyKeyDown = function(e) {
   } else if(e.keyCode === 40 /* Down */) {
     var nextElem   = this._nextListItem();
     var nextOffset = Romo.offset(nextElem);
-    var nextHeight = parseInt(Romo.css(nextElem, 'height'));
+    var nextHeight = parseInt(Romo.css(nextElem, 'height'), 10);
 
     this._highlightItem(nextElem);
 
@@ -490,7 +490,7 @@ RomoOptionListDropdown.prototype._scrollTopToItem = function(itemElem) {
 
     var scrollOffsetTop = Romo.offset(scrollElem).top;
     var selOffsetTop    = Romo.offset(itemElem).top;
-    var selOffset       = parseInt(Romo.css(itemElem, 'height')) / 2;
+    var selOffset       = parseInt(Romo.css(itemElem, 'height'), 10) / 2;
 
     scrollElem.scrollTop = selOffsetTop - scrollOffsetTop - selOffset;
   }
@@ -503,7 +503,7 @@ RomoOptionListDropdown.prototype._scrollBottomToItem = function(itemElem) {
 
     var scrollOffsetTop = Romo.offset(scrollElem).top;
     var selOffsetTop    = Romo.offset(itemElem).top;
-    var selOffset       = scrollElem.offsetHeight - parseInt(Romo.css(itemElem, 'height'));
+    var selOffset       = scrollElem.offsetHeight - parseInt(Romo.css(itemElem, 'height'), 10);
 
     scrollElem.scrollTop = selOffsetTop - scrollOffsetTop - selOffset;
   }

--- a/assets/js/romo/spinner.js
+++ b/assets/js/romo/spinner.js
@@ -18,26 +18,26 @@ RomoSpinner.prototype.doStart = function(customBasisSize) {
   var basisSize = (
     customBasisSize                                 ||
     Romo.data(this.elem, 'romo-spinner-basis-size') ||
-    Math.min(parseInt(Romo.css(this.elem, "width")), parseInt(Romo.css(this.elem, "height")))
+    Math.min(parseInt(Romo.css(this.elem, "width"), 10), parseInt(Romo.css(this.elem, "height"), 10))
   );
 
   var spinnerOpts = {
-    lines:     11,                           // The number of lines to draw
-    width:     2,                            // The line thickness
-    length:    parseInt(basisSize) / 4.5,    // The length of each line
-    radius:    parseInt(basisSize) / 5.5,    // The radius of the inner circle
-    corners:   1,                            // Corner roundness (0..1)
-    rotate:    0,                            // The rotation offset
-    direction: 1,                            // 1: clockwise, -1: counterclockwise
-    color:     Romo.css(this.elem, 'color'), // #rgb or #rrggbb or array of colors
-    speed:     1,                            // Rounds per second
-    trail:     60,                           // Afterglow percentage
-    shadow:    false,                        // Whether to render a shadow
-    hwaccel:   false,                        // Whether to use hardware acceleration
-    className: 'spinner',                    // The CSS class to assign to the spinner
-    zIndex:    1000,                         // The z-index (defaults to 2000000000)
-    top:       '50%',                        // Top position relative to parent
-    left:      '50%'                         // Left position relative to parent
+    lines:     11,                            // The number of lines to draw
+    width:     2,                             // The line thickness
+    length:    parseInt(basisSize, 10) / 4.5, // The length of each line
+    radius:    parseInt(basisSize, 10) / 5.5, // The radius of the inner circle
+    corners:   1,                             // Corner roundness (0..1)
+    rotate:    0,                             // The rotation offset
+    direction: 1,                             // 1: clockwise, -1: counterclockwise
+    color:     Romo.css(this.elem, 'color'),  // #rgb or #rrggbb or array of colors
+    speed:     1,                             // Rounds per second
+    trail:     60,                            // Afterglow percentage
+    shadow:    false,                         // Whether to render a shadow
+    hwaccel:   false,                         // Whether to use hardware acceleration
+    className: 'spinner',                     // The CSS class to assign to the spinner
+    zIndex:    1000,                          // The z-index (defaults to 2000000000)
+    top:       '50%',                         // Top position relative to parent
+    left:      '50%'                          // Left position relative to parent
   };
   this.spinner = new Spinner(spinnerOpts);
 

--- a/assets/js/romo/tooltip.js
+++ b/assets/js/romo/tooltip.js
@@ -66,7 +66,7 @@ RomoTooltip.prototype.doPlacePopupElem = function() {
   var configPosition = this.popupPosition;
 
   if (configHeight === 'detect' && (configPosition === 'top' || configPosition === 'bottom')) {
-    var popupHeight = parseInt(Romo.css(this.popupElem, 'height'));
+    var popupHeight = parseInt(Romo.css(this.popupElem, 'height'), 10);
     var topAvailHeight = this._getPopupMaxAvailableHeight('top');
     var bottomAvailHeight = this._getPopupMaxAvailableHeight('bottom');
 


### PR DESCRIPTION
This is a small set of cleanups from the effort to stop using
jquery. This includes:

* Update the `parseInt` to always pass a radix of 10 to avoid
confusion and ensure it works consistently across browsers as
recommended by MDN.
* Update some remaining `$.proxy` calls. These were most likely
the result of a bad merge.
* Update a few final `attr` and `setAttr` calls that can use
`data` and `setData` instead.
* Update the datepicker `_highlightItem` to allow passing an
`undefined` value to it and update the `_onPopupClose` to pass
`undefined` instead of an empty jquery object (`$()`). This should
have been done when datepicker was updated to not use jquery but
was probably missed. This switches to passing `undefined` because
Romo doesn't support building empty objects like jquery did.
* Fix a couple missing parenthesis in the dropdown and modal
components.
* Fix modal form and inline form using the dropdown form for their
`_bindElem` function.

@kellyredding - Ready for review.