### PR TITLE
Update dropdown and modal to not always expect a `contentElem`

### DIFF
--- a/assets/js/romo/dropdown.js
+++ b/assets/js/romo/dropdown.js
@@ -242,7 +242,9 @@ RomoDropdown.prototype._bindBody = function() {
   }
 
   this.closeElem = Romo.find(this.popupElem, '[data-romo-dropdown-close="true"]')[0];
-  Romo.on(this.closeElem, 'click', Romo.proxy(this.onPopupClose, this));
+  if (this.closeElem !== undefined) {
+    Romo.on(this.closeElem, 'click', Romo.proxy(this.onPopupClose, this));
+  }
 
   Romo.setStyle(this.contentElem, 'min-height', Romo.data(this.elem, 'romo-dropdown-min-height'));
   Romo.setStyle(this.contentElem, 'height',     Romo.data(this.elem, 'romo-dropdown-height'));
@@ -266,14 +268,16 @@ RomoDropdown.prototype._bindBody = function() {
 }
 
 RomoDropdown.prototype._resetBody = function() {
-  Romo.rmStyle(this.contentElem, 'min-width');
-  Romo.rmStyle(this.contentElem, 'max-width');
-  Romo.rmStyle(this.contentElem, 'width');
-  Romo.rmStyle(this.contentElem, 'min-height');
-  Romo.rmStyle(this.contentElem, 'max-height');
-  Romo.rmStyle(this.contentElem, 'height');
-  Romo.rmStyle(this.contentElem, 'overflow-x');
-  Romo.rmStyle(this.contentElem, 'overflow-y');
+  if (this.contentElem !== undefined) {
+    Romo.rmStyle(this.contentElem, 'min-width');
+    Romo.rmStyle(this.contentElem, 'max-width');
+    Romo.rmStyle(this.contentElem, 'width');
+    Romo.rmStyle(this.contentElem, 'min-height');
+    Romo.rmStyle(this.contentElem, 'max-height');
+    Romo.rmStyle(this.contentElem, 'height');
+    Romo.rmStyle(this.contentElem, 'overflow-x');
+    Romo.rmStyle(this.contentElem, 'overflow-y');
+  }
 }
 
 RomoDropdown.prototype._loadBodyStart = function() {

--- a/assets/js/romo/modal.js
+++ b/assets/js/romo/modal.js
@@ -182,11 +182,15 @@ RomoModal.prototype._bindBody = function() {
   }
 
   this.closeElem = Romo.find(this.popupElem, '[data-romo-modal-close="true"]')[0];
-  Romo.on(this.closeElem, 'click', Romo.proxy(this._onPopupClose, this));
+  if (this.closeElem !== undefined) {
+    Romo.on(this.closeElem, 'click', Romo.proxy(this._onPopupClose, this));
+  }
 
   this.dragElem = Romo.find(this.popupElem, '[data-romo-modal-drag="true"]')[0];
-  Romo.addClass(this.dragElem, 'romo-modal-grab');
-  Romo.on(this.dragElem, 'mousedown', Romo.proxy(this._onMouseDown, this));
+  if (this.dragElem !== undefined) {
+    Romo.addClass(this.dragElem, 'romo-modal-grab');
+    Romo.on(this.dragElem, 'mousedown', Romo.proxy(this._onMouseDown, this));
+  }
 
   var css = {
     'min-width':  Romo.data(this.elem, 'romo-modal-min-width'),
@@ -211,15 +215,19 @@ RomoModal.prototype._bindBody = function() {
 }
 
 RomoModal.prototype._resetBody = function() {
-  Romo.rmStyle(this.contentElem, 'min-width');
-  Romo.rmStyle(this.contentElem, 'max-width');
-  Romo.rmStyle(this.contentElem, 'width');
-  Romo.rmStyle(this.contentElem, 'min-height');
-  Romo.rmStyle(this.contentElem, 'max-height');
-  Romo.rmStyle(this.contentElem, 'height');
-  Romo.rmStyle(this.contentElem, 'overflow');
+  if (this.contentElem !== undefined) {
+    Romo.rmStyle(this.contentElem, 'min-width');
+    Romo.rmStyle(this.contentElem, 'max-width');
+    Romo.rmStyle(this.contentElem, 'width');
+    Romo.rmStyle(this.contentElem, 'min-height');
+    Romo.rmStyle(this.contentElem, 'max-height');
+    Romo.rmStyle(this.contentElem, 'height');
+    Romo.rmStyle(this.contentElem, 'overflow');
+  }
 
-  Romo.off(this.closeElem, 'click', Romo.proxy(this.onPopupClose, this));
+  if (this.closeElem !== undefined) {
+    Romo.off(this.closeElem, 'click', Romo.proxy(this.onPopupClose, this));
+  }
 }
 
 RomoModal.prototype._loadBodyStart = function() {


### PR DESCRIPTION
This updates the dropdown and modal components to not always
expect that they have content. This is particularly true when
they are initializing and they reset their body. Their
`contentElem` won't exist yet so styles can't be removed from it.
This also does a similar check for a `closeElem` and the modal's
`dragElem` which may not exist when the dropdown/modal is first
initialized.

Note: This doesn't update the tooltip component because it doesn't
follow the same pattern as dropdowns and modals. It doesn't have
a content elem and instead uses its `bodyElem` when resetting and
it seems to always have a `bodyElem`.

@kellyredding - Ready for review.