### PR TITLE
Update `on`, `off, and `trigger` to take multiple elems

### DIFF
--- a/assets/js/romo/base.js
+++ b/assets/js/romo/base.js
@@ -490,18 +490,9 @@ Romo.prototype.initAfterHtml = function(elem, htmlString) {
 
 // events
 
-Romo.prototype.on = function(elem, eventName, fn) {
-  var elemString = Object.prototype.toString.call(elem);
-  if (
-    elemString === '[object NodeList]'       ||
-    elemString === '[object HTMLCollection]' ||
-    Array.isArray(elem)
-  ) {
-    throw new Error('Can only bind events on individual elems, not collections.');
-  }
-
+Romo.prototype.on = function(elems, eventName, fn) {
   var proxyFn = function(e) {
-    var result = fn.apply(elem, e.detail === undefined ? [e] : [e].concat(e.detail));
+    var result = fn.apply(e.target, e.detail === undefined ? [e] : [e].concat(e.detail));
     if (result === false) {
       e.preventDefault();
       e.stopPropagation();
@@ -510,41 +501,27 @@ Romo.prototype.on = function(elem, eventName, fn) {
   }
   proxyFn._romofid = this._fn(fn)._romofid;
 
-  elem.addEventListener(eventName, proxyFn);
-  var key = this._handlerKey(elem, eventName, proxyFn);
-  if (this._handlers[key] === undefined) {
+  Romo.array(elems).forEach(Romo.proxy(function(elem) {
+    elem.addEventListener(eventName, proxyFn);
+    var key = this._handlerKey(elem, eventName, proxyFn);
+    if (this._handlers[key] === undefined) {
+      this._handlers[key] = [];
+    }
+    this._handlers[key].push(proxyFn);
+  }, this));
+}
+
+Romo.prototype.off = function(elems, eventName, fn) {
+  Romo.array(elems).forEach(Romo.proxy(function(elem) {
+    var key = this._handlerKey(elem, eventName, fn);
+    (this._handlers[key] || []).forEach(function(proxyFn) {
+      elem.removeEventListener(eventName, proxyFn);
+    });
     this._handlers[key] = [];
-  }
-  this._handlers[key].push(proxyFn);
+  }, this));
 }
 
-Romo.prototype.off = function(elem, eventName, fn) {
-  var elemString = Object.prototype.toString.call(elem);
-  if (
-    elemString === '[object NodeList]'       ||
-    elemString === '[object HTMLCollection]' ||
-    Array.isArray(elem)
-  ) {
-    throw new Error('Can only unbind events on individual elems, not collections.');
-  }
-
-  var key = this._handlerKey(elem, eventName, fn);
-  (this._handlers[key] || []).forEach(function(proxyFn) {
-    elem.removeEventListener(eventName, proxyFn);
-  });
-  this._handlers[key] = [];
-}
-
-Romo.prototype.trigger = function(elem, customEventName, args) {
-  var elemString = Object.prototype.toString.call(elem);
-  if (
-    elemString === '[object NodeList]'       ||
-    elemString === '[object HTMLCollection]' ||
-    Array.isArray(elem)
-  ) {
-    throw new Error('Can only trigger events on individual elems, not collections.');
-  }
-
+Romo.prototype.trigger = function(elems, customEventName, args) {
   var event = undefined;
   if (typeof window.CustomEvent === "function") {
     event = new CustomEvent(customEventName, { detail: args });
@@ -552,7 +529,9 @@ Romo.prototype.trigger = function(elem, customEventName, args) {
     event = document.createEvent('CustomEvent');
     event.initCustomEvent(customEventName, false, false, args);
   }
-  elem.dispatchEvent(event);
+  Romo.array(elems).forEach(function(elem) {
+    elem.dispatchEvent(event);
+  });
 }
 
 Romo.prototype.ready = function(eventHandlerFn) {


### PR DESCRIPTION
This updates the `on`, `off`, and `trigger` helpers to take
multiple elems instead of just a single elem. This is part of an
effort to make the helpers more convenient when dealing with
collections of elems and avoid having extra noisy `forEach` loops.

This updates the `on` helper to build a single proxy function and
bind it to the multiple elems. This avoids building a proxy
function for each elem but otherwise just loops over the previous
behavior in a `forEach` loop.

This also updates the `trigger` helper to build a single event and
then loop over the passed elems dispatch it. Similar to the `on`
helper this avoids building a new identical event for each elem
which is hopefully slightly more performant.

The also updates the `off` helper but it simply loops over its
elems and runs its previous logic.

@kellyredding - Ready for review.