### PR TITLE
selects: update to handle zero options

### DIFF
--- a/assets/js/romo/select.js
+++ b/assets/js/romo/select.js
@@ -272,7 +272,10 @@ RomoSelect.prototype._elemValues = function() {
   var selectedOptElems = Romo.find(this.elem, 'OPTION[selected]');
   if (selectedOptElems.length === 0 && this.romoSelectedOptionsList === undefined) {
     // if a non-multi select has no selected options, treat the first option as selected
-    selectedOptElems = [Romo.find(this.elem, 'OPTION')[0]];
+    var firstOptElem = Romo.find(this.elem, 'OPTION')[0];
+    if (firstOptElem !== undefined) {
+      selectedOptElems = [firstOptElem];
+    }
   }
   return selectedOptElems.map(function(selectedOptElem) {
     return (Romo.attr(selectedOptElem, 'value') || '');
@@ -280,13 +283,14 @@ RomoSelect.prototype._elemValues = function() {
 }
 
 RomoSelect.prototype._refreshUI = function() {
-  var text = undefined;
+  var text = '';
   if (this.romoSelectedOptionsList !== undefined) {
-    text = '';
     this.romoSelectedOptionsList.doRefreshUI();
-  } else {
+  } else if (this._elemValues().length !== 0) {
     var optionElem = Romo.find(this.elem, 'OPTION[value="'+this._elemValues()[0]+'"]')[0];
-    text = optionElem.innerText.trim();
+    if (optionElem !== undefined) {
+      text = optionElem.innerText.trim();
+    }
   }
 
   var textElem = Romo.find(this.romoSelectDropdown.elem, '.romo-select-text')[0];


### PR DESCRIPTION
This updates the elem values logic to only fall back to selecting
the first option as the selected if there is at least one option.
This was erroring on selects with no options in their markup.

This also updates the refresh ui logic to only grab the inner text
of the selected option if their is an option elem selected.  This
was missed when we originally converted this logic from the jQuery
version.

@jcredding ready for review.