### PR TITLE
update `{add|remove|toggle}Class` methods to take space-separated list

### DIFF
--- a/assets/js/romo/base.js
+++ b/assets/js/romo/base.js
@@ -173,17 +173,23 @@ Romo.prototype.css = function(elem, styleName) {
 }
 
 Romo.prototype.addClass = function(elem, className) {
-  elem.classList.add(className);
+  className.split(' ').filter(function(n){ return n; }).forEach(function(name) {
+    elem.classList.add(name);
+  });
   return className;
 }
 
 Romo.prototype.removeClass = function(elem, className) {
-  elem.classList.remove(className);
+  className.split(' ').filter(function(n){ return n; }).forEach(function(name) {
+    elem.classList.remove(name);
+  });
   return className;
 }
 
 Romo.prototype.toggleClass = function(elem, className) {
-  elem.classList.toggle(className);
+  className.split(' ').filter(function(n){ return n; }).forEach(function(name) {
+    elem.classList.toggle(name);
+  });
   return className;
 }
 


### PR DESCRIPTION
This is a convenience so you can add/remove/toggle multiple classes
with a single call: `elem.addClass('class1 class2');`.  This is
required by the dropdown, modal, and tooltip components with their
`-style-class` data attr settings.  If a user wants to set many
classes using that single data attr, there isn't a way unless the
"*Class" methods take space separated class names.

Note: I had to filter the "falsy" results after splitting to
cover the case where multiple spaces exist between class names.
Using falsy gets the empty strings the split would produce.
I also only chose to not add this behavior to the `hasClass`
method b/c it is unclear whether has class should check wheter
all or any of the classes exists.  Due to this ambiguity, I
thought it better to not support space separated classes for that
method.

@jcredding ready for review.