### PR TITLE
Fix select displaying an empty text option as selected

### DIFF
--- a/assets/js/romo/select.js
+++ b/assets/js/romo/select.js
@@ -273,14 +273,16 @@ RomoSelect.prototype._refreshUI = function() {
     text = '';
     this.romoSelectedOptionsList.doRefreshUI();
   } else {
-    text = Romo.find(this.elem, 'OPTION[value="'+this._elemValues()[0]+'"]').innerText.trim();
-  }
-  if (text === '') {
-    text = '&nbsp;'
+    var optionElem = Romo.find(this.elem, 'OPTION[value="'+this._elemValues()[0]+'"]')[0];
+    text = optionElem.innerText.trim();
   }
 
   var textElem = Romo.find(this.romoSelectDropdown.elem, '.romo-select-text')[0];
-  Romo.updateText(textElem, text);
+  if (text === '') {
+    Romo.updateHtml(textElem, '&nbsp;');
+  } else {
+    Romo.updateText(textElem, text);
+  }
 }
 
 RomoSelect.prototype._onCaretClick = function(e) {


### PR DESCRIPTION
This fixes the select component trying to display an empty text
option as the selected value. An empty text option is one whose
`innerText` is an empty string. This also fixes multi selects
display since they never display a selected value in the select
itself.

The component was previously displaying the `&nbsp;` as text and
not properly interpretting it as a space. To fix this, the
component now switches between using `updateHtml` and `updateText`
depending on if the selected option's `innerText` is empty.

This also fixes an issue with finding the selected option. The
logic forgot to selected the first selected option and instead
tried to read `innerText` from a collection.

@kellyredding - Ready for review.