### PR TITLE
Update `Romo.remove` to take multiple elems

### DIFF
--- a/assets/js/romo/base.js
+++ b/assets/js/romo/base.js
@@ -340,7 +340,9 @@ Romo.prototype.initElemsHtml = function(htmlString) {
 // DOM manipulation
 
 Romo.prototype.remove = function(elem) {
-  return elem.parentNode.removeChild(elem);
+  return Romo.array(elems).map(function(elem) {
+    return elem.parentNode.removeChild(elem);
+  });
 }
 
 Romo.prototype.replace = function(elem, replacementElem) {


### PR DESCRIPTION
This updates the `Romo.remove` helper to take multiple elems. This
is part of an effort to make the helpers more conveninent when
dealing with collections of elems and avoid having extra noisy
`forEach` loops. This will allow passing a single elem or multiple
elems and remove them from the DOM.

@kellyredding - Ready for review.