### PR TITLE
Fix `Romo.elems` working for tr, th, td, and other table related tags

### DIFF
--- a/assets/js/romo/base.js
+++ b/assets/js/romo/base.js
@@ -270,7 +270,24 @@ Romo.prototype.elems = function(htmlString) {
   context.head.appendChild(base);
 
   context.body.innerHTML = htmlString;
-  return this.array(context.body.children);
+  if (context.body.children.length !== 0) {
+    return this.array(context.body.children);
+  } else {
+    var results = Romo._elemsTagNameRegEx.exec(htmlString);
+    if (!results){ return []; }
+
+    var tagName = results[1].toLowerCase();
+    var wrap    = Romo._elemsWrapMap[tagName];
+    if (!wrap){ return []; }
+
+    context.body.innerHTML = wrap[1] + htmlString + wrap[2];
+    var parentElem = context.body;
+    var i = wrap[0];
+    while(i-- !== 0) {
+      parentElem = parentElem.lastChild;
+    }
+    return this.array(parentElem.children)
+  }
 }
 
 Romo.prototype.remove = function(elem) {
@@ -817,6 +834,20 @@ Romo.prototype._deserializeValue = function(value) {
 Romo.prototype._addEventCallback = function(name, callback) {
   this._eventCallbacks.push({ eventName: name, callback:  callback });
 }
+
+Romo.prototype._elemsTagNameRegEx = /<([a-z][^\/\0>\x20\t\r\n\f]+)/i;
+
+Romo.prototype._elemsWrapMap = {
+  'caption':  [1, "<table>",            "</table>"],
+  'colgroup': [1, "<table>",            "</table>"],
+  'col':      [2, "<table><colgroup>",  "</colgroup></table>"],
+  'thead':    [1, "<table>",            "</table>"],
+  'tbody':    [1, "<table>",            "</table>"],
+  'tfoot':    [1, "<table>",            "</table>"],
+  'tr':       [2, "<table><tbody>",     "</tbody></table>"],
+  'th':       [3, "<table><tbody><tr>", "</tr></tbody></table>"],
+  'td':       [3, "<table><tbody><tr>", "</tr></tbody></table>"]
+};
 
 // RomoParentChildElems
 


### PR DESCRIPTION
This updates the `Romo.elems` logic to handle table related tags.
Previously, when passing HTML for a tr, th, td, and other table
related tags the `elems` helper would return an empty array. This
is because the trick of setting the HTML on the body of a new
document wouldn't actually add the HTML. The browsers won't allow
adding "invalid" HTML fragments and simply ignore the request. The
table related tags are invalid because they are not within a
`<table>` elem. This was noticed with the datepicker component
because they try to build a table for their calendars and build
the individual cells and rows before adding them all to the
table.

This fixes the issue by borrowing logic from jquery for properly
wrapping these HTML fragments within their correct tags. This
allows the content to be added and then read back out as we were
previously doing. The `elems` helper now tries to add the HTML
straight to the body and read it off and if it can't find any
HTML it then tries wrapping the content. If the helper can't find
a tag in the HTML string or if the tag isn't a known tag that
needs to be wrapped an empty array is returned because we know
adding the HTML to the body and reading it off already couldn't
find any HTML elements. If a tag can be found and we have an
entry for it in the wrap configuration then the wrap HTML is
used with the HTML string and written to the body. The helper
then descends through the wrap HTML elements to get to the HTML
string elements and returns them.

@kellyredding - Ready for review.