### PR TITLE
Update option list dropdown to properly display options

### DIFF
--- a/assets/js/romo/option_list_dropdown.js
+++ b/assets/js/romo/option_list_dropdown.js
@@ -225,7 +225,13 @@ RomoOptionListDropdown.prototype._buildListOptionElem = function(item) {
 
   Romo.setData(itemElem, 'romo-option-list-dropdown-option-value',        value);
   Romo.setData(itemElem, 'romo-option-list-dropdown-option-display-text', displayText);
-  Romo.updateHtml(itemElem, displayHtml);
+
+  var displayElems = Romo.elems(displayHtml);
+  if (displayElems.length !== 0) {
+    Romo.update(itemElem, displayElems);
+  } else {
+    Romo.updateText(itemElem, displayHtml);
+  }
 
   if (item.selected === true) {
     Romo.addClass(itemElem, 'selected');


### PR DESCRIPTION
This fixes an issue with the option list dropdowns not displaying
its options when their `displayHtml` didn't contain any HTML
elements. This made it appear as if selects and pickers didn't
have any options in their dropdown. This fixes the issue by
checking if there are any HTML elements in the options
`displayHtml` and if not then the `displayHtml` is added as text
to the option. This allows the options API to remain unchanged
and fixes the options displaying correctly.

@kellyredding - Ready for review.