### PR TITLE
currency text input: add onkey to update hidden input on key

### DIFF
--- a/assets/js/romo/currency_text_input.js
+++ b/assets/js/romo/currency_text_input.js
@@ -35,9 +35,14 @@ RomoCurrencyTextInput.prototype._bindElem = function() {
   Romo.on(this.elem, 'change', Romo.proxy(function(e) {
     this._refreshInputValue();
   }, this));
+  Romo.on(this.elem, 'romoOnkey:trigger', Romo.proxy(function(e, triggerEvent, romoOnkey) {
+    this._refreshInputValue(true);
+  }, this));
   Romo.on(this.elem, 'romoCurrencyTextInput:triggerUpdateInputValue', Romo.proxy(function(e) {
     this._refreshInputValue();
   }, this));
+
+  new RomoOnkey(this.elem)
 
   this._refreshInputValue();
 }
@@ -108,13 +113,15 @@ RomoCurrencyTextInput.prototype._bindIndicatorTextInput = function() {
   new RomoIndicatorTextInput(this.elem);
 }
 
-RomoCurrencyTextInput.prototype._refreshInputValue = function() {
+RomoCurrencyTextInput.prototype._refreshInputValue = function(skipRefreshElemValue) {
   var unFormattedValue = this._unFormatCurrencyValue(this.elem.value);
   this.hiddenInputElem.value = unFormattedValue;
-  if (Romo.data(this.elem, 'romo-currency-text-input-format-for-currency') !== false) {
-    this.elem.value = this._formatCurrencyValue(unFormattedValue);
-  } else {
-    this.elem.value = unFormattedValue;
+  if (!skipRefreshElemValue) {
+    if (Romo.data(this.elem, 'romo-currency-text-input-format-for-currency') !== false) {
+      this.elem.value = this._formatCurrencyValue(unFormattedValue);
+    } else {
+      this.elem.value = unFormattedValue;
+    }
   }
 }
 


### PR DESCRIPTION
This makes it so you can type in the input and hit enter and have
it use the correct value.  Before, the correct value wasn't set
until a 'change' event happened on the input (which doesn't fire
when hitting enter on an input).

This brings in romo's onkey component on the input with no delay.
This means that on every keystroke, the hidden value is updated.
I changed the refresh function to take a skip param that skips
updating the elem value.  This is b/c you don't want the value
changing (ie reformatting) as the user types b/c it is
disorienting.  The onkey refresh skips this while the other don't.

Overall, this makes the input more friendly when typing and
hitting enter to submit forms.

@jcredding ready for review.