### PR TITLE
picker/select/select-dropdown: properly bind label click events

### DIFF
--- a/assets/js/romo/base.js
+++ b/assets/js/romo/base.js
@@ -700,10 +700,12 @@ Romo.prototype.array = function(value) {
     return Array.prototype.slice.call(value)
   }
 
-  // short circuit for passing elems, this ensures these remain fast and avoids
-  // running into the is like an array logic; this fixes issues with select and
-  // form elements being like an array and returning unexpected results
-  if (typeof(value.nodeType) === 'number') {
+  // short circuit for passing individual elems and "not truthy" values, this
+  // ensures these remain fast (the individual elems) and avoids running into
+  // the is like an array logic; this fixes issues with select and form elems
+  // being like an array and returning unexpected results.  This also fixes
+  // passing in null/undefined values.
+  if (!value || typeof(value.nodeType) === 'number') {
     return [value];
   }
 

--- a/assets/js/romo/picker.js
+++ b/assets/js/romo/picker.js
@@ -74,8 +74,9 @@ RomoPicker.prototype._bindElem = function() {
   this.doSetValue(this._elemValues());
 
   if (Romo.attr(this.elem, 'id') !== undefined) {
-    var labelElem = Romo.f('label[for="'+Romo.attr(this.elem, 'id')+'"]')[0];
+    var labelElem = Romo.f('label[for="'+Romo.attr(this.elem, 'id')+'"]');
     Romo.on(labelElem, 'click', Romo.proxy(function(e) {
+      e.preventDefault();
       this.romoOptionListDropdown.doFocus();
     }, this));
   }

--- a/assets/js/romo/select.js
+++ b/assets/js/romo/select.js
@@ -54,8 +54,9 @@ RomoSelect.prototype._bindElem = function() {
   this.doSetValue(this._elemValues());
 
   if (Romo.attr(this.elem, 'id') !== undefined) {
-    var labelElem = Romo.f('label[for="'+Romo.attr(this.elem, 'id')+'"]')[0]
+    var labelElem = Romo.f('label[for="'+Romo.attr(this.elem, 'id')+'"]');
     Romo.on(labelElem, 'click', Romo.proxy(function(e) {
+      e.preventDefault();
       this.romoSelectDropdown.doFocus();
     }, this));
   }

--- a/assets/js/romo/select_dropdown.js
+++ b/assets/js/romo/select_dropdown.js
@@ -154,8 +154,9 @@ RomoSelectDropdown.prototype._bindElem = function() {
   Romo.trigger(this.elem, 'romoOptionListDropdown:triggerListOptionsUpdate', [this.selectedItemElem()]);
 
   if (Romo.attr(this.elem, 'id') !== undefined) {
-    var labelElem = Romo.f('label[for="'+Romo.attr(this.elem, 'id')+'"]')[0];
+    var labelElem = Romo.f('label[for="'+Romo.attr(this.elem, 'id')+'"]');
     Romo.on(labelElem, 'click', Romo.proxy(function(e) {
+      e.preventDefault();
       this.elem.focus();
     }, this));
   }


### PR DESCRIPTION
The previous implementation was looking for a label and binding
a click event handler.  However, it wasn't checking if there was
actually a label before trying to bind the event.  This switches
to just passing the set of elems returned by the find call to the
on event bind (now that this can take a set of elems).  For most
cases there will only be a single elem in the set and for the case
that there is no elem, no event will be bound.

This also fixes a small bug in the base `array` implementation.
We added a short-circuit for single element checks.  However this
broke the case where you pass `undefined` to `.array` b/c you
can't call `nodeType` on `undefined`.  This adds an undefined
check to the short-circuit to avoid this case.  This came up when
debugging the select/picker label error.

@jcredding ready for review.