### PR TITLE
base js: fix Romo.elems to be more robust, work with TR strings

### DIFF
--- a/assets/js/romo/base.js
+++ b/assets/js/romo/base.js
@@ -304,17 +304,15 @@ Romo.prototype.elems = function(htmlString) {
   base.href = document.location.href;
   context.head.appendChild(base);
 
-  context.body.innerHTML = htmlString;
-  if (context.body.children.length !== 0) {
+  var results = Romo._elemsTagNameRegEx.exec(htmlString);
+  if (!results){ return []; }
+
+  var tagName = results[1].toLowerCase();
+  var wrap    = Romo._elemsWrapMap[tagName];
+  if (!wrap) {
+    context.body.innerHTML = htmlString;
     return this.array(context.body.children);
   } else {
-    var results = Romo._elemsTagNameRegEx.exec(htmlString);
-    if (!results){ return []; }
-
-    var tagName = results[1].toLowerCase();
-    var wrap    = Romo._elemsWrapMap[tagName];
-    if (!wrap){ return []; }
-
     context.body.innerHTML = wrap[1] + htmlString + wrap[2];
     var parentElem = context.body;
     var i = wrap[0];
@@ -854,7 +852,7 @@ Romo.prototype._deserializeValue = function(value) {
   }
 }
 
-Romo.prototype._elemsTagNameRegEx = /<([a-z][^\/\0>\x20\t\r\n\f]+)/i;
+Romo.prototype._elemsTagNameRegEx = /<([a-z-]+)[\s\/>]+/i;
 
 Romo.prototype._elemsWrapMap = {
   'caption':  [1, "<table>",            "</table>"],


### PR DESCRIPTION
I was rewriting one of our apps that calls `.elems` on an html str
with a `<tr ...` elem.  Assigning `context.body.innerHTML` didn't
return empty children as expected.  Instead the context stripped
all of the tr/td markup and applied the td contents.  So the body
children was a list of the non tr/td elems.  This is not correct.

It seems the context is inconsistent in how it writes incomplete
table markup.  With some elems (ie TDs) it does nothing.  With
others (like this TR example) it writes something.  This shows
that it is unreliable to blindly write the body inner html.

This switches to instead parse the tag name of every given html
string.  If there is a tag name and we don't have wrap markup
specified for that tag, then the context body inner html is
written as before.  If there is a wrap, then that logic is applied
as before.  The only downside to this implementation is the regex
match is run for every html string (even if it will not need any
wrapping).  However, this is safer in light of the inner html
writing inconsistencies.

This also updates the `._elemsTagNameRegEx` helper.  The previous
version didn't recognize single letter tag names.  I've tested
this regex against: multi letter, single letter, hyphenated, and
immediate closed tag markup.

![imagessc5t](https://user-images.githubusercontent.com/82110/32304471-797a748e-bf3d-11e7-9909-96eab2b4611d.jpg)

@jcredding ready for review.
