### PR TITLE
Event propagation cleanups

### DIFF
--- a/assets/js/romo/dropdown.js
+++ b/assets/js/romo/dropdown.js
@@ -340,14 +340,14 @@ RomoDropdown.prototype._loadBodyError = function(xhr) {
 }
 
 RomoDropdown.prototype._onToggle = function(e) {
+  e.preventDefault();
+
   if (
     Romo.hasClass(this.elem, 'disabled') === false &&
     Romo.data(this.elem, 'romo-dropdown-disable-toggle') !== true
   ) {
     this.doToggle();
   }
-
-  return false;
 }
 
 RomoDropdown.prototype._onPopupOpen = function(e) {

--- a/assets/js/romo/indicator_text_input.js
+++ b/assets/js/romo/indicator_text_input.js
@@ -128,11 +128,12 @@ RomoIndicatorTextInput.prototype._placeIndicatorElem = function() {
 }
 
 RomoIndicatorTextInput.prototype._onIndicatorClick = function(e) {
+  e.preventDefault();
+
   if (this.elem.disabled === false) {
     this.elem.focus();
     Romo.trigger(this.elem, 'romoIndicatorTextInput:indicatorClick');
   }
-  return false;
 }
 
 // private

--- a/assets/js/romo/modal.js
+++ b/assets/js/romo/modal.js
@@ -275,10 +275,11 @@ RomoModal.prototype._loadBodyError = function(xhr) {
 }
 
 RomoModal.prototype._onToggle = function(e) {
+  e.preventDefault();
+
   if (Romo.hasClass(this.elem, 'disabled') === false) {
     this.doToggle();
   }
-  return false;
 }
 
 RomoModal.prototype._onPopupOpen = function(e) {

--- a/assets/js/romo/tooltip.js
+++ b/assets/js/romo/tooltip.js
@@ -313,6 +313,7 @@ RomoTooltip.prototype._onSetContent = function(e, value) {
 
 RomoTooltip.prototype._onResizeWindow = function(e) {
   this.doPlacePopupElem();
+  return true;
 }
 
 RomoTooltip.prototype._getPopupMaxAvailableHeight = function(position) {


### PR DESCRIPTION
This is a small set of event propagation cleanups that were
noticed while stress testing romo components. This is part of
the effort to switch from jquery to vanilla js.

This updates dropdown and modal components to only prevent the
default for their `_onToggle` event handlers and not stop
propagation. This allows launching a dropdown to close a modal
and vice versa (only if the dropdown is not on the modal). These
were previously stopping propagation which would open the
modal/dropdown but it wouldn't close the other dropdown/modal.
These were incorrectly updated in PR 163 and 165 when updating
the dropdown and modal components to modern conventions so this
fixes the updates from those commits.

This also updates the indicator text input to allow clicking its
indicator to propagate. This is an edge case so if a dropdown or
modal is open and the indicator is clicked it will still
propagate the event and close modals/dropdowns or whatever other
behavior is needed.

Finally, this updates the tooltip `_onResizeWindow` to return
true because the dropdown and modal versions of this function
do. This keeps them all consistent.

See #163 and #165

@kellyredding - Ready for review.