### PR TITLE
Don't set `undefined` data attrs

### DIFF
--- a/assets/js/romo/picker.js
+++ b/assets/js/romo/picker.js
@@ -173,17 +173,24 @@ RomoPicker.prototype._bindOptionListDropdown = function() {
 RomoPicker.prototype._buildOptionListDropdownElem = function() {
   var romoOptionListDropdownElem = Romo.elems('<div class="romo-picker romo-btn" tabindex="0"><span class="romo-picker-text"></span></div>')[0];
 
+  Romo.setData(romoOptionListDropdownElem, 'romo-dropdown-overflow-x',           'hidden');
+  Romo.setData(romoOptionListDropdownElem, 'romo-dropdown-width',                'elem');
   Romo.setData(romoOptionListDropdownElem, 'romo-option-list-focus-style-class', 'romo-picker-focus');
 
-  Romo.setData(romoOptionListDropdownElem, 'romo-dropdown-position',    Romo.data(this.elem, 'romo-picker-dropdown-position'));
-  Romo.setData(romoOptionListDropdownElem, 'romo-dropdown-style-class', Romo.data(this.elem, 'romo-picker-dropdown-style-class'));
-  Romo.setData(romoOptionListDropdownElem, 'romo-dropdown-min-height',  Romo.data(this.elem, 'romo-picker-dropdown-min-height'));
-  Romo.setData(romoOptionListDropdownElem, 'romo-dropdown-max-height',  Romo.data(this.elem, 'romo-picker-dropdown-max-height'));
-  Romo.setData(romoOptionListDropdownElem, 'romo-dropdown-height',      Romo.data(this.elem, 'romo-picker-dropdown-height'));
-  Romo.setData(romoOptionListDropdownElem, 'romo-dropdown-overflow-x',  'hidden');
-  Romo.setData(romoOptionListDropdownElem, 'romo-dropdown-width',       'elem');
-  if (Romo.data(romoOptionListDropdownElem, 'romo-dropdown-max-height') === undefined) {
-    Romo.setData(romoOptionListDropdownElem, 'romo-dropdown-max-height', 'detect');
+  if (Romo.data(this.elem, 'romo-picker-dropdown-position') !== undefined) {
+    Romo.setData(romoOptionListDropdownElem, 'romo-dropdown-position', Romo.data(this.elem, 'romo-picker-dropdown-position'));
+  }
+  if (Romo.data(this.elem, 'romo-picker-dropdown-style-class') !== undefined) {
+    Romo.setData(romoOptionListDropdownElem, 'romo-dropdown-style-class', Romo.data(this.elem, 'romo-picker-dropdown-style-class'));
+  }
+  if (Romo.data(this.elem, 'romo-picker-dropdown-min-height') !== undefined) {
+    Romo.setData(romoOptionListDropdownElem, 'romo-dropdown-min-height', Romo.data(this.elem, 'romo-picker-dropdown-min-height'));
+  }
+  if (Romo.data(this.elem, 'romo-picker-dropdown-max-height') !== undefined) {
+    Romo.setData(romoOptionListDropdownElem, 'romo-dropdown-max-height', Romo.data(this.elem, 'romo-picker-dropdown-max-height'));
+  }
+  if (Romo.data(this.elem, 'romo-picker-dropdown-height') !== undefined) {
+    Romo.setData(romoOptionListDropdownElem, 'romo-dropdown-height', Romo.data(this.elem, 'romo-picker-dropdown-height'));
   }
   if (Romo.data(this.elem, 'romo-picker-filter-placeholder') !== undefined) {
     Romo.setData(romoOptionListDropdownElem, 'romo-option-list-dropdown-filter-placeholder', Romo.data(this.elem, 'romo-picker-filter-placeholder'));
@@ -199,6 +206,10 @@ RomoPicker.prototype._buildOptionListDropdownElem = function() {
   }
   if (Romo.data(this.elem, 'romo-picker-open-on-focus') !== undefined) {
     Romo.setData(romoOptionListDropdownElem, 'romo-option-list-dropdown-open-on-focus', Romo.data(this.elem, 'romo-picker-open-on-focus'));
+  }
+
+  if (Romo.data(romoOptionListDropdownElem, 'romo-dropdown-max-height') === undefined) {
+    Romo.setData(romoOptionListDropdownElem, 'romo-dropdown-max-height', 'detect');
   }
 
   var classList = Romo.attr(this.elem, 'class') !== undefined ? Romo.attr(this.elem, 'class').split(/\s+/) : [];

--- a/assets/js/romo/select.js
+++ b/assets/js/romo/select.js
@@ -142,15 +142,23 @@ RomoSelect.prototype._bindSelectDropdown = function() {
 RomoSelect.prototype._buildSelectDropdownElem = function() {
   var romoSelectDropdownElem = Romo.elems('<div class="romo-select romo-btn" tabindex="0"><span class="romo-select-text"></span></div>')[0];
 
-  Romo.setData(romoSelectDropdownElem, 'romo-dropdown-position',    Romo.data(this.elem, 'romo-select-dropdown-position'));
-  Romo.setData(romoSelectDropdownElem, 'romo-dropdown-style-class', Romo.data(this.elem, 'romo-select-dropdown-style-class'));
-  Romo.setData(romoSelectDropdownElem, 'romo-dropdown-min-height',  Romo.data(this.elem, 'romo-select-dropdown-min-height'));
-  Romo.setData(romoSelectDropdownElem, 'romo-dropdown-max-height',  Romo.data(this.elem, 'romo-select-dropdown-max-height'));
-  Romo.setData(romoSelectDropdownElem, 'romo-dropdown-height',      Romo.data(this.elem, 'romo-select-dropdown-height'));
-  Romo.setData(romoSelectDropdownElem, 'romo-dropdown-overflow-x',  'hidden');
-  Romo.setData(romoSelectDropdownElem, 'romo-dropdown-width',       'elem');
-  if (Romo.data(romoSelectDropdownElem, 'romo-dropdown-max-height') === undefined) {
-    Romo.setData(romoSelectDropdownElem, 'romo-dropdown-max-height', 'detect');
+  Romo.setData(romoSelectDropdownElem, 'romo-dropdown-overflow-x', 'hidden');
+  Romo.setData(romoSelectDropdownElem, 'romo-dropdown-width',      'elem');
+
+  if (Romo.data(this.elem, 'romo-select-dropdown-position') !== undefined) {
+    Romo.setData(romoSelectDropdownElem, 'romo-dropdown-position', Romo.data(this.elem, 'romo-select-dropdown-position'));
+  }
+  if (Romo.data(this.elem, 'romo-select-dropdown-style-class') !== undefined) {
+    Romo.setData(romoSelectDropdownElem, 'romo-dropdown-style-class', Romo.data(this.elem, 'romo-select-dropdown-style-class'));
+  }
+  if (Romo.data(this.elem, 'romo-select-dropdown-min-height') !== undefined) {
+    Romo.setData(romoSelectDropdownElem, 'romo-dropdown-min-height',  Romo.data(this.elem, 'romo-select-dropdown-min-height'));
+  }
+  if (Romo.data(this.elem, 'romo-select-dropdown-max-height') !== undefined) {
+    Romo.setData(romoSelectDropdownElem, 'romo-dropdown-max-height',  Romo.data(this.elem, 'romo-select-dropdown-max-height'));
+  }
+  if (Romo.data(this.elem, 'romo-select-dropdown-height') !== undefined) {
+    Romo.setData(romoSelectDropdownElem, 'romo-dropdown-height', Romo.data(this.elem, 'romo-select-dropdown-height'));
   }
   if (Romo.data(this.elem, 'romo-select-filter-placeholder') !== undefined) {
     Romo.setData(romoSelectDropdownElem, 'romo-select-dropdown-filter-placeholder', Romo.data(this.elem, 'romo-select-filter-placeholder'));
@@ -172,6 +180,10 @@ RomoSelect.prototype._buildSelectDropdownElem = function() {
   }
   if (Romo.data(this.elem, 'romo-select-open-on-focus') !== undefined) {
     Romo.setData(romoSelectDropdownElem, 'romo-select-dropdown-open-on-focus', Romo.data(this.elem, 'romo-select-open-on-focus'));
+  }
+
+  if (Romo.data(romoSelectDropdownElem, 'romo-dropdown-max-height') === undefined) {
+    Romo.setData(romoSelectDropdownElem, 'romo-dropdown-max-height', 'detect');
   }
 
   var classList = Romo.attr(this.elem, 'class') !== undefined ? Romo.attr(this.elem, 'class').split(/\s+/) : [];


### PR DESCRIPTION
This updates the select and picker components to not write
`undefined` data attrs. This was noticed while investigating
issues with selects dropdowns. I noticed the element had a lot
of data attrs with `undefined` values. This was happening
because the select was writing some of its data attrs using
the values of other data attrs. If the other data attrs weren't
set their `data` method returned `undefined`. In everywhere
outside of the select and picker components we first check if
the data attr is undefined before trying to set another data
attr. This updates the select and picker components to follow
this pattern.

Note: This didn't seem to be causing any issues because the `data`
method is smart and properly deserializes the `undefined` value.
This change is still valueable because in the HTML it looks like
an issue and its inconsistent with the rest of Romo. There are
some edge cases that this could effect if the data attrs were
being used in selectors but based on the data attrs I don't think
this is likely.

@kellyredding - Ready for review. I was investigating this as a cause for the dropdown heights being incorrect but as the commit says I don't think this was causing any problems just noisy.