### PR TITLE
Update `Romo.offset`, don't use `document.body`

### DIFF
--- a/assets/js/romo/base.js
+++ b/assets/js/romo/base.js
@@ -202,8 +202,8 @@ Romo.prototype.hide = function(elem) {
 Romo.prototype.offset = function(elem) {
   var rect = elem.getBoundingClientRect();
   return {
-    top:  rect.top  + document.body.scrollTop,
-    left: rect.left + document.body.scrollLeft
+    top:  rect.top  + window.pageYOffset,
+    left: rect.left + window.pageXOffset
   };
 }
 


### PR DESCRIPTION
This updates `Romo.offset` to not use `document.body` to get the
scroll top or scroll left. In the latest versions of browsers
this has been deprecated and always returns 0. This fixes errors
with positioning dropdowns, tooltips, modals, and other
components when the viewport is scrolled.

This switches to using `window.pageYOffset` and
`window.pageXOffset`. This would have used `scrollY` and
`scrollX` which seems to be the preferred method for getting this
data but these are not supported in IE 9. The offset methods
are aliases for the scroll methods in non IE 9 browsers so this
should work in all browsers. Here's the MDN articles for
`scrollY` and `pageYOffset`:

https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollY
https://developer.mozilla.org/en-US/docs/Web/API/Window/pageYOffset

@kellyredding - Ready for review.