### PR TITLE
Fix spinner resetting HTML when stopped

### DIFF
--- a/assets/js/romo/spinner.js
+++ b/assets/js/romo/spinner.js
@@ -60,7 +60,7 @@ RomoSpinner.prototype.doStop = function() {
     this.spinner = undefined;
   }
   if (this.elemHtml !== undefined) {
-    Romo.updateHtml(this.elem, this.elemHtml);
+    this.elem.innerHTML = this.elemHtml;
   }
   Romo.rmStyle(this.elem, 'position');
   Romo.rmStyle(this.elem, 'width');


### PR DESCRIPTION
This fixes spinners resetting their HTML when they are stopped.
They were previously using `updateHtml` but many times the
content they had replaced was simply the text of a button or an
nbsp. When this would happen `updateHtml` would error saying it
wasn't valid HTML. This avoids trying to detect if the content it
replaced is HTML and instead switches to writing `innerHTML` which
allows passing text, nbsp, or HTML.

@kellyredding - Ready for review.