### PR TITLE
update how dropdown and tooltip popups are placed in modals

### DIFF
--- a/assets/js/romo/base.js
+++ b/assets/js/romo/base.js
@@ -206,10 +206,11 @@ Romo.prototype.hide = function(elem) {
 }
 
 Romo.prototype.offset = function(elem) {
-  var rect = elem.getBoundingClientRect();
+  var elemRect = elem.getBoundingClientRect();
+  var bodyRect = document.body.getBoundingClientRect();
   return {
-    top:  rect.top  + window.pageYOffset,
-    left: rect.left + window.pageXOffset
+    top:  elemRect.top  - bodyRect.top,
+    left: elemRect.left - bodyRect.left
   };
 }
 

--- a/assets/js/romo/dropdown.js
+++ b/assets/js/romo/dropdown.js
@@ -82,15 +82,18 @@ RomoDropdown.prototype.doPopupClose = function() {
 }
 
 RomoDropdown.prototype.doPlacePopupElem = function() {
+  var elemRect   = this.elem.getBoundingClientRect();
+  var elemOffset = undefined;
+
   if (Romo.parents(this.elem, '.romo-modal-popup').length !== 0) {
     Romo.setStyle(this.popupElem, 'position', 'fixed');
+    elemOffset = elemRect;
+  } else {
+    elemOffset = Romo.offset(this.elem);
   }
 
-  var elemRect   = this.elem.getBoundingClientRect();
   var elemHeight = elemRect.height;
   var elemWidth  = elemRect.width;
-
-  var elemOffset = Romo.offset(this.elem);
   var elemTop    = elemOffset.top;
   var elemLeft   = elemOffset.left
 
@@ -119,38 +122,38 @@ RomoDropdown.prototype.doPlacePopupElem = function() {
 
     // remove any height difference between the popup and content elems
     // assumes popup height always greater than or equal to content height
-    configHeight = configHeight - (popupOffsetHeight - this.contentElem.offsetHeight);
-    Romo.setStyle(this.contentElem, 'max-height', configHeight.toString() + 'px');
+    var contentMaxHeight = configHeight - (popupOffsetHeight - this.contentElem.offsetHeight);
+    Romo.setStyle(this.contentElem, 'max-height', contentMaxHeight.toString() + 'px');
   }
 
   if(popupOffsetHeight > configHeight) {
     popupOffsetHeight = configHeight;
   }
 
-  var offsetTop = undefined;
+  var posTop = undefined;
   switch (configPosition) {
     case 'top':
       var pad = 2;
-      offsetTop = elemTop - popupOffsetHeight - pad;
+      posTop = elemTop - popupOffsetHeight - pad;
       break;
     case 'bottom':
       var pad = 2;
-      offsetTop = elemTop + elemHeight + pad;
+      posTop = elemTop + elemHeight + pad;
       break;
   }
 
-  var offsetLeft = undefined;
+  var posLeft = undefined;
   switch (this.popupAlignment) {
     case 'left':
-      offsetLeft = elemLeft;
+      posLeft = elemLeft;
       break;
     case 'right':
-      offsetLeft = elemLeft + elemWidth - popupOffsetWidth;
+      posLeft = elemLeft + elemWidth - popupOffsetWidth;
       break;
   }
 
-  Romo.setStyle(this.popupElem, 'top',  this._roundPosOffsetVal(offsetTop)+'px');
-  Romo.setStyle(this.popupElem, 'left', this._roundPosOffsetVal(offsetLeft)+'px');
+  Romo.setStyle(this.popupElem, 'top',  this._roundPosOffsetVal(posTop)+'px');
+  Romo.setStyle(this.popupElem, 'left', this._roundPosOffsetVal(posLeft)+'px');
 }
 
 RomoDropdown.prototype.doSetPopupZIndex = function(relativeElem) {

--- a/assets/js/romo/tooltip.js
+++ b/assets/js/romo/tooltip.js
@@ -52,15 +52,18 @@ RomoTooltip.prototype.doPopupClose = function() {
 }
 
 RomoTooltip.prototype.doPlacePopupElem = function() {
+  var elemRect   = this.elem.getBoundingClientRect();
+  var elemOffset = undefined;
+
   if (Romo.parents(this.elem, '.romo-modal-popup').length !== 0) {
     Romo.setStyle(this.popupElem, 'position', 'fixed');
+    elemOffset = elemRect;
+  } else {
+    elemOffset = Romo.offset(this.elem);
   }
 
-  var elemRect   = this.elem.getBoundingClientRect();
   var elemHeight = elemRect.height;
   var elemWidth  = elemRect.width;
-
-  var elemOffset = Romo.offset(this.elem);
   var elemTop    = elemOffset.top;
   var elemLeft   = elemOffset.left
 
@@ -98,29 +101,29 @@ RomoTooltip.prototype.doPlacePopupElem = function() {
     popupOffsetHeight = configHeight;
   }
 
-  var offsetTop  = undefined;
-  var offsetLeft = undefined;
+  var posTop  = undefined;
+  var posLeft = undefined;
   switch (configPosition) {
     case 'top':
-      offsetTop  = elemTop - popupOffsetHeight - pad;
-      offsetLeft = elemLeft + (elemWidth / 2) - (popupOffsetWidth / 2);
+      posTop  = elemTop - popupOffsetHeight - pad;
+      posLeft = elemLeft + (elemWidth / 2) - (popupOffsetWidth / 2);
       break;
     case 'bottom':
-      offsetTop  = elemTop + elemHeight + pad;
-      offsetLeft = elemLeft + (elemWidth / 2) - (popupOffsetWidth / 2);
+      posTop  = elemTop + elemHeight + pad;
+      posLeft = elemLeft + (elemWidth / 2) - (popupOffsetWidth / 2);
       break;
     case 'left':
-      offsetTop  = elemTop + (elemHeight / 2) - (popupOffsetHeight / 2);
-      offsetLeft = elemLeft - popupOffsetWidth - pad;
+      posTop  = elemTop + (elemHeight / 2) - (popupOffsetHeight / 2);
+      posLeft = elemLeft - popupOffsetWidth - pad;
       break;
     case 'right':
-      offsetTop  = elemTop + (elemHeight / 2) - (popupOffsetHeight / 2);
-      offsetLeft = elemLeft + elemWidth + pad;
+      posTop  = elemTop + (elemHeight / 2) - (popupOffsetHeight / 2);
+      posLeft = elemLeft + elemWidth + pad;
       break;
   }
 
-  Romo.setStyle(this.popupElem, 'top',  offsetTop + 'px');
-  Romo.setStyle(this.popupElem, 'left', offsetLeft + 'px');
+  Romo.setStyle(this.popupElem, 'top',  posTop + 'px');
+  Romo.setStyle(this.popupElem, 'left', posLeft + 'px');
 }
 
 RomoTooltip.prototype.doSetContent = function(value) {


### PR DESCRIPTION
This fixes an issue with placing dropdown/tooltip popups nested in
modals.  Previously, the elem's offset was always used to place
the popup.  The offset, according to jQuery's docs, is "the
current coordinates of the element relative to the document". This
works for dropdowns that are positioned in the document's flow
and move as the document is scrolled.  However, if the dropdown
is placed in a fixed position elem, such as a modal popup, these
coordinates aren't useful b/c the dropdown isn't moving as the
document is scrolled.  In these cases, we need to just use the
elem's bounding rectangle coordinates, which are relative to the
viewport.  All of this is similarly true for the tooltip popup.

This updates the code to, in addition to setting the a fixed
position, use the elem rectangle in place of the offset for the
popup positioning logic.  This causes the dropdown/tooltip popups
to position correctly in modals.

In addtions, this fixes a bug in calculating the max content
height in the dropdowns.  Instead of overriding the config height
for this calculation, I switched to using a dedicated max height
var that uses the config height but doesn't mutate it.  This was
a bug in the jQuery version as well and was causing the popups
to not detect and move to the top of the elem when available
height was present.  It worked when the popup height and content
height were the same.  However, selects now have a filter that
makes the content height less than the popup height.  Changing
the config height, which is based on the popup height, to suite
the content height breaks this case b/c the content and popup
heights aren't equal.

Finally, this does a couple other tweaks:

* I updated the offset top/left vars in the place popup functions
  of dropdown/tooltip to be named "pos top/left".  I think this
  name is more accurate as these values are used to do the
  positioning and the values aren't always based off the offset
  anymore.
* I changed the implementation of the base `offset` method to
  line up with the "relative to the document" definition better.
  This takes the rectangle of the elem and subtracts off the
  rectangle of the document body.  This gets a position relactive
  to the document and doesn't rely on the page offset window
  variable which are marginally supported in older browsers.
  Mostly I like how this implementation lines up with the method
  definition though.

@jcredding ready for review.