### PR TITLE
Update `Romo.children` and `Romo.siblings` to take optional selector

### DIFF
--- a/assets/js/romo/base.js
+++ b/assets/js/romo/base.js
@@ -29,8 +29,15 @@ Romo.prototype.is = function(elem, selector) {
   ).call(elem, selector);
 };
 
-Romo.prototype.children = function(parentElem) {
-  return this.array(parentElem.children);
+Romo.prototype.children = function(parentElem, selector) {
+  var childElems = this.array(parentElem.children);
+  if (selector) {
+    return childElems.filter(function(childElem) {
+      return Romo.is(childElem, selector);
+    });
+  } else {
+    return childElems;
+  }
 }
 
 Romo.prototype.parent = function(childElem) {
@@ -73,8 +80,8 @@ Romo.prototype.closest = function(fromElem, selector) {
   }
 }
 
-Romo.prototype.siblings = function(elem) {
-  return Array.prototype.filter.call(elem.parentNode.children, function(childElem) {
+Romo.prototype.siblings = function(elem, selector) {
+  return Romo.children(Romo.parent(elem), selector).filter(function(childElem) {
     return childElem !== elem;
   });
 }


### PR DESCRIPTION
This updates the `Romo.children` and `Romo.siblings` helpers to
take an optional selector. This makes these helpers consistent
with the other helpers that find elements (like `parents` and
`closest`). This also fixes a bug with the select dropdown
component already expecting the `children` helper to accept and
use a selector. This was keeping selects from filtering their
options when their filter text input was changed.

This updates the `children` helper to take a selector and if
provided, it filters the child elems by using `Romo.is` to see
if they match the selector. This updates the `siblings` helper
to simply call the `children` helper and pass a selector. Now
that it's calling `children` it knows the result will be an
array so it can directly call `filter` on the result.

@kellyredding - Ready for review.