### PR TITLE
base: update `find` to optionally take a list of parent elems

### DIFF
--- a/assets/js/romo/base.js
+++ b/assets/js/romo/base.js
@@ -14,8 +14,13 @@ Romo.prototype.f = function(selector) {
   return this.array(document.querySelectorAll(selector));
 }
 
-Romo.prototype.find = function(parentElem, selector) {
-  return this.array(parentElem.querySelectorAll(selector));
+Romo.prototype.find = function(parentElems, selector) {
+  return this.array(parentElems).reduce(
+    Romo.proxy(function(foundElems, parentElem) {
+      return foundElems.concat(this.array(parentElem.querySelectorAll(selector)));
+    }, this),
+    []
+  );
 }
 
 Romo.prototype.is = function(elem, selector) {


### PR DESCRIPTION
In this case it would find all elems under each parent elem in the
list.  This makes it more like jQuery's api and also eliminates
this need to manually iterate over each parent elem and redo that
same logic for each parent's elems.

This is part of updating certain base api methods to optionally
take and work with a list of given elems.  We are doing this to
not only make the api more friendly to work with, but also to make
common operations on sets of elems more performant.

@jcredding ready for review.