### PR TITLE
Update `ParentChildElems.remove` to ignore non element nodes

### DIFF
--- a/assets/js/romo/base.js
+++ b/assets/js/romo/base.js
@@ -815,6 +815,8 @@ RomoParentChildElems.prototype.add = function(parentElem, childElems) {
 }
 
 RomoParentChildElems.prototype.remove = function(nodeElem) {
+  if (nodeElem.nodeType !== Node.ELEMENT_NODE){ return false; }
+
   if (Romo.data(nodeElem, 'romo-parent-removed-observer-disabled') !== true) {
     if (Romo.data(nodeElem, this.attrName) !== undefined) {
       // node is a parent elem itself


### PR DESCRIPTION
This updates the `ParentChildElems.remove` to ignore nodes that
are not element nodes. This fixes an issue with the `remove`
method trying to remove a text node. The `removeNodes` from the
mutation record can return non element nodes and then the parent
child elems logic tries to remove them. Since the `remove` method
requires element nodes this updates it to ignore any other kind
of nodes.

@kellyredding - Ready for review.