### PR TITLE
Update `Datepicker` to pass multi elems to `Romo.on`

### DIFF
--- a/assets/js/romo/datepicker.js
+++ b/assets/js/romo/datepicker.js
@@ -39,10 +39,8 @@ RomoDatepicker.prototype.doRefreshUI = function(date) {
   Romo.trigger(this.elem, 'romoDatepicker:refresh', [rDate, this]);
 
   var itemElems = Romo.find(this.calTable, this.itemSelector);
-  itemElems.forEach(Romo.proxy(function(itemElem) {
-    Romo.on(itemElem, 'mouseenter', Romo.proxy(this._onItemEnter, this));
-    Romo.on(itemElem, 'click',      Romo.proxy(this._onItemClick, this));
-  }, this));
+  Romo.on(itemElems, 'mouseenter', Romo.proxy(this._onItemEnter, this));
+  Romo.on(itemElems, 'click',      Romo.proxy(this._onItemClick, this));
 
   Romo.on(this.romoDropdown.popupElem, 'mousedown', Romo.proxy(this._onPopupMouseDown, this));
   Romo.on(this.romoDropdown.popupElem, 'mouseup',   Romo.proxy(this._onPopupMouseUp, this));
@@ -279,9 +277,7 @@ RomoDatepicker.prototype._refreshCalendar = function(date) {
   var tableBodyElem = Romo.find(this.calTable, 'tbody')[0];
   Romo.updateHtml(tableBodyElem, '');
   var rowElems = this._buildCalendarBodyRows(date);
-  rowElems.forEach(Romo.proxy(function(rowElem) {
-    Romo.append(tableBodyElem, rowElem);
-  }, this));
+  Romo.append(tableBodyElem, rowElems);
 
   this.refreshDate = date;
 }
@@ -392,7 +388,7 @@ RomoDatepicker.prototype._buildCalendarBodyRows = function(date) {
 }
 
 RomoDatepicker.prototype._highlightItem = function(itemElem) {
-  var highlightElem = Romo.find(this.calTable, 'TD.romo-datepicker-highlight')[0]
+  var highlightElem = Romo.find(this.calTable, 'TD.romo-datepicker-highlight')[0];
   if(highlightElem !== undefined) {
     Romo.removeClass(highlightElem, 'romo-datepicker-highlight');
   }


### PR DESCRIPTION
This updates the `Datepicker` component to make use of romo's
helpers that now take multiple elems. This involved updating
the binding of mouse enter and click on the calendar items. This
was the only logic that could make use of the helper function
updates.

This also updates a `Romo.append` call passing the set of row
elems instead of iterating over the set and appending them one
at a time. This could have been done previously as the `append`
function has always taken multiple elems but was missed. I
noticed it because I was looking for loops used with romo helpers
to make use of the helpers now taking multiple elems.

This also adds a missing semicolon to the end of a line which is
part of our style conventions.

@kellyredding - Ready for review.