### PR TITLE
Update `Romo.ajax` and `Form` to handle additional scenarios

### DIFF
--- a/assets/js/romo/form.js
+++ b/assets/js/romo/form.js
@@ -141,10 +141,10 @@ RomoForm.prototype._browserSubmit = function() {
 }
 
 RomoForm.prototype._nonBrowserGetSubmit = function() {
-  var formData = this._getFormData(this._getFormValues({ includeFiles: false }));
+  var formValues = this._getFormValues({ includeFiles: false });
 
   if (Romo.data(this.elem, 'romo-form-redirect-page') === true) {
-    var paramString = Romo.param(formData, {
+    var paramString = Romo.param(formValues, {
       removeEmpty:  this.removeEmptyGetParams,
       decodeValues: this.decodeParams
     });
@@ -154,21 +154,21 @@ RomoForm.prototype._nonBrowserGetSubmit = function() {
       Romo.redirectPage(Romo.attr(this.elem, 'action'));
     }
   } else {
-    this._ajaxSubmit(formData);
+    this._ajaxSubmit(formValues);
   }
 }
 
 RomoForm.prototype._nonBrowserNonGetSubmit = function() {
-  var formData = this._getFormData(this._getFormValues({ includeFiles: true }));
+  var formValues = this._getFormValues({ includeFiles: true });
 
-  this._ajaxSubmit(formData);
+  this._ajaxSubmit(formValues);
 }
 
-RomoForm.prototype._ajaxSubmit = function(formData) {
+RomoForm.prototype._ajaxSubmit = function(formValues) {
   Romo.ajax({
     url:     Romo.attr(this.elem, 'action'),
     type:    Romo.attr(this.elem, 'method'),
-    data:    formData,
+    data:    formValues,
     success: Romo.proxy(this._onSubmitSuccess, this),
     error:   Romo.proxy(this._onSubmitError,   this)
   });
@@ -216,15 +216,6 @@ RomoForm.prototype._completeSubmit = function() {
   } else {
     this.submitRunning = false;
   }
-}
-
-RomoForm.prototype._getFormData = function(formValues) {
-  var formData = new FormData;
-  for (var name in formValues) {
-    formValues[name].forEach(function(value){ formData.append(name, value) });
-  }
-
-  return formData;
 }
 
 RomoForm.prototype._getFormValues = function(opts) {
@@ -275,7 +266,7 @@ RomoForm.prototype._getFormValues = function(opts) {
   var listDelims = Romo.find(this.elem, '[data-romo-form-list-values="true"]').reduce(
     function(delims, inputElem) {
       delims[Romo.attr(inputElem, 'name')] = (
-        Romo.data(currElem, 'romo-form-list-values-delim') ||
+        Romo.data(inputElem, 'romo-form-list-values-delim') ||
         this.defaultListValuesDelim
       );
       return delims;
@@ -285,6 +276,13 @@ RomoForm.prototype._getFormValues = function(opts) {
   for (var name in listDelims) {
     if (formValues[name]) {
       formValues[name] = [formValues[name].join(listDelims[name])];
+    }
+  }
+
+  // remove the array from any single item array values
+  for(var key in formValues) {
+    if (formValues[key].length === 1) {
+      formValues[key] = formValues[key][0]
     }
   }
 


### PR DESCRIPTION
This updates the `Romo.ajax` helper and the `Form` component to
handle additional scenarios. These were noticed while testing
the components.

For the `Romo.ajax` helper this updates it to always expect an
object as the data passed to it. This was previously the case
for `GET` requests because they passed the data to `Romo.param`
which only accepts key-value objects. This now updates non GET
requests to do similar logic by expecting to iterate over the
data and build a `FormData`. This fixes issues with non GET
calls that were passing key-value objects. The previous logic was
ignoring the key-value objects because the xhr `send` only accepts
specific classes. Note: The logic for building `FormData` was
pulled from the `Form` component.

This also fixes `Romo.ajax` calls that don't include a success
or error callback. This adds checks to make sure they are present
before trying to call them.

For the `Form` component this fixes issues with its non browser
`GET` submits trying to build params from a `FormData`. This
was erroring because `Romo.param` expects key-value objects and
errors when passed a `FormData`. This updates it to simply build
the form values and pass those onto the `Romo.param` helper.

This also updates the `Form` component to work with the
`Romo.ajax` expecting a key-value object by no longer passing it
`FormData`. The `Form` component no longer builds form data and
instead simply passes the form values return value. The form
values logic now also changes any keys whose values are single
item arrays to remove the array and just use the single item that
was in the array. This was causing servers to interpret the params
as arrays which caused server logic to not work as expected
because the params should have been non array values.

@kellyredding - Ready for review.