### PR TITLE
base: rework elems init API

### DIFF
--- a/assets/js/romo/ajax.js
+++ b/assets/js/romo/ajax.js
@@ -126,6 +126,4 @@ RomoAjax.prototype._trigger = function(eventName, eventData) {
   }
 }
 
-Romo.onInitUI(function(elem) {
-  Romo.initUIElems(elem, '[data-romo-ajax-auto="true"]').forEach(function(elem) { new RomoAjax(elem); });
-});
+Romo.addElemsInitSelector('[data-romo-ajax-auto="true"]', RomoAjax);

--- a/assets/js/romo/currency_text_input.js
+++ b/assets/js/romo/currency_text_input.js
@@ -168,6 +168,4 @@ RomoCurrencyTextInput.prototype._getNewInputName = function() {
   );
 }
 
-Romo.onInitUI(function(elem) {
-  Romo.initUIElems(elem, '[data-romo-currency-text-input-auto="true"]').forEach(function(elem) { new RomoCurrencyTextInput(elem); });
-});
+Romo.addElemsInitSelector('[data-romo-currency-text-input-auto="true"]', RomoCurrencyTextInput);

--- a/assets/js/romo/datepicker.js
+++ b/assets/js/romo/datepicker.js
@@ -401,6 +401,4 @@ RomoDatepicker.prototype._highlightItem = function(itemElem) {
   }
 }
 
-Romo.onInitUI(function(elem) {
-  Romo.initUIElems(elem, '[data-romo-datepicker-auto="true"]').forEach(function(elem) { new RomoDatepicker(elem); });
-});
+Romo.addElemsInitSelector('[data-romo-datepicker-auto="true"]', RomoDatepicker);

--- a/assets/js/romo/dropdown.js
+++ b/assets/js/romo/dropdown.js
@@ -439,6 +439,4 @@ RomoDropdown.prototype._roundPosOffsetVal = function(value) {
   return Math.round(value*100) / 100;
 }
 
-Romo.onInitUI(function(elem) {
-  Romo.initUIElems(elem, '[data-romo-dropdown-auto="true"]').forEach(function(elem) { new RomoDropdown(elem); });
-});
+Romo.addElemsInitSelector('[data-romo-dropdown-auto="true"]', RomoDropdown);

--- a/assets/js/romo/dropdown_form.js
+++ b/assets/js/romo/dropdown_form.js
@@ -101,7 +101,4 @@ RomoDropdownForm.prototype._bindForm = function() {
   }
 }
 
-Romo.onInitUI(function(elem) {
-  Romo.initUIElems(elem, '[data-romo-dropdownForm-auto="true"]').forEach(function(elem) { new RomoDropdownForm(elem); });
-});
-
+Romo.addElemsInitSelector('[data-romo-dropdownForm-auto="true"]', RomoDropdownForm);

--- a/assets/js/romo/form.js
+++ b/assets/js/romo/form.js
@@ -294,7 +294,4 @@ RomoForm.prototype._getXhrDataType = function() {
   return ((dataType === undefined) ? 'json' : dataType);
 }
 
-Romo.onInitUI(function(elem) {
-  Romo.initUIElems(elem, '[data-romo-form-auto="true"]').forEach(function(elem) { new RomoForm(elem); });
-});
-
+Romo.addElemsInitSelector('[data-romo-form-auto="true"]', RomoForm);

--- a/assets/js/romo/indicator_text_input.js
+++ b/assets/js/romo/indicator_text_input.js
@@ -167,6 +167,4 @@ RomoIndicatorTextInput.prototype._getIndicatorPosition = function() {
   );
 }
 
-Romo.onInitUI(function(elem) {
-  Romo.initUIElems(elem, '[data-romo-indicator-text-input-auto="true"]').forEach(function(elem) { new RomoIndicatorTextInput(elem); });
-});
+Romo.addElemsInitSelector('[data-romo-indicator-text-input-auto="true"]', RomoIndicatorTextInput);

--- a/assets/js/romo/inline.js
+++ b/assets/js/romo/inline.js
@@ -91,7 +91,4 @@ RomoInline.prototype._onDismissClick = function(e) {
   }
 }
 
-Romo.onInitUI(function(elem) {
-  Romo.initUIElems(elem, '[data-romo-inline-auto="true"]').forEach(function(elem) { new RomoInline(elem); });
-});
-
+Romo.addElemsInitSelector('[data-romo-inline-auto="true"]', RomoInline);

--- a/assets/js/romo/inline_form.js
+++ b/assets/js/romo/inline_form.js
@@ -97,7 +97,4 @@ RomoInlineForm.prototype._bindForm = function() {
   }
 }
 
-Romo.onInitUI(function(elem) {
-  Romo.initUIElems(elem, '[data-romo-inlineForm-auto="true"]').forEach(function(elem) { new RomoInlineForm(elem); });
-});
-
+Romo.addElemsInitSelector('[data-romo-inlineForm-auto="true"]', RomoInlineForm);

--- a/assets/js/romo/modal.js
+++ b/assets/js/romo/modal.js
@@ -385,6 +385,4 @@ RomoModal.prototype._onResizeWindow = function(e) {
   return true;
 }
 
-Romo.onInitUI(function(elem) {
-  Romo.initUIElems(elem, '[data-romo-modal-auto="true"]').forEach(function(elem) { new RomoModal(elem); });
-});
+Romo.addElemsInitSelector('[data-romo-modal-auto="true"]', RomoModal);

