### PR TITLE
add `.updateText` base js method; switch to using it in components

### DIFF
--- a/assets/js/romo/base.js
+++ b/assets/js/romo/base.js
@@ -298,6 +298,10 @@ Romo.prototype.updateHtml = function(elem, htmlString) {
   return this.update(elem, this.elems(htmlString));
 }
 
+Romo.prototype.updateText = function(elem, textString) {
+  elem.innerText = textString;
+}
+
 Romo.prototype.initUpdate = function(elem, childElems) {
   return this.triggerInitUI(this.update(elem, childElems));
 }

--- a/assets/js/romo/datepicker.js
+++ b/assets/js/romo/datepicker.js
@@ -274,7 +274,7 @@ RomoDatepicker.prototype._clearBlurTimeout = function() {
 
 RomoDatepicker.prototype._refreshCalendar = function(date) {
   var titleElem = Romo.find(this.calTable, '.romo-datepicker-title')[0];
-  titleElem.innerText = this._buildCalendarTitle(date);
+  Romo.updateText(titleElem, this._buildCalendarTitle(date));
 
   var tableBodyElem = Romo.find(this.calTable, 'tbody')[0];
   Romo.updateHtml(tableBodyElem, '');
@@ -302,7 +302,7 @@ RomoDatepicker.prototype._buildCalendarHeader = function() {
   if (prevClass) {
     Romo.appendHtml(thPrevElem, '<i class="'+prevClass+'"></i>');
   } else {
-    thPrevElem.innerText = '<<';
+    Romo.updateText(thPrevElem, '<<');
   }
   Romo.append(titleRowElem, thPrevElem);
 
@@ -312,7 +312,7 @@ RomoDatepicker.prototype._buildCalendarHeader = function() {
   if (nextClass) {
     Romo.appendHtml(thNextElem, '<i class="'+nextClass+'"></i>');
   } else {
-    thNextElem.innerText = '>>';
+    Romo.updateText(thNextElem, '>>');
   }
   Romo.append(titleRowElem, thNextElem);
   Romo.append(headerElem, titleRowElem);

--- a/assets/js/romo/option_list_dropdown.js
+++ b/assets/js/romo/option_list_dropdown.js
@@ -240,7 +240,7 @@ RomoOptionListDropdown.prototype._buildListOptionElem = function(item) {
 
 RomoOptionListDropdown.prototype._buildListOptGroupElem = function(item) {
   var itemElem = Romo.elems('<li data-romo-option-list-dropdown-item="optgroup"></li>')[0];
-  itemElem.innerText = item.label;
+  Romo.updateText(itemElem, item.label);
 
   return itemElem;
 }

--- a/assets/js/romo/picker.js
+++ b/assets/js/romo/picker.js
@@ -359,7 +359,9 @@ RomoPicker.prototype._refreshUI = function() {
   if (text === '') {
     text = '&nbsp;'
   }
-  Romo.find(this.romoOptionListDropdown.elem, '.romo-picker-text').innerText = text;
+
+  var textElem = Romo.find(this.romoOptionListDropdown.elem, '.romo-picker-text')[0];
+  Romo.updateText(textElem, text);
 }
 
 RomoPicker.prototype._onCaretClick = function(e) {

--- a/assets/js/romo/select.js
+++ b/assets/js/romo/select.js
@@ -278,7 +278,9 @@ RomoSelect.prototype._refreshUI = function() {
   if (text === '') {
     text = '&nbsp;'
   }
-  Romo.find(this.romoSelectDropdown.elem, '.romo-select-text')[0].innerText = text;
+
+  var textElem = Romo.find(this.romoSelectDropdown.elem, '.romo-select-text')[0];
+  Romo.updateText(textElem, text);
 }
 
 RomoSelect.prototype._onCaretClick = function(e) {

--- a/assets/js/romo/select_dropdown.js
+++ b/assets/js/romo/select_dropdown.js
@@ -105,7 +105,7 @@ RomoSelectDropdown.prototype._bindElem = function() {
         custOptElem = Romo.find(this.optionElemsParentElem, 'OPTION[data-romo-select-dropdown-custom-option="true"]')[0];
       }
       Romo.setAttr(custOptElem, 'value', itemValue);
-      custOptElem.innerText = itemDisplayText;
+      Romo.updateText(custOptElem,  itemDisplayText);
     } else if (custOptElem !== undefined) {
       // a non custom value is being selected. remove any existing custom option
       Romo.remove(custOptElem);


### PR DESCRIPTION
This is part of building out the Romo vanilla js api.  Since we
have an `.updateHtml` method for setting an elem's html content,
it feels more natural and consistent to have an `.updateText`
method for setting an elem's text content.

Note: I've chose to jux this next to the `.updateHtml` method def
since they are similar in function.  However, there isn't any
corresponding "init" method b/c text content doesn't need any
initialization.  Also, there isn't any other "text" manipulation
methods (like replace, before/after, prepend/append) b/c text
content can only be updated.

@jcredding ready for review.