### PR TITLE
Update dropdowns, modals, and tooltips to use `setTimeout` to place popup

### DIFF
--- a/assets/js/romo/dropdown.js
+++ b/assets/js/romo/dropdown.js
@@ -324,14 +324,14 @@ RomoDropdown.prototype._resetBody = function() {
 RomoDropdown.prototype._loadBodyStart = function() {
   Romo.updateHtml(this.bodyElem, '');
   this._bindBody();
-  this.doPlacePopupElem();
+  setTimeout(Romo.proxy(this.doPlacePopupElem, this), 1);
   Romo.trigger(this.elem, 'romoDropdown:loadBodyStart', [this]);
 }
 
 RomoDropdown.prototype._loadBodySuccess = function(data) {
   Romo.initUpdateHtml(this.bodyElem, data);
   this._bindBody();
-  this.doPlacePopupElem();
+  setTimeout(Romo.proxy(this.doPlacePopupElem, this), 1);
   Romo.trigger(this.elem, 'romoDropdown:loadBodySuccess', [data, this]);
 }
 

--- a/assets/js/romo/modal.js
+++ b/assets/js/romo/modal.js
@@ -259,14 +259,14 @@ RomoModal.prototype._resetBody = function() {
 RomoModal.prototype._loadBodyStart = function() {
   Romo.updateHtml(this.bodyElem, '');
   this._bindBody();
-  this.doPlacePopupElem();
+  setTimeout(Romo.proxy(this.doPlacePopupElem, this), 1);
   Romo.trigger(this.elem, 'romoModal:loadBodyStart', [this]);
 }
 
 RomoModal.prototype._loadBodySuccess = function(data) {
   Romo.initUpdateHtml(this.bodyElem, data);
   this._bindBody();
-  this.doPlacePopupElem();
+  setTimeout(Romo.proxy(this.doPlacePopupElem, this), 1);
   Romo.trigger(this.elem, 'romoModal:loadBodySuccess', [data, this]);
 }
 

--- a/assets/js/romo/tooltip.js
+++ b/assets/js/romo/tooltip.js
@@ -126,7 +126,7 @@ RomoTooltip.prototype.doPlacePopupElem = function() {
 RomoTooltip.prototype.doSetContent = function(value) {
   Romo.setData(this.elem, 'romo-tooltip-content', value);
   this._setBodyHtml(Romo.data(this.elem, 'romo-tooltip-content'));
-  this.doPlacePopupElem();
+  setTimeout(Romo.proxy(this.doPlacePopupElem, this), 1);
 }
 
 RomoTooltip.prototype.doSetPopupZIndex = function(relativeElem) {
@@ -250,14 +250,14 @@ RomoTooltip.prototype._resetBody = function() {
 RomoTooltip.prototype._loadBodyStart = function() {
   this._setBodyHtml('');
   this._bindBody();
-  this.doPlacePopupElem();
+  setTimeout(Romo.proxy(this.doPlacePopupElem, this), 1);
   Romo.trigger(this.elem, 'romoTooltip:loadBodyStart', [this]);
 }
 
 RomoTooltip.prototype._loadBodySuccess = function(data) {
   Romo.initUpdateHtml(this.bodyElem, data);
   this._bindBody();
-  this.doPlacePopupElem();
+  setTimeout(Romo.proxy(this.doPlacePopupElem, this), 1);
   Romo.trigger(this.elem, 'romoTooltip:loadBodySuccess', [data, this]);
 }
 


### PR DESCRIPTION
This updates dropdowns, modals, and tooltips to use `setTimeout`
to place their popups. This fixes issues with the components
calculating their height/width appropriately when their content
is updated with components like pickers and selects. Both of these
change their HTML which causes their height to change. This in
turn causes the outer components height to change as well so
previous calculations may no longer be correct. By moving the
components into a `setTimeout` this allows the other components
time to adjust their HTML before placing the popup elem.

Note: This wasn't done on the popup open or resize event handler
for the components because it caused the dropdowns, modals, and
tooltips to have minor display issues. When the popup was opened
sometimes there would be a quick flash of the popup positioned
incorrectly. When resizing the animation wasn't smooth and it
would jitter as it adjusted its position based on the new window
size. This limits using the `setTimeout` to when the content of
the popup might change thus causing its height or width to
change.

@kellyredding - Ready for review.