--- a/assets/js/romo/modal_form.js
+++ b/assets/js/romo/modal_form.js
@@ -110,6 +110,4 @@ RomoModalForm.prototype._bindForm = function() {
   }
 }
 
-Romo.onInitUI(function(elem) {
-  Romo.initUIElems(elem, '[data-romo-modalForm-auto="true"]').forEach(function(elem) { new RomoModalForm(elem); });
-});
+Romo.addElemsInitSelector('[data-romo-modalForm-auto="true"]', RomoModalForm);

--- a/assets/js/romo/onkey.js
+++ b/assets/js/romo/onkey.js
@@ -35,6 +35,4 @@ RomoOnkey.prototype._doTrigger = function(triggerEvent) {
   );
 }
 
-Romo.onInitUI(function(elem) {
-  Romo.initUIElems(elem, '[data-romo-onkey-auto="true"]').forEach(function(elem) { new RomoOnkey(elem); });
-});
+Romo.addElemsInitSelector('[data-romo-onkey-auto="true"]', RomoOnkey);

--- a/assets/js/romo/option_list_dropdown.js
+++ b/assets/js/romo/option_list_dropdown.js
@@ -621,6 +621,4 @@ RomoOptionListDropdown.prototype._getHighlightedItemElem = function() {
   return Romo.find(this.romoDropdown.bodyElem, 'LI.romo-option-list-dropdown-highlight')[0];
 }
 
-Romo.onInitUI(function(elem) {
-  Romo.initUIElems(elem, '[data-romo-option-list-dropdown-auto="true"]').forEach(function(elem) { new RomoOptionListDropdown(elem); });
-});
+Romo.addElemsInitSelector('[data-romo-option-list-dropdown-auto="true"]', RomoOptionListDropdown);

--- a/assets/js/romo/picker.js
+++ b/assets/js/romo/picker.js
@@ -398,6 +398,4 @@ RomoPicker.prototype._getCaretPosition = function() {
   );
 }
 
-Romo.onInitUI(function(elem) {
-  Romo.initUIElems(elem, '[data-romo-picker-auto="true"]').forEach(function(elem) { new RomoPicker(elem); });
-});
+Romo.addElemsInitSelector('[data-romo-picker-auto="true"]', RomoPicker);

--- a/assets/js/romo/select.js
+++ b/assets/js/romo/select.js
@@ -329,6 +329,4 @@ RomoSelect.prototype._getCaretPosition = function() {
   );
 }
 
-Romo.onInitUI(function(elem) {
-  Romo.initUIElems(elem, '[data-romo-select-auto="true"]').forEach(function(elem) { new RomoSelect(elem); });
-});
+Romo.addElemsInitSelector('[data-romo-select-auto="true"]', RomoSelect);

--- a/assets/js/romo/select_dropdown.js
+++ b/assets/js/romo/select_dropdown.js
@@ -256,6 +256,4 @@ RomoSelectDropdown.prototype._buildCustomOptionItem = function(value) {
   };
 }
 
-Romo.onInitUI(function(elem) {
-  Romo.initUIElems(elem, '[data-romo-select-dropdown-auto="true"]').forEach(function(elem) { new RomoSelectDropdown(elem); });
-});
+Romo.addElemsInitSelector('[data-romo-select-dropdown-auto="true"]', RomoSelectDropdown);

--- a/assets/js/romo/sortable.js
+++ b/assets/js/romo/sortable.js
@@ -271,6 +271,4 @@ RomoSortable.prototype._resetGrabClasses = function() {
   }, this));
 }
 
-Romo.onInitUI(function(elem) {
-  Romo.initUIElems(elem, '[data-romo-sortable-auto="true"]').forEach(function(elem) { new RomoSortable(elem); });
-});
+Romo.addElemsInitSelector('[data-romo-sortable-auto="true"]', RomoSortable);

--- a/assets/js/romo/spinner.js
+++ b/assets/js/romo/spinner.js
@@ -95,6 +95,4 @@ RomoSpinner.prototype._onStop = function(e) {
   this.doStop();
 }
 
-Romo.onInitUI(function(elem) {
-  Romo.initUIElems(elem, '[data-romo-spinner-auto="true"]').forEach(function(elem) { new RomoSpinner(elem); });
-});
+Romo.addElemsInitSelector('[data-romo-spinner-auto="true"]', RomoSpinner);

--- a/assets/js/romo/tooltip.js
+++ b/assets/js/romo/tooltip.js
@@ -354,6 +354,4 @@ RomoTooltip.prototype._setBodyHtml = function(content) {
   }
 }
 
-Romo.onInitUI(function(elem) {
-  Romo.initUIElems(elem, '[data-romo-tooltip-auto="true"]').forEach(function(elem) { new RomoTooltip(elem); });
-});
+Romo.addElemsInitSelector('[data-romo-tooltip-auto="true"]', RomoTooltip);


### PR DESCRIPTION
We noticed, while evaluating updates to the api to task optional
elem collections, that the API to setup auto elem init components
was a bit cumbersome and involved a bit of boilerplate code.  This
reworks the API to make it so you only make a single api call
passing in the elem selector and the component class.  Romo now
handles all of the boilerplate init logic in it's private helpers.

This also renames the api, in general, as "elems init".  "UI" was
a little ambiguous and components may or may not be related to UI.
A better way to describe all of this is initializing elems with a
component.  The private helpers were also reworked to be slightly
more efficient now that the `find` method can take a set of elems.

Note: this also removes the `_addEventCallback` method.  This
method isn't used and should have been removed earlier but was
missed.

@jcredding ready for review.