### PR TITLE
Update append/prepend, before/after, and update to allow single elem

### DIFF
--- a/assets/js/romo/base.js
+++ b/assets/js/romo/base.js
@@ -289,7 +289,7 @@ Romo.prototype.initReplaceHtml = function(elem, htmlString) {
 
 Romo.prototype.update = function(elem, childElems) {
   elem.innerHTML = '';
-  return childElems.map(function(childElem) {
+  return Romo.array(childElems).map(function(childElem) {
     return elem.appendChild(childElem);
   });
 }
@@ -312,7 +312,7 @@ Romo.prototype.initUpdateHtml = function(elem, htmlString) {
 
 Romo.prototype.prepend = function(elem, childElems) {
   var refElem = elem.firstChild;
-  return childElems.reverse().map(function(childElem) {
+  return Romo.array(childElems).reverse().map(function(childElem) {
     refElem = elem.insertBefore(childElem, refElem);
     return refElem;
   }).reverse();
@@ -331,7 +331,7 @@ Romo.prototype.initPrependHtml = function(elem, htmlString) {
 }
 
 Romo.prototype.append = function(elem, childElems) {
-  return childElems.map(function(childElem) {
+  return Romo.array(childElems).map(function(childElem) {
     return elem.appendChild(childElem);
   });
 }
@@ -351,7 +351,7 @@ Romo.prototype.initAppendHtml = function(elem, htmlString) {
 Romo.prototype.before = function(elem, siblingElems) {
   var refElem    = elem;
   var parentElem = elem.parentNode;
-  return siblingElems.reverse().map(function(siblingElem) {
+  return Romo.array(siblingElems).reverse().map(function(siblingElem) {
     refElem = parentElem.insertBefore(siblingElem, refElem);
     return refElem;
   }).reverse();
@@ -372,7 +372,7 @@ Romo.prototype.initBeforeHtml = function(elem, htmlString) {
 Romo.prototype.after = function(elem, siblingElems) {
   var refElem    = this.next(elem);
   var parentElem = elem.parentNode;
-  return siblingElems.map(function(siblingElem) {
+  return Romo.array(siblingElems).map(function(siblingElem) {
     return parentElem.insertBefore(siblingElem, refElem);
   });
 }
@@ -630,7 +630,11 @@ Romo.prototype.array = function(value) {
   // remain fast and don't run through all of the logic to detect if an object
   // is like an array
   var valString = Object.prototype.toString.call(value);
-  if(valString === '[object NodeList]' || valString === '[object HTMLCollection]') {
+  if (
+    valString === '[object NodeList]'       ||
+    valString === '[object HTMLCollection]' ||
+    Array.isArray(value)
+  ) {
     return Array.prototype.slice.call(value)
   }
 


### PR DESCRIPTION
This updates the Romo helpers for updating or inserting elems to
allow passing a single elem. This is done by having them call
`Romo.array` on whatever they are passed and then using their
previous implementation which expected a set of elems. This was
noticed because dropdowns try to append their popup elem to a
popup parent and were erroring because it wasn't an array.

This also updates the `Romo.array` helper to short circuit if it's
passed an array object. This keeps the append/prepend,
before/after, and update fast when passed arrays of elems. This
probably should have been done in PR 177 when we originally
updated `Romo.array` to convert any value to an array and when
we added the short-circuit for `NodeList` and `HTMLCollection`.

@kellyredding - Ready for review.