### PR TITLE
Fixes and cleanups related to modals

### DIFF
--- a/assets/js/romo/dropdown.js
+++ b/assets/js/romo/dropdown.js
@@ -282,10 +282,10 @@ RomoDropdown.prototype._bindBody = function() {
     this.contentElem = this.bodyElem;
   }
 
-  this.closeElem = Romo.find(this.popupElem, '[data-romo-dropdown-close="true"]')[0];
-  if (this.closeElem !== undefined) {
-    Romo.on(this.closeElem, 'click', Romo.proxy(this._onPopupClose, this));
-  }
+  this.closeElems = Romo.find(this.popupElem, '[data-romo-dropdown-close="true"]');
+  this.closeElems.forEach(Romo.proxy(function(closeElem) {
+    Romo.on(closeElem, 'click', Romo.proxy(this._onPopupClose, this));
+  }, this));
 
   Romo.setStyle(this.contentElem, 'min-height', Romo.data(this.elem, 'romo-dropdown-min-height'));
   Romo.setStyle(this.contentElem, 'height',     Romo.data(this.elem, 'romo-dropdown-height'));

--- a/assets/js/romo/modal_form.js
+++ b/assets/js/romo/modal_form.js
@@ -70,7 +70,7 @@ RomoModalForm.prototype._bindModal = function() {
   }, this));
 }
 
-RomoModalForm.prototype.doBindForm = function() {
+RomoModalForm.prototype._bindForm = function() {
   this.romoForm = undefined;
   var formElem = Romo.find(this.romoModal.popupElem, '[data-romo-form-auto="modalForm"]')[0];
 


### PR DESCRIPTION
This is a set of fixes and cleanups related to modals. These
were discovered while testing modals and modal forms, and getting
them working. This includes:

* Add missing `px` when setting the modal `top` and `left` styles
to place the modal. This was also done for dropdowns in PR 192 and
was similarly missed in modals when switching from jquery to
vanilla js.
* Update the logic to place the modal to be consistent with the
dropdown logic (PR 192). This avoids using a `css` object and
switches to separate local variables for determing the top and
left for the modal. Since we are no longer using the jquery
`offset` method which took an object there isn't any gain in
building a `css` object.
* Update the bind body logic to bind to multiple close and drag
elems. This was noticed because modals typically have both a
X for closing the modal and a close button. The same was done for
drag elems because there isn't really any negatives to supporting
multiple and we may want a modal with multiple drag elems in the
future.
* Update the dropdown close elem binding to match the modals. This
is to keep them consistent and as mentioned for the drag elems
there isn't really a negative to supporting multiple.
* Update modal and modal form private method names. The modal
mouse related event bindings were using the wrong method names
and the modal form's method for binding the form was incorrect.
This updates the modal form's method name to match the dropdown
form and the inline form method name.

See #192

@kellyredding - Ready for review.