### PR TITLE
Update select/picker related components to pass multi elems to romo helpers

### DIFF
--- a/assets/js/romo/option_list_dropdown.js
+++ b/assets/js/romo/option_list_dropdown.js
@@ -129,10 +129,8 @@ RomoOptionListDropdown.prototype.doSetListItems = function(itemsList) {
   this._updateOptionsListUI();
 
   var itemElems = Romo.find(this.optionListContainerElem, this.itemSelector);
-  itemElems.forEach(Romo.proxy(function(itemElem) {
-    Romo.on(itemElem, 'mouseenter', Romo.proxy(this._onItemEnter, this));
-    Romo.on(itemElem, 'click',      Romo.proxy(this._onItemClick, this));
-  }, this));
+  Romo.on(itemElems, 'mouseenter', Romo.proxy(this._onItemEnter, this));
+  Romo.on(itemElems, 'click',      Romo.proxy(this._onItemClick, this));
 }
 
 /* private */

--- a/assets/js/romo/picker.js
+++ b/assets/js/romo/picker.js
@@ -214,10 +214,9 @@ RomoPicker.prototype._buildOptionListDropdownElem = function() {
     Romo.setData(romoOptionListDropdownElem, 'romo-dropdown-max-height', 'detect');
   }
 
-  var classList = Romo.attr(this.elem, 'class') !== undefined ? Romo.attr(this.elem, 'class').split(/\s+/) : [];
-  classList.forEach(Romo.proxy(function(classItem) {
-    Romo.addClass(romoOptionListDropdownElem, classItem);
-  }, this));
+  if (Romo.attr(this.elem, 'class') !== undefined) {
+    Romo.addClass(romoSelectDropdownElem, Romo.attr(this.elem, 'class'));
+  }
   if (Romo.attr(this.elem, 'style') !== undefined) {
     Romo.setAttr(romoOptionListDropdownElem, 'style', Romo.attr(this.elem, 'style'));
   }

--- a/assets/js/romo/select.js
+++ b/assets/js/romo/select.js
@@ -186,10 +186,9 @@ RomoSelect.prototype._buildSelectDropdownElem = function() {
     Romo.setData(romoSelectDropdownElem, 'romo-dropdown-max-height', 'detect');
   }
 
-  var classList = Romo.attr(this.elem, 'class') !== undefined ? Romo.attr(this.elem, 'class').split(/\s+/) : [];
-  classList.forEach(Romo.proxy(function(classItem) {
-    Romo.addClass(romoSelectDropdownElem, classItem);
-  }, this));
+  if (Romo.attr(this.elem, 'class') !== undefined) {
+    Romo.addClass(romoSelectDropdownElem, Romo.attr(this.elem, 'class'));
+  }
   if (Romo.attr(this.elem, 'style') !== undefined) {
     Romo.setAttr(romoSelectDropdownElem, 'style', Romo.attr(this.elem, 'style'));
   }

--- a/assets/js/romo/select_dropdown.js
+++ b/assets/js/romo/select_dropdown.js
@@ -138,12 +138,8 @@ RomoSelectDropdown.prototype._bindElem = function() {
       return elem.textContent.replace(/\W/g, ' ');
     });
 
-    wbFilter.matchingElems.forEach(Romo.proxy(function(matchingElem) {
-      Romo.removeClass(matchingElem, this.filterHiddenClass);
-    }, this));
-    wbFilter.notMatchingElems.forEach(Romo.proxy(function(notMatchingElem) {
-      Romo.addClass(notMatchingElem, this.filterHiddenClass);
-    }, this));
+    Romo.removeClass(wbFilter.matchingElems, this.filterHiddenClass);
+    Romo.addClass(wbFilter.notMatchingElems, this.filterHiddenClass);
     this._setListItems();
 
     if (filterValue !== '') {

--- a/assets/js/romo/selected_options_list.js
+++ b/assets/js/romo/selected_options_list.js
@@ -58,9 +58,7 @@ RomoSelectedOptionsList.prototype.doRefreshUI = function() {
   var addItems = this.items.filter(function(item) {
     return uiValues.indexOf(item.value) === -1;
   });
-  rmElems.forEach(Romo.proxy(function(rmElem) {
-    Romo.remove(rmElem);
-  }, this));
+  Romo.remove(rmElems);
   addItems.forEach(Romo.proxy(function(addItem) {
     var addElem = this._buildItemElem(addItem);
     uiListElem.append(addElem);


### PR DESCRIPTION
This updates the select, picker, select dropdown, option list
dropdown, and selected options list components to make use of
romo's helpers that now take multiple elems.

This involved a number of small changes to each component:

* This updates the option list dropdown to pass all of its item
elems to `Romo.on` when binding to the mouse enter and click
events.
* This updates the select dropdown to pass the matching and non
matching elems from the word boundary filter when adding/removing
classes.
* This updates the selected options list to pass all of the elems
to remove to `Romo.remove` instead of removing them individually.
* This updates the select and picker components to not split their
class list and simply pass it to `addClass`. The `addClass` helper
was previously updated to accept a string of multiple class names.

@kellyredding - Ready for review.