### PR TITLE
Fix event binding for the same elem, event type, and function

### DIFF
--- a/assets/js/romo/base.js
+++ b/assets/js/romo/base.js
@@ -600,11 +600,12 @@ Romo.prototype.on = function(elem, eventName, fn) {
   }
   proxyFn._romofid = this._fn(fn)._romofid;
 
+  elem.addEventListener(eventName, proxyFn);
   var key = this._handlerKey(elem, eventName, proxyFn);
-  if (!this._handlers[key]) {
-    elem.addEventListener(eventName, proxyFn);
-    this._handlers[key] = proxyFn;
+  if (this._handlers[key] === undefined) {
+    this._handlers[key] = [];
   }
+  this._handlers[key].push(proxyFn);
 }
 
 Romo.prototype.off = function(elem, eventName, fn) {
@@ -617,12 +618,11 @@ Romo.prototype.off = function(elem, eventName, fn) {
     throw new Error('Can only unbind events on individual elems, not collections.');
   }
 
-  var key     = this._handlerKey(elem, eventName, fn);
-  var proxyFn = this._handlers[key];
-  if (proxyFn) {
+  var key = this._handlerKey(elem, eventName, fn);
+  (this._handlers[key] || []).forEach(function(proxyFn) {
     elem.removeEventListener(eventName, proxyFn);
-    this._handlers[key] = undefined;
-  }
+  });
+  this._handlers[key] = [];
 }
 
 Romo.prototype.trigger = function(elem, customEventName, args) {


### PR DESCRIPTION
This fixes event binding for the same elem, event type, and
function. This was noticed with dropdowns binding to the resize
event on the window elem. We previously assumed the dropdown
function `_onResizeWindow` was unique per instanace of the romo
dropdown component but this is not the case. So the old `on` and
`off` logic saw multiple dropdown components binding the resize
event to the window as the same and only actually bound the first
one. This caused only the first dropdown to resize and none of
the others would. This fixes it by storing multiple handlers per
key and adding or removing event handlers for each.

Note: This changes the `off` so that it will remove all of the
event handlers for the elem, event type, and function combination.
So in the above example when either dropdown calls `off` on the
window resize binding, it removes all of the dropdowns binding.
This is because there is no way to uniquely identify the function
per dropdown instance so we can't only remove the one event
handler. This was a limitation in jquery as well so it shouldn't
cause any unexpected issues.

@kellyredding - Ready for review.