### PR TITLE
base: update `array` to work with select elems

### DIFF
--- a/assets/js/romo/base.js
+++ b/assets/js/romo/base.js
@@ -700,9 +700,11 @@ Romo.prototype.array = function(value) {
     typeof(object)          === 'function' &&
     typeof(object.nodeType) !== 'number'
   );
+  var isSelect = (object.nodeName && object.nodeName.toLowerCase() === 'select');
   var likeArray = (
     typeof(object) !== 'string' &&
     !isFunction                 &&
+    !isSelect                   &&
     object !== window           &&
     ( Array.isArray(object) ||
       length === 0          ||


### PR DESCRIPTION
Select elems, it turns out, are "array like" in that they have a
length attr.  This caused them to return an array of their options
when passed to the prev `array` implementation.

This updates the logic to specifically test for select elems and
handle them much like functions are specifically tested for.  I
think these are the only elems that are "array like".

@jcredding ready for review.  Are you cool with me just adding a hard check for selects like this?  Are you cool with the check implementation?