### PR TITLE
Fix using window height/width, use document elem client height/width

### DIFF
--- a/assets/js/romo/dropdown.js
+++ b/assets/js/romo/dropdown.js
@@ -429,8 +429,9 @@ RomoDropdown.prototype._getPopupMaxAvailableHeight = function(position) {
       maxHeight = elemTop - this._getPopupMaxHeightDetectPad(position);
       break;
     case 'bottom':
-      var elemBottom = this.elem.getBoundingClientRect().bottom;
-      maxHeight = window.innerHeight - elemBottom - this._getPopupMaxHeightDetectPad(position);
+      var viewportHeight = document.documentElement.clientHeight;
+      var elemBottom     = this.elem.getBoundingClientRect().bottom;
+      maxHeight = viewportHeight - elemBottom - this._getPopupMaxHeightDetectPad(position);
       break;
   }
 

--- a/assets/js/romo/modal.js
+++ b/assets/js/romo/modal.js
@@ -83,14 +83,16 @@ RomoModal.prototype.doPopupClose = function() {
 }
 
 RomoModal.prototype.doPlacePopupElem = function() {
-  var w          = this.popupElem.offsetWidth;
-  var h          = this.popupElem.offsetHeight;
-  var min        = 75;
-  var centerTop  = window.innerHeight / 2 - h / 2;
-  var centerLeft = window.innerWidth  / 2 - w / 2;
-  var css        = {};
+  var w              = this.popupElem.offsetWidth;
+  var h              = this.popupElem.offsetHeight;
+  var min            = 75;
+  var viewportHeight = document.documentElement.clientHeight;
+  var viewportWidth  = document.documentElement.clientWidth;
+  var centerTop      = viewportHeight / 2 - h / 2;
+  var centerLeft     = viewportWidth  / 2 - w / 2;
+  var css            = {};
 
-  css.top = window.innerHeight * 0.15;
+  css.top = viewportHeight * 0.15;
   if (centerTop < css.top) { css.top = centerTop; }
   if (css.top < min) { css.top = min; }
 
@@ -107,7 +109,7 @@ RomoModal.prototype.doPlacePopupElem = function() {
     var bodyBottom    = this.bodyElem.getBoundingClientRect().bottom;
     var padBottom     = bodyBottom - contentBottom;
 
-    var maxHeight = window.innerHeight - contentTop - padBottom - pad;
+    var maxHeight = viewportHeight - contentTop - padBottom - pad;
     Romo.setStyle(this.contentElem, 'max-height', maxHeight.toString() + 'px');
   }
 }

--- a/assets/js/romo/tooltip.js
+++ b/assets/js/romo/tooltip.js
@@ -313,8 +313,9 @@ RomoTooltip.prototype._getPopupMaxAvailableHeight = function(position) {
       maxHeight = elemTop - this._getPopupMaxHeightDetectPad(position);
       break;
     case 'bottom':
-      var elemBottom = this.elem.getBoundingClientRect().bottom;
-      maxHeight = window.innerHeight - elemBottom - this._getPopupMaxHeightDetectPad(position);
+      var viewportHeight = document.documentElement.clientHeight;
+      var elemBottom     = this.elem.getBoundingClientRect().bottom;
+      maxHeight = viewportHeight - elemBottom - this._getPopupMaxHeightDetectPad(position);
       break;
   }
 


### PR DESCRIPTION
This fixes dropdowns, modals, and tooltips detecting the correct
window height (and width for modals). This was noticed because
dropdowns were not being correctly sized to fit within the window
when they were taller than the viewport. This is a bug from
switching from `$(window).height` to `window.innerHeight` (same
for width). When making the change I believed these were
equivalent but jquery actually uses
`document.documentElement.clientHeight` for the windows height
(same for width). The document elem client height is aware of the
scroll bars and removes their height from its. This fixes the
dropdowns only growing to the page height and should also fix
modals and tooltips positioning and sizing (they haven't been
fully tested yet).

@kellyredding - Ready for review.