### PR TITLE
Remove `setTimeout` when auto init components, init first

### DIFF
--- a/assets/js/romo/base.js
+++ b/assets/js/romo/base.js
@@ -452,9 +452,7 @@ Romo.prototype.onInitUI = function(fn) {
 Romo.prototype.triggerInitUI = function(onElems) {
   Romo.array(onElems).forEach(Romo.proxy(function(elem) {
     this._initUICallbacks.forEach(function(fn) {
-      setTimeout(function() {
-        fn(elem);
-      }, 1);
+      fn(elem);
     });
   }, this));
 


### PR DESCRIPTION
This updates the `triggerInitUI` logic to no longer init
components in a `setTimeout`. This is to fix an issue with
components not initializing before javascript from `Romo.ready`.
Javascript in a `Romo.ready` function was running expecting
components were initialized and ready but they weren't. This is
because by using `setTimeout` all of the component init was
pushed on the reactor loop after any of the already added
`Romo.ready` functions. This removes the `setTimeout` call so
the components are initialized and available.

@kellyredding - Ready for review.