### PR TITLE
Fix dropdowns placing their popup elem

### DIFF
--- a/assets/js/romo/dropdown.js
+++ b/assets/js/romo/dropdown.js
@@ -86,10 +86,16 @@ RomoDropdown.prototype.doPlacePopupElem = function() {
     Romo.setStyle(this.popupElem, 'position', 'fixed');
   }
 
-  var pos    = Romo.assign({}, this.elem.getBoundingClientRect(), Romo.offset(this.elem));
-  var w      = this.popupElem.offsetWidth;
-  var h      = this.popupElem.offsetHeight;
-  var offset = {};
+  var elemRect   = this.elem.getBoundingClientRect();
+  var elemHeight = elemRect.height;
+  var elemWidth  = elemRect.width;
+
+  var elemOffset = Romo.offset(this.elem);
+  var elemTop    = elemOffset.top;
+  var elemLeft   = elemOffset.left
+
+  var popupOffsetWidth  = this.popupElem.offsetWidth;
+  var popupOffsetHeight = this.popupElem.offsetHeight;
 
   var configHeight = Romo.data(this.elem, 'romo-dropdown-height') ||
                      Romo.data(this.elem, 'romo-dropdown-max-height');
@@ -105,43 +111,46 @@ RomoDropdown.prototype.doPlacePopupElem = function() {
       configHeight = this._getPopupMaxAvailableHeight(configPosition);
     } else if (topAvailHeight > bottomAvailHeight) {
       configPosition = 'top';
-      configHeight = topAvailHeight;
+      configHeight   = topAvailHeight;
     } else {
       configPosition = 'bottom';
-      configHeight = bottomAvailHeight;
+      configHeight   = bottomAvailHeight;
     }
 
     // remove any height difference between the popup and content elems
     // assumes popup height always greater than or equal to content height
-    configHeight = configHeight - (h - this.contentElem.offsetHeight);
+    configHeight = configHeight - (popupOffsetHeight - this.contentElem.offsetHeight);
     Romo.setStyle(this.contentElem, 'max-height', configHeight.toString() + 'px');
   }
 
-  if(h > configHeight) {
-    h = configHeight;
+  if(popupOffsetHeight > configHeight) {
+    popupOffsetHeight = configHeight;
   }
 
+  var offsetTop = undefined;
   switch (configPosition) {
     case 'top':
       var pad = 2;
-      Romo.assign(offset, { top: pos.top - h - pad });
+      offsetTop = elemTop - popupOffsetHeight - pad;
       break;
     case 'bottom':
       var pad = 2;
-      Romo.assign(offset, { top: pos.top + pos.height + pad });
-      break;
-  }
-  switch (this.popupAlignment) {
-    case 'left':
-      Romo.assign(offset, { left: pos.left });
-      break;
-    case 'right':
-      Romo.assign(offset, { left: pos.left + pos.width - w });
+      offsetTop = elemTop + elemHeight + pad;
       break;
   }
 
-  Romo.setStyle(this.popupElem, 'top',  this._roundPosOffsetVal(offset.top));
-  Romo.setStyle(this.popupElem, 'left', this._roundPosOffsetVal(offset.left));
+  var offsetLeft = undefined;
+  switch (this.popupAlignment) {
+    case 'left':
+      offsetLeft = elemLeft;
+      break;
+    case 'right':
+      offsetLeft = elemLeft + elemWidth - popupOffsetWidth;
+      break;
+  }
+
+  Romo.setStyle(this.popupElem, 'top',  this._roundPosOffsetVal(offsetTop)+'px');
+  Romo.setStyle(this.popupElem, 'left', this._roundPosOffsetVal(offsetLeft)+'px');
 }
 
 RomoDropdown.prototype.doSetPopupZIndex = function(relativeElem) {


### PR DESCRIPTION
This fixes a couple issues with dropdowns placing their popup
elem. This is part of updating Romo to no longer use jquery.
These were found while trying to open a select component which
positions a dropdown on the bottom or top of the select input.

First, this fixes using `Romo.assign` with the `DOMRect` object
that the `getBoundingClientRect` returns. The `DOMRect` doesn't
work when passed to `Object.assign` (this is what `Romo.assign`
uses). It simply doesn't copy any of it's keys into the resulting
object. This caused the calculations to sometimes result in a
`NaN` value because they would add or subtract an `undefined`
value. This fixes the issue by avoiding using `Romo.assign` in
this case. There's not really any value in maintaining an offset
object because we can't pass it as a single arg like we previously
did with the jquery `offset` method. This switches to using
separate local variables and also updates variable names to try
and better manage all the different values.

Next, this updates the final `setStyle` calls to add the missing
`px` to the end of the values they are setting. Without the `px`
the values were being ignored which caused the dropdown to not
be positioned correctly.

@kellyredding - Ready for review.