### PR TITLE
Update dropdown, modal, and inline to pass multi elems to helpers

### DIFF
--- a/assets/js/romo/dropdown.js
+++ b/assets/js/romo/dropdown.js
@@ -280,9 +280,7 @@ RomoDropdown.prototype._bindBody = function() {
   }
 
   this.closeElems = Romo.find(this.popupElem, '[data-romo-dropdown-close="true"]');
-  this.closeElems.forEach(Romo.proxy(function(closeElem) {
-    Romo.on(closeElem, 'click', Romo.proxy(this._onPopupClose, this));
-  }, this));
+  Romo.on(this.closeElems, 'click', Romo.proxy(this._onPopupClose, this));
 
   Romo.setStyle(this.contentElem, 'min-height', Romo.data(this.elem, 'romo-dropdown-min-height'));
   Romo.setStyle(this.contentElem, 'height',     Romo.data(this.elem, 'romo-dropdown-height'));

--- a/assets/js/romo/inline.js
+++ b/assets/js/romo/inline.js
@@ -51,9 +51,7 @@ RomoInline.prototype._bindElem = function() {
 
 RomoInline.prototype._bindDismiss = function() {
   this.dismissElems = Romo.find(this.elem, '[data-romo-inline-dismiss]');
-  this.dismissElems.forEach(Romo.proxy(function(dismissElem) {
-    Romo.on(dismissElem, 'click', Romo.proxy(this._onDismissClick, this));
-  }, this));
+  Romo.on(this.dismissElems, 'click', Romo.proxy(this._onDismissClick, this));
 }
 
 RomoInline.prototype._loadStart = function() {

--- a/assets/js/romo/modal.js
+++ b/assets/js/romo/modal.js
@@ -108,13 +108,11 @@ RomoModal.prototype.doPlacePopupElem = function() {
 }
 
 RomoModal.prototype.doBindElemKeyUp = function() {
-  Romo.on(this.elem,      'keyup', Romo.proxy(this._onElemKeyUp, this));
-  Romo.on(this.popupElem, 'keyup', Romo.proxy(this._onElemKeyUp, this));
+  Romo.on([this.elem, this.popupElem], 'keyup', Romo.proxy(this._onElemKeyUp, this));
 }
 
 RomoModal.prototype.doUnBindElemKeyUp = function() {
-  Romo.off(this.elem,      'keyup', Romo.proxy(this._onElemKeyUp, this));
-  Romo.off(this.popupElem, 'keyup', Romo.proxy(this._onElemKeyUp, this));
+  Romo.off([this.elem, this.popupElem], 'keyup', Romo.proxy(this._onElemKeyUp, this));
 }
 
 RomoModal.prototype.doBindWindowBodyClick = function() {
@@ -203,15 +201,11 @@ RomoModal.prototype._bindBody = function() {
   }
 
   this.closeElems = Romo.find(this.popupElem, '[data-romo-modal-close="true"]');
-  this.closeElems.forEach(Romo.proxy(function(closeElem) {
-    Romo.on(closeElem, 'click', Romo.proxy(this._onPopupClose, this));
-  }, this));
+  Romo.on(this.closeElems, 'click', Romo.proxy(this._onPopupClose, this));
 
   this.dragElems = Romo.find(this.popupElem, '[data-romo-modal-drag="true"]');
-  this.dragElems.forEach(Romo.proxy(function(dragElem) {
-    Romo.on(dragElem, 'mousedown', Romo.proxy(this._onMouseDown, this));
-    Romo.addClass(dragElem, 'romo-modal-grab');
-  }, this));
+  Romo.on(this.dragElems, 'mousedown', Romo.proxy(this._onMouseDown, this));
+  Romo.addClass(this.dragElems, 'romo-modal-grab');
 
   var css = {
     'min-width':  Romo.data(this.elem, 'romo-modal-min-width'),
@@ -246,9 +240,7 @@ RomoModal.prototype._resetBody = function() {
     Romo.rmStyle(this.contentElem, 'overflow');
   }
 
-  this.closeElems.forEach(Romo.proxy(function(closeElem) {
-    Romo.off(closeElem, 'click', Romo.proxy(this._onPopupClose, this));
-  }, this));
+  Romo.off(this.closeElems, 'click', Romo.proxy(this._onPopupClose, this));
 }
 
 RomoModal.prototype._loadBodyStart = function() {
@@ -295,10 +287,8 @@ RomoModal.prototype._onMouseDown = function(e) {
 }
 
 RomoModal.prototype._dragStart = function(e) {
-  this.dragElems.forEach(Romo.proxy(function(dragElem) {
-    Romo.addClass(dragElem, 'romo-modal-grabbing');
-    Romo.removeClass(dragElem, 'romo-modal-grab');
-  }, this));
+  Romo.addClass(this.dragElems, 'romo-modal-grabbing');
+  Romo.removeClass(this.dragElems, 'romo-modal-grab');
 
   Romo.setStyle(this.popupElem, 'width',  Romo.css(this.popupElem, 'width'));
   Romo.setStyle(this.popupElem, 'height', Romo.css(this.popupElem, 'height'));
@@ -332,10 +322,8 @@ RomoModal.prototype._onMouseUp = function(e) {
 }
 
 RomoModal.prototype._dragStop = function(e) {
-  this.dragElems.forEach(Romo.proxy(function(dragElem) {
-    Romo.addClass(dragElem, 'romo-modal-grab');
-    Romo.removeClass(dragElem, 'romo-modal-grabbing');
-  }, this));
+  Romo.addClass(this.dragElems, 'romo-modal-grab');
+  Romo.removeClass(this.dragElems, 'romo-modal-grabbing');
 
   Romo.rmStyle(this.popupElem, 'width');
   Romo.rmStyle(this.popupElem, 'height');


### PR DESCRIPTION
This updates the dropdown, modal, and inline components to make
use of romo's helpers now accepting multiple elems. This involved
updating the binding of close/dismiss elems, binding modal drag
elems, and binding keyup on modals. This also updates the modals
to pass all of its drag elems when adding or removing classes
from them. This was all of the logic for these components that
could make use of the helper function updates.

@kellyredding - Ready for review.