### PR TITLE
Update init replace methods to return single elem

### DIFF
--- a/assets/js/romo/base.js
+++ b/assets/js/romo/base.js
@@ -359,11 +359,11 @@ Romo.prototype.replaceHtml = function(elem, htmlString) {
 }
 
 Romo.prototype.initReplace = function(elem, replacementElem) {
-  return this.initElems(this.replace(elem, replacementElem));
+  return this.initElems(this.replace(elem, replacementElem))[0];
 }
 
 Romo.prototype.initReplaceHtml = function(elem, htmlString) {
-  return this.initElems(this.replaceHtml(elem, htmlString));
+  return this.initElems(this.replaceHtml(elem, htmlString))[0];
 }
 
 Romo.prototype.update = function(elem, childElems) {


### PR DESCRIPTION
This updates the `initReplace` and `initReplaceHtml` methods to
be consistent with their non init versions and return the single
elem that was replaced. This was changed in PR 227. The previous
helper `triggerInitUI` would cast whatever it was passed as an
array and then iterate over it. It would return the original value
not the array. The new implementation does the same only it
returns the array instead of the original value. This is because
the `_elemsInitTrigger` is passed the array and returns it.

This fixes the problem by having the `initReplace` and
`initReplaceHtml` simply pull the first item out of the array
results that `initElems` returns. This keeps them consistent
with the other replace methods.

@kellyredding - Ready for review. Not sure if my commit message is confusing, here's the methods and how they changed.

Here's the old implementation: https://github.com/redding/romo/blob/396aafb2a61982f997e68609b140262debcd7e99/assets/js/romo/base.js#L540. It casts the passed in elems as an array but doesn't actually return the result of that.

Here's the new implemenation:

* The `_elemsInitTrigger` is passed `onElems` and returns them: https://github.com/redding/romo/pull/227/files#diff-c70908c67fdb558245885de69420b32eR865
* The `initElems ` casts the elems as an array and because of the `_elemsInitTrigger` function it returns them as well: https://github.com/redding/romo/pull/227/files#diff-c70908c67fdb558245885de69420b32eR308

Hopefully this makes sense. We could also change the init methods to return whatever they are passed but it might be more consistent that they always return an array.