### PR TITLE
Update `Romo.array`, short circuit if passed a `Node`

### DIFF
--- a/assets/js/romo/base.js
+++ b/assets/js/romo/base.js
@@ -699,6 +699,13 @@ Romo.prototype.array = function(value) {
     return Array.prototype.slice.call(value)
   }
 
+  // short circuit for passing elems, this ensures these remain fast and avoids
+  // running into the is like an array logic; this fixes issues with select and
+  // form elements being like an array and returning unexpected results
+  if (typeof(value.nodeType) === 'number') {
+    return [value];
+  }
+
   var object = Object(value)
   var length = undefined;
   if (!!object && 'length' in object) {
@@ -710,11 +717,9 @@ Romo.prototype.array = function(value) {
     typeof(object)          === 'function' &&
     typeof(object.nodeType) !== 'number'
   );
-  var isSelect = (object.nodeName && object.nodeName.toLowerCase() === 'select');
   var likeArray = (
     typeof(value) !== 'string' &&
     !isFunction                &&
-    !isSelect                  &&
     object !== window          &&
     ( Array.isArray(object) ||
       length === 0          ||


### PR DESCRIPTION
This updates the `Romo.array` logic to short circuit if passed a
`Node` object. This is in preparation for making more of Romo's
helpers allow collections to be passed to them and also fixes
issues with trying to pass elements to `Romo.array`.

First, this is in preparation for some of Romo's helpers using
`Romo.array` on the elem that is passed to them and then iterating
over the array. This is being done to make the helpers more useful
and avoid noisy `forEach` calls.

Second, this fixes edge case issues with some elements being
array like and returning unexpected results. This was addressed
for select elements in PR 217 but is also an issue for form
elements. For selects they were returning an array of their
option elements and forms would return an array of their input
elements. This fixes the issue by checking if an object is a
`Node` which is the superclass of all elements and if so returning
a single item array that contains the element. This also removes
the check for select elements from PR 217 as it's no longer
needed.

See #217

@kellyredding - Ready for review.