### PR TITLE
Don't use selectors that start with `>`

### DIFF
--- a/assets/js/romo/dropdown.js
+++ b/assets/js/romo/dropdown.js
@@ -181,7 +181,9 @@ RomoDropdown.prototype._bindPopup = function() {
     this._bindElemKeyUp();
   }, this));
 
-  this.bodyElem = Romo.find(this.popupElem, '> .romo-dropdown-body')[0];
+  this.bodyElem = Romo.children(this.popupElem).find(Romo.proxy(function(childElem){
+    return Romo.is(childElem, '.romo-dropdown-body');
+  }, this));
   if (Romo.data(this.elem, 'romo-dropdown-style-class') !== undefined) {
     Romo.addClass(this.bodyElem, Romo.data(this.elem, 'romo-dropdown-style-class'));
   }

--- a/assets/js/romo/modal.js
+++ b/assets/js/romo/modal.js
@@ -133,7 +133,9 @@ RomoModal.prototype._bindPopup = function() {
   var popupParentElem = Romo.closest(this.elem, Romo.data(this.elem, 'romo-dropdown-append-to-closest') || 'body');
   Romo.append(popupParentElem, this.popupElem)
 
-  this.bodyElem = Romo.find(this.popupElem, '> .romo-modal-body')[0];
+  this.bodyElem = Romo.children(this.popupElem).find(Romo.proxy(function(childElem){
+    return Romo.is(childElem, '.romo-modal-body');
+  }, this));
   if (Romo.data(this.elem, 'romo-modal-style-class') !== undefined) {
     Romo.addClass(this.bodyElem, Romo.data(this.elem, 'romo-modal-style-class'));
   }

--- a/assets/js/romo/tooltip.js
+++ b/assets/js/romo/tooltip.js
@@ -161,7 +161,9 @@ RomoTooltip.prototype._bindPopup = function() {
   var popupParentElem = Romo.closest(this.elem, Romo.data(this.elem, 'romo-tooltip-append-to-closest') || 'body');
   Romo.append(popupParentElem, this.popupElem);
 
-  this.bodyElem = Romo.find(this.popupElem, '> .romo-tooltip-body')[0];
+  this.bodyElem = Romo.children(this.popupElem).find(Romo.proxy(function(childElem){
+    return Romo.is(childElem, '.romo-tooltip-body');
+  }, this));
   if (Romo.data(this.elem, 'romo-tooltip-style-class') !== undefined) {
     Romo.addClass(this.bodyElem, Romo.data(this.elem, 'romo-tooltip-style-class'));
   }


### PR DESCRIPTION
This updates dropdowns, modals, and tooltips to not use a
selector that starts with `>`. This isn't a valid selector and
causes `querySelectorAll` to thow an error. To get around this,
this switches to using `Romo.children` and `Romo.is` to find any
children that match the class.

Note: There is a `:scope` pseudo class that can be used to make
a selector like `:scope > .className` but it doesn't have great
support in all the browsers.

@kellyredding - Ready for review.