### PR TITLE
Fix `&nbsp;` usage for select and picker family of components

### DIFF
--- a/assets/js/romo/option_list_dropdown.js
+++ b/assets/js/romo/option_list_dropdown.js
@@ -221,7 +221,7 @@ RomoOptionListDropdown.prototype._buildListOptionElem = function(item) {
   var itemElem    = Romo.elems('<li data-romo-option-list-dropdown-item="opt"></li>')[0];
   var value       = item.value       || '';
   var displayText = item.displayText || '';
-  var displayHtml = item.displayHtml || item.displayText || '&nbsp;'
+  var displayHtml = item.displayHtml || item.displayText || '<span>&nbsp;</span>'
 
   Romo.setData(itemElem, 'romo-option-list-dropdown-option-value',        value);
   Romo.setData(itemElem, 'romo-option-list-dropdown-option-display-text', displayText);

--- a/assets/js/romo/picker.js
+++ b/assets/js/romo/picker.js
@@ -294,7 +294,7 @@ RomoPicker.prototype._buildDefaultOptionItems = function() {
       'type':        'option',
       'value':       '',
       'displayText': (Romo.data(this.elem, 'romo-picker-empty-option-display-text') || ''),
-      'displayHtml': '&nbsp;'
+      'displayHtml': '<span>&nbsp;</span>'
     });
   }
 
@@ -356,12 +356,13 @@ RomoPicker.prototype._refreshUI = function() {
   if (this.romoSelectedOptionsList !== undefined) {
     this.romoSelectedOptionsList.doRefreshUI();
   }
-  if (text === '') {
-    text = '&nbsp;'
-  }
 
   var textElem = Romo.find(this.romoOptionListDropdown.elem, '.romo-picker-text')[0];
-  Romo.updateText(textElem, text);
+  if (text === '') {
+    Romo.updateHtml(textElem, '<span>&nbsp;</span>');
+  } else {
+    Romo.updateText(textElem, text);
+  }
 }
 
 RomoPicker.prototype._onCaretClick = function(e) {

--- a/assets/js/romo/select.js
+++ b/assets/js/romo/select.js
@@ -279,7 +279,7 @@ RomoSelect.prototype._refreshUI = function() {
 
   var textElem = Romo.find(this.romoSelectDropdown.elem, '.romo-select-text')[0];
   if (text === '') {
-    Romo.updateHtml(textElem, '&nbsp;');
+    Romo.updateHtml(textElem, '<span>&nbsp;</span>');
   } else {
     Romo.updateText(textElem, text);
   }

--- a/assets/js/romo/select_dropdown.js
+++ b/assets/js/romo/select_dropdown.js
@@ -205,7 +205,7 @@ RomoSelectDropdown.prototype._buildOptionItem = function(optionElem) {
   item['type']        = 'option';
   item['value']       = (Romo.attr(optionElem, 'value') || '');
   item['displayText'] = (optionElem.innerText.trim() || '');
-  item['displayHtml'] = (optionElem.innerText.trim() || '&nbsp;');
+  item['displayHtml'] = (optionElem.innerText.trim() || '<span>&nbsp;</span>');
 
   if (optionElem.selected) {
     item['selected'] = true;


### PR DESCRIPTION
This updates the select, picker, select dropdown, and option list
dropdown components `&nbsp;` usage. With the changes to the
`updateHtml` method in PR 197 trying to call `updateHtml` with
just `&nbsp;` errors. This is because there are no HTML elements
in the nbsp string. To avoid this error the nbsp strings are now
wrapped in a span.

The previous usage of `updateHtml` seemed to work with the nbsp
string but was actually not working correctly. It seemed to work
because the select and picker elements it was checked on kept
their height with or without the nbsp. So the nbsp appeared to be
working correctly even though it wasn't actually being inserted
into the DOM (the `updateHtml` call was removing the content of
the elem when the nbsp string was passed to it). The errors from
PR 197 revealed this issue but it would have also become apparent
for elements that relied on the nbsp to give them height as well.

This also updates the picker setting its text elem to match the
implementation from the select. The select was previously updated
to in PR 191. This keeps the components consistent since their
logic is very similar and avoids the picker displaying the
string `"&nbsp;"` in its elem incorrectly.

See #191 and #197 

@kellyredding - Ready for review.