### PR TITLE
Update the add/change HTML methods to error when passed non HTML

### DIFF
--- a/assets/js/romo/base.js
+++ b/assets/js/romo/base.js
@@ -283,7 +283,11 @@ Romo.prototype.replace = function(elem, replacementElem) {
 }
 
 Romo.prototype.replaceHtml = function(elem, htmlString) {
-  return this.replace(elem, this.elems(htmlString)[0]);
+  var replacementElem = Romo.elems(htmlString)[0];
+  if (replacementElem === undefined && (typeof(htmlString) !== 'string' || htmlString.trim() !== '')) {
+    throw new Error("Invalid HTML string, doesn't contain an HTML element.");
+  }
+  return this.replace(elem, replacementElem);
 }
 
 Romo.prototype.initReplace = function(elem, replacementElem) {
@@ -302,7 +306,11 @@ Romo.prototype.update = function(elem, childElems) {
 }
 
 Romo.prototype.updateHtml = function(elem, htmlString) {
-  return this.update(elem, this.elems(htmlString));
+  var childElems = Romo.elems(htmlString);
+  if (childElems.length === 0 && (typeof(htmlString) !== 'string' || htmlString.trim() !== '')) {
+    throw new Error("Invalid HTML string, doesn't contain any HTML elements.");
+  }
+  return this.update(elem, childElems);
 }
 
 Romo.prototype.updateText = function(elem, textString) {
@@ -326,7 +334,11 @@ Romo.prototype.prepend = function(elem, childElems) {
 }
 
 Romo.prototype.prependHtml = function(elem, htmlString) {
-  return this.prepend(elem, this.elems(htmlString));
+  var childElems = Romo.elems(htmlString);
+  if (childElems.length === 0 && (typeof(htmlString) !== 'string' || htmlString.trim() !== '')) {
+    throw new Error("Invalid HTML string, doesn't contain any HTML elements.");
+  }
+  return this.prepend(elem, childElems);
 }
 
 Romo.prototype.initPrepend = function(elem, childElems) {
@@ -344,7 +356,11 @@ Romo.prototype.append = function(elem, childElems) {
 }
 
 Romo.prototype.appendHtml = function(elem, htmlString) {
-  return this.append(elem, this.elems(htmlString));
+  var childElems = Romo.elems(htmlString);
+  if (childElems.length === 0 && (typeof(htmlString) !== 'string' || htmlString.trim() !== '')) {
+    throw new Error("Invalid HTML string, doesn't contain any HTML elements.");
+  }
+  return this.append(elem, childElems);
 }
 
 Romo.prototype.initAppend = function(elem, childElems) {
@@ -365,7 +381,11 @@ Romo.prototype.before = function(elem, siblingElems) {
 }
 
 Romo.prototype.beforeHtml = function(elem, htmlString) {
-  return this.before(elem, this.elems(htmlString));
+  var siblingElems = Romo.elems(htmlString);
+  if (siblingElems.length === 0 && (typeof(htmlString) !== 'string' || htmlString.trim() !== '')) {
+    throw new Error("Invalid HTML string, doesn't contain any HTML elements.");
+  }
+  return this.before(elem, siblingElems);
 }
 
 Romo.prototype.initBefore = function(elem, siblingElems) {
@@ -385,7 +405,11 @@ Romo.prototype.after = function(elem, siblingElems) {
 }
 
 Romo.prototype.afterHtml = function(elem, htmlString) {
-  return this.after(elem, this.elems(htmlString));
+  var siblingElems = Romo.elems(htmlString);
+  if (siblingElems.length === 0 && (typeof(htmlString) !== 'string' || htmlString.trim() !== '')) {
+    throw new Error("Invalid HTML string, doesn't contain any HTML elements.");
+  }
+  return this.after(elem, siblingElems);
 }
 
 Romo.prototype.initAfter = function(elem, siblingElems) {


### PR DESCRIPTION
This updates the add/change HTML methods on `Romo` to error if
they are passed non HTML strings. This is to help with the switch
from jquery to vanilla js. In jquery, the `html` helper would take
either HTML or text and update the element(s) appropriately. With
Romo if the add/change HTML methods were passed strings that
didn't include HTML then they would either add nothing and if
it was the replace or update it would remove the elem or its
content. To avoid this, the methods now throw an error if the
parsed HTML is empty but the HTML string wasn't empty.

This also includes updating the add/change HTML methods to not
accept non string values like `undefined` and `null`. Previously
these would either remove an elem or its content when using the
replace or update helpers and they would do nothing when using
the other helpers (prepent/append/before/after). Since the
behavior is inconsistent between the helpers and could hide
problems we decided it would be better for these to error as well.

@kellyredding - Ready for review.