### PR TITLE
Fix parsing z-index from parent elems

### DIFF
--- a/assets/js/romo/base.js
+++ b/assets/js/romo/base.js
@@ -239,15 +239,15 @@ Romo.prototype.parseZIndex = function(elem) {
   }
 
   // for the case where z-index is inherited from a parent elem
+  var pval = 0;
   var parentIndexes = Romo.parents(elem).forEach(Romo.proxy(function(parentElem) {
-    var pval = this.parseElemZIndex(parentElem);
-    if (pval !== 0) {
-      return pval;
+    if (pval === 0) {
+      pval = this.parseElemZIndex(parentElem);
     }
   }, this));
 
   // z-index is 'auto' all the way up
-  return 0;
+  return pval;
 }
 
 Romo.prototype.parseElemZIndex = function(elem) {


### PR DESCRIPTION
This fixes parsing z-index values from parent elems. This was
noticed while testing a datepicker on a modal. The datepicker
wasn't properly parsing its parent modals z-index so its dropdown
was appearing behind the modal. This fixes the parent z-index
parsing by having it properly short-circuit the loop. Previously
we were using return which in javascript only returns out of the
loop and not out of the function as a whole. Now the function
checks if it has a non zero z-index value and if so it stops
parsing parent elems z-index values and returns the non-zero
parent z-index.

@kellyredding - Ready for review.