### PR TITLE
js: reorg event handler methods into event functions sections

### DIFF
--- a/assets/js/romo/ajax.js
+++ b/assets/js/romo/ajax.js
@@ -53,22 +53,6 @@ RomoAjax.prototype._bindElem = function() {
   Romo.on(this.elem, 'romoAjax:triggerInvoke', Romo.proxy(this._onTriggerInvoke, this));
 }
 
-RomoAjax.prototype._onInvoke = function(e) {
-  e.preventDefault();
-
-  if (Romo.hasClass(this.elem, 'disabled') === false) {
-    this.doInvoke();
-  }
-}
-
-RomoAjax.prototype._onTriggerInvoke = function(e, data) {
-  e.stopPropagation();
-
-  if (Romo.hasClass(this.elem, 'disabled') === false) {
-    this.doInvoke(data);
-  }
-}
-
 RomoAjax.prototype._invoke = function() {
   this.invokeQueued  = false;
   this.invokeRunning = true;
@@ -99,16 +83,6 @@ RomoAjax.prototype._call = function(callUrl, data) {
   });
 }
 
-RomoAjax.prototype._onCallSuccess = function(data, status, xhr) {
-  this._trigger('romoAjax:callSuccess', [data, this]);
-  this._completeInvoke();
-}
-
-RomoAjax.prototype._onCallError = function(xhr, errorType, error) {
-  this._trigger('romoAjax:callError', [xhr, this]);
-  this._completeInvoke();
-}
-
 RomoAjax.prototype._completeInvoke = function() {
   this._trigger('romoAjax:invoke', [this]);
   if (this.invokeQueued === true) {
@@ -125,5 +99,35 @@ RomoAjax.prototype._trigger = function(eventName, eventData) {
     Romo.trigger(this.elem, eventName, eventData);
   }
 }
+
+// event functions
+
+RomoAjax.prototype._onInvoke = function(e) {
+  e.preventDefault();
+
+  if (Romo.hasClass(this.elem, 'disabled') === false) {
+    this.doInvoke();
+  }
+}
+
+RomoAjax.prototype._onTriggerInvoke = function(e, data) {
+  e.stopPropagation();
+
+  if (Romo.hasClass(this.elem, 'disabled') === false) {
+    this.doInvoke(data);
+  }
+}
+
+RomoAjax.prototype._onCallSuccess = function(data, status, xhr) {
+  this._trigger('romoAjax:callSuccess', [data, this]);
+  this._completeInvoke();
+}
+
+RomoAjax.prototype._onCallError = function(xhr, errorType, error) {
+  this._trigger('romoAjax:callError', [xhr, this]);
+  this._completeInvoke();
+}
+
+// init
 
 Romo.addElemsInitSelector('[data-romo-ajax-auto="true"]', RomoAjax);

--- a/assets/js/romo/currency_text_input.js
+++ b/assets/js/romo/currency_text_input.js
@@ -175,4 +175,8 @@ RomoCurrencyTextInput.prototype._getNewInputName = function() {
   );
 }
 
+// event functions
+
+// init
+
 Romo.addElemsInitSelector('[data-romo-currency-text-input-auto="true"]', RomoCurrencyTextInput);

--- a/assets/js/romo/datepicker.js
+++ b/assets/js/romo/datepicker.js
@@ -183,72 +183,6 @@ RomoDatepicker.prototype._selectHighlightedItem = function() {
   this._triggerSetDateChangeEvent();
 }
 
-RomoDatepicker.prototype._onTriggerSetDate = function(e, value) {
-  this.doSetDate(value);
-  this._triggerSetDateChangeEvent();
-}
-
-RomoDatepicker.prototype._onElemKeyDown = function(e) {
-  if (Romo.hasClass(this.elem, 'disabled') === false) {
-    if (this.romoDropdown.popupOpen()) {
-      return true;
-    } else {
-      if(e.keyCode === 40 /* Down */ ) {
-        this.romoDropdown.doPopupOpen();
-        this.romoDropdown.popupElem.focus();
-        return false;
-      } else {
-        return true;
-      }
-    }
-  }
-  return true;
-}
-
-RomoDatepicker.prototype._onPopupOpen = function(e) {
-  if (Romo.hasClass(this.elem, 'disabled') === false) {
-    this.doSetDate(this.elem.value);
-    this.doRefreshUI();
-  }
-}
-
-RomoDatepicker.prototype._onPopupClose = function(e) {
-  this._highlightItem(undefined);
-}
-
-RomoDatepicker.prototype._onItemEnter = function(e) {
-  this._highlightItem(e.target);
-  return false
-}
-
-RomoDatepicker.prototype._onItemClick = function(e) {
-  this._clearBlurTimeout();
-  this._selectHighlightedItem();
-  return false;
-}
-
-RomoDatepicker.prototype._onPrevClick = function(e) {
-  this._clearBlurTimeout();
-  this._refreshToPrevMonth();
-  return false;
-}
-
-RomoDatepicker.prototype._onNextClick = function(e) {
-  this._clearBlurTimeout();
-  this._refreshToNextMonth();
-  return false;
-}
-
-RomoDatepicker.prototype._onPopupMouseDown = function(e) {
-  this.popupMouseDown = true;
-}
-
-RomoDatepicker.prototype._onPopupMouseUp = function(e) {
-  this.popupMouseDown = false;
-}
-
-// private
-
 RomoDatepicker.prototype._show = function(elem) {
   Romo.show(elem);
 }
@@ -396,5 +330,73 @@ RomoDatepicker.prototype._highlightItem = function(itemElem) {
     Romo.addClass(itemElem, 'romo-datepicker-highlight');
   }
 }
+
+// event functions
+
+RomoDatepicker.prototype._onTriggerSetDate = function(e, value) {
+  this.doSetDate(value);
+  this._triggerSetDateChangeEvent();
+}
+
+RomoDatepicker.prototype._onElemKeyDown = function(e) {
+  if (Romo.hasClass(this.elem, 'disabled') === false) {
+    if (this.romoDropdown.popupOpen()) {
+      return true;
+    } else {
+      if(e.keyCode === 40 /* Down */ ) {
+        this.romoDropdown.doPopupOpen();
+        this.romoDropdown.popupElem.focus();
+        return false;
+      } else {
+        return true;
+      }
+    }
+  }
+  return true;
+}
+
+RomoDatepicker.prototype._onPopupOpen = function(e) {
+  if (Romo.hasClass(this.elem, 'disabled') === false) {
+    this.doSetDate(this.elem.value);
+    this.doRefreshUI();
+  }
+}
+
+RomoDatepicker.prototype._onPopupClose = function(e) {
+  this._highlightItem(undefined);
+}
+
+RomoDatepicker.prototype._onItemEnter = function(e) {
+  this._highlightItem(e.target);
+  return false
+}
+
+RomoDatepicker.prototype._onItemClick = function(e) {
+  this._clearBlurTimeout();
+  this._selectHighlightedItem();
+  return false;
+}
+
+RomoDatepicker.prototype._onPrevClick = function(e) {
+  this._clearBlurTimeout();
+  this._refreshToPrevMonth();
+  return false;
+}
+
+RomoDatepicker.prototype._onNextClick = function(e) {
+  this._clearBlurTimeout();
+  this._refreshToNextMonth();
+  return false;
+}
+
+RomoDatepicker.prototype._onPopupMouseDown = function(e) {
+  this.popupMouseDown = true;
+}
+
+RomoDatepicker.prototype._onPopupMouseUp = function(e) {
+  this.popupMouseDown = false;
+}
+
+// init
 
 Romo.addElemsInitSelector('[data-romo-datepicker-auto="true"]', RomoDatepicker);

--- a/assets/js/romo/dropdown.js
+++ b/assets/js/romo/dropdown.js
@@ -336,6 +336,39 @@ RomoDropdown.prototype._loadBodyError = function(xhr) {
   Romo.trigger(this.elem, 'romoDropdown:loadBodyError', [xhr, this]);
 }
 
+RomoDropdown.prototype._parsePositionData = function(posString) {
+  var posData = (posString || '').split(',');
+  return { position: posData[0], alignment: posData[1] };
+}
+
+RomoDropdown.prototype._getPopupMaxAvailableHeight = function(position) {
+  var maxHeight = undefined;
+
+  switch (position) {
+    case 'top':
+      var elemTop = this.elem.getBoundingClientRect().top;
+      maxHeight = elemTop - this._getPopupMaxHeightDetectPad(position);
+      break;
+    case 'bottom':
+      var viewportHeight = document.documentElement.clientHeight;
+      var elemBottom     = this.elem.getBoundingClientRect().bottom;
+      maxHeight = viewportHeight - elemBottom - this._getPopupMaxHeightDetectPad(position);
+      break;
+  }
+
+  return maxHeight;
+}
+
+RomoDropdown.prototype._getPopupMaxHeightDetectPad = function(position) {
+  return Romo.data(this.elem, 'romo-dropdown-max-height-detect-pad-'+position) || Romo.data(this.elem, 'romo-dropdown-max-height-detect-pad') || 10;
+}
+
+RomoDropdown.prototype._roundPosOffsetVal = function(value) {
+  return Math.round(value*100) / 100;
+}
+
+// event functions
+
 RomoDropdown.prototype._onToggle = function(e) {
   e.preventDefault();
 
@@ -408,35 +441,6 @@ RomoDropdown.prototype._onResizeWindow = function(e) {
   return true;
 }
 
-RomoDropdown.prototype._parsePositionData = function(posString) {
-  var posData = (posString || '').split(',');
-  return { position: posData[0], alignment: posData[1] };
-}
-
-RomoDropdown.prototype._getPopupMaxAvailableHeight = function(position) {
-  var maxHeight = undefined;
-
-  switch (position) {
-    case 'top':
-      var elemTop = this.elem.getBoundingClientRect().top;
-      maxHeight = elemTop - this._getPopupMaxHeightDetectPad(position);
-      break;
-    case 'bottom':
-      var viewportHeight = document.documentElement.clientHeight;
-      var elemBottom     = this.elem.getBoundingClientRect().bottom;
-      maxHeight = viewportHeight - elemBottom - this._getPopupMaxHeightDetectPad(position);
-      break;
-  }
-
-  return maxHeight;
-}
-
-RomoDropdown.prototype._getPopupMaxHeightDetectPad = function(position) {
-  return Romo.data(this.elem, 'romo-dropdown-max-height-detect-pad-'+position) || Romo.data(this.elem, 'romo-dropdown-max-height-detect-pad') || 10;
-}
-
-RomoDropdown.prototype._roundPosOffsetVal = function(value) {
-  return Math.round(value*100) / 100;
-}
+// init
 
 Romo.addElemsInitSelector('[data-romo-dropdown-auto="true"]', RomoDropdown);

--- a/assets/js/romo/dropdown_form.js
+++ b/assets/js/romo/dropdown_form.js
@@ -101,4 +101,8 @@ RomoDropdownForm.prototype._bindForm = function() {
   }
 }
 
+// event functions
+
+// init
+
 Romo.addElemsInitSelector('[data-romo-dropdownForm-auto="true"]', RomoDropdownForm);

--- a/assets/js/romo/form.js
+++ b/assets/js/romo/form.js
@@ -69,48 +69,6 @@ RomoForm.prototype._bindElem = function() {
   }
 }
 
-RomoForm.prototype._onSubmitClick = function(e) {
-  e.preventDefault();
-
-  var submitElem = e.target;
-  if (!Romo.hasClass(submitElem, 'disabled')) {
-    if (Romo.data(submitElem, 'romo-form-submit') === 'confirm') {
-      Romo.trigger(this.elem, 'romoForm:confirmSubmit', [this]);
-    } else {
-      this.doSubmit();
-    }
-  }
-}
-
-RomoForm.prototype._onTriggerSubmit = function() {
-  var disabled = this.submitElems.reduce(function(disabled, submitElem) {
-    return disabled || Romo.hasClass(submitElem, 'disabled');
-  }, false);
-  if (!disabled) {
-    var confirm = this.submitElems.reduce(function(confirm, submitElem) {
-      return confirm || Romo.data(submitElem, 'romo-form-submit') === 'confirm';
-    }, false);
-    if (confirm) {
-      Romo.trigger(this.elem, 'romoForm:confirmSubmit', [this]);
-    } else {
-      this.doSubmit();
-    }
-  }
-}
-
-RomoForm.prototype._onFormKeyPress = function(e) {
-  if (Romo.data(this.elem, 'romo-form-disable-keypress') !== true) {
-    var targetElem = e.target;
-    if (targetElem.nodeName.toLowerCase() !== 'textarea' && e.keyCode === 13 /* Enter */) {
-      e.preventDefault();
-      if (Romo.data(this.elem,  'romo-form-disable-enter-submit') !== true &&
-          Romo.data(targetElem, 'romo-form-disable-enter-submit') !== true) {
-        this._onTriggerSubmit();
-      }
-    }
-  }
-}
-
 RomoForm.prototype._submit = function() {
   this.submitQueued  = false;
   this.submitRunning = true;
@@ -166,38 +124,6 @@ RomoForm.prototype._ajaxSubmit = function(formValues) {
   });
 }
 
-
-RomoForm.prototype._onSubmitSuccess = function(response, status, xhr) {
-  Romo.trigger(this.elem, 'romoForm:clearMsgs');
-
-  var dataType = this._getXhrDataType();
-  Romo.trigger(
-    this.elem,
-    'romoForm:submitSuccess',
-    [(dataType === 'json' ? JSON.parse(response) : response), this]
-  );
-
-  this._completeSubmit();
-}
-
-RomoForm.prototype._onSubmitError = function(statusText, status, xhr) {
-  Romo.trigger(this.elem, 'romoForm:clearMsgs');
-
-  if(status === 422) {
-    var dataType = this._getXhrDataType();
-    Romo.trigger(
-      this.elem,
-      'romoForm:submitInvalidMsgs',
-      [(dataType === 'json' ? JSON.parse(xhr.responseText) : xhr.responseText), xhr, this]
-    );
-  } else {
-    Romo.trigger(this.elem, 'romoForm:submitXhrError', [xhr, this]);
-  }
-  Romo.trigger(this.elem, 'romoForm:submitError', [xhr, this]);
-  Romo.trigger(this.spinnerElems, 'romoSpinner:triggerStop');
-
-  this._completeSubmit();
-}
 
 RomoForm.prototype._completeSubmit = function() {
   Romo.trigger(this.elem, 'romoForm:submitComplete', [this]);
@@ -283,5 +209,83 @@ RomoForm.prototype._getXhrDataType = function() {
   var dataType = Romo.data(this.elem, 'romo-form-xhr-data-type');
   return ((dataType === undefined) ? 'json' : dataType);
 }
+
+// event functions
+
+RomoForm.prototype._onSubmitClick = function(e) {
+  e.preventDefault();
+
+  var submitElem = e.target;
+  if (!Romo.hasClass(submitElem, 'disabled')) {
+    if (Romo.data(submitElem, 'romo-form-submit') === 'confirm') {
+      Romo.trigger(this.elem, 'romoForm:confirmSubmit', [this]);
+    } else {
+      this.doSubmit();
+    }
+  }
+}
+
+RomoForm.prototype._onTriggerSubmit = function() {
+  var disabled = this.submitElems.reduce(function(disabled, submitElem) {
+    return disabled || Romo.hasClass(submitElem, 'disabled');
+  }, false);
+  if (!disabled) {
+    var confirm = this.submitElems.reduce(function(confirm, submitElem) {
+      return confirm || Romo.data(submitElem, 'romo-form-submit') === 'confirm';
+    }, false);
+    if (confirm) {
+      Romo.trigger(this.elem, 'romoForm:confirmSubmit', [this]);
+    } else {
+      this.doSubmit();
+    }
+  }
+}
+
+RomoForm.prototype._onFormKeyPress = function(e) {
+  if (Romo.data(this.elem, 'romo-form-disable-keypress') !== true) {
+    var targetElem = e.target;
+    if (targetElem.nodeName.toLowerCase() !== 'textarea' && e.keyCode === 13 /* Enter */) {
+      e.preventDefault();
+      if (Romo.data(this.elem,  'romo-form-disable-enter-submit') !== true &&
+          Romo.data(targetElem, 'romo-form-disable-enter-submit') !== true) {
+        this._onTriggerSubmit();
+      }
+    }
+  }
+}
+
+RomoForm.prototype._onSubmitSuccess = function(response, status, xhr) {
+  Romo.trigger(this.elem, 'romoForm:clearMsgs');
+
+  var dataType = this._getXhrDataType();
+  Romo.trigger(
+    this.elem,
+    'romoForm:submitSuccess',
+    [(dataType === 'json' ? JSON.parse(response) : response), this]
+  );
+
+  this._completeSubmit();
+}
+
+RomoForm.prototype._onSubmitError = function(statusText, status, xhr) {
+  Romo.trigger(this.elem, 'romoForm:clearMsgs');
+
+  if(status === 422) {
+    var dataType = this._getXhrDataType();
+    Romo.trigger(
+      this.elem,
+      'romoForm:submitInvalidMsgs',
+      [(dataType === 'json' ? JSON.parse(xhr.responseText) : xhr.responseText), xhr, this]
+    );
+  } else {
+    Romo.trigger(this.elem, 'romoForm:submitXhrError', [xhr, this]);
+  }
+  Romo.trigger(this.elem, 'romoForm:submitError', [xhr, this]);
+  Romo.trigger(this.spinnerElems, 'romoSpinner:triggerStop');
+
+  this._completeSubmit();
+}
+
+// init
 
 Romo.addElemsInitSelector('[data-romo-form-auto="true"]', RomoForm);

--- a/assets/js/romo/indicator_text_input.js
+++ b/assets/js/romo/indicator_text_input.js
@@ -123,17 +123,6 @@ RomoIndicatorTextInput.prototype._placeIndicatorElem = function() {
   }
 }
 
-RomoIndicatorTextInput.prototype._onIndicatorClick = function(e) {
-  e.preventDefault();
-
-  if (this.elem.disabled === false) {
-    this.elem.focus();
-    Romo.trigger(this.elem, 'romoIndicatorTextInput:indicatorClick');
-  }
-}
-
-// private
-
 RomoIndicatorTextInput.prototype._getIndicatorPaddingPx = function() {
   return (
     Romo.data(this.elem, 'romo-indicator-text-input-indicator-padding-px') ||
@@ -154,5 +143,18 @@ RomoIndicatorTextInput.prototype._getIndicatorPosition = function() {
     this.defaultIndicatorPosition
   );
 }
+
+// event functions
+
+RomoIndicatorTextInput.prototype._onIndicatorClick = function(e) {
+  e.preventDefault();
+
+  if (this.elem.disabled === false) {
+    this.elem.focus();
+    Romo.trigger(this.elem, 'romoIndicatorTextInput:indicatorClick');
+  }
+}
+
+// init
 
 Romo.addElemsInitSelector('[data-romo-indicator-text-input-auto="true"]', RomoIndicatorTextInput);

--- a/assets/js/romo/inline.js
+++ b/assets/js/romo/inline.js
@@ -71,6 +71,8 @@ RomoInline.prototype._loadError = function(xhr) {
   Romo.trigger(this.elem, 'romoInline:loadError', [xhr, this]);
 }
 
+// event functions
+
 RomoInline.prototype._onDismissClick = function(e) {
   e.preventDefault();
 
@@ -88,5 +90,7 @@ RomoInline.prototype._onDismissClick = function(e) {
     }
   }
 }
+
+// init
 
 Romo.addElemsInitSelector('[data-romo-inline-auto="true"]', RomoInline);

--- a/assets/js/romo/inline_form.js
+++ b/assets/js/romo/inline_form.js
@@ -97,4 +97,8 @@ RomoInlineForm.prototype._bindForm = function() {
   }
 }
 
+// event functions
+
+// init
+
 Romo.addElemsInitSelector('[data-romo-inlineForm-auto="true"]', RomoInlineForm);

--- a/assets/js/romo/modal.js
+++ b/assets/js/romo/modal.js
@@ -263,6 +263,47 @@ RomoModal.prototype._loadBodyError = function(xhr) {
   Romo.trigger(this.elem, 'romoModal:loadBodyError', [xhr, this]);
 }
 
+RomoModal.prototype._dragStart = function(e) {
+  Romo.addClass(this.dragElems, 'romo-modal-grabbing');
+  Romo.removeClass(this.dragElems, 'romo-modal-grab');
+
+  Romo.setStyle(this.popupElem, 'width',  Romo.css(this.popupElem, 'width'));
+  Romo.setStyle(this.popupElem, 'height', Romo.css(this.popupElem, 'height'));
+
+  this._dragDiffX = e.clientX - this.popupElem.offsetLeft;
+  this._dragDiffY = e.clientY - this.popupElem.offsetTop;
+  Romo.on(window, 'mousemove', Romo.proxy(this._onMouseMove, this));
+  Romo.on(window, 'mouseup',   Romo.proxy(this._onMouseUp,   this));
+
+  Romo.trigger(this.elem, "romoModal:dragStart", [this]);
+}
+
+RomoModal.prototype._dragMove = function(clientX, clientY) {
+  var placeX = clientX - this._dragDiffX;
+  var placeY = clientY - this._dragDiffY;
+  Romo.setStyle(this.popupElem, 'left', placeX+'px');
+  Romo.setStyle(this.popupElem, 'top',  placeY+'px');
+
+  Romo.trigger(this.elem, "romoModal:dragMove", [placeX, placeY, this]);
+}
+
+RomoModal.prototype._dragStop = function(e) {
+  Romo.addClass(this.dragElems, 'romo-modal-grab');
+  Romo.removeClass(this.dragElems, 'romo-modal-grabbing');
+
+  Romo.rmStyle(this.popupElem, 'width');
+  Romo.rmStyle(this.popupElem, 'height');
+
+  Romo.off(window, 'mousemove', Romo.proxy(this._onMouseMove, this));
+  Romo.off(window, 'mouseup',   Romo.proxy(this._onMouseUp, this));
+  delete this._dragDiffX;
+  delete this._dragDiffY;
+
+  Romo.trigger(this.elem, "romoModal:dragStop", [this]);
+}
+
+// event functions
+
 RomoModal.prototype._onToggle = function(e) {
   e.preventDefault();
 
@@ -288,54 +329,15 @@ RomoModal.prototype._onMouseDown = function(e) {
   return false;
 }
 
-RomoModal.prototype._dragStart = function(e) {
-  Romo.addClass(this.dragElems, 'romo-modal-grabbing');
-  Romo.removeClass(this.dragElems, 'romo-modal-grab');
-
-  Romo.setStyle(this.popupElem, 'width',  Romo.css(this.popupElem, 'width'));
-  Romo.setStyle(this.popupElem, 'height', Romo.css(this.popupElem, 'height'));
-
-  this._dragDiffX = e.clientX - this.popupElem.offsetLeft;
-  this._dragDiffY = e.clientY - this.popupElem.offsetTop;
-  Romo.on(window, 'mousemove', Romo.proxy(this._onMouseMove, this));
-  Romo.on(window, 'mouseup',   Romo.proxy(this._onMouseUp,   this));
-
-  Romo.trigger(this.elem, "romoModal:dragStart", [this]);
-}
-
 RomoModal.prototype._onMouseMove = function(e) {
   Romo.trigger(Romo.f('body')[0], 'romoModal:mousemove');
   this._dragMove(e.clientX, e.clientY);
   return false;
 }
 
-RomoModal.prototype._dragMove = function(clientX, clientY) {
-  var placeX = clientX - this._dragDiffX;
-  var placeY = clientY - this._dragDiffY;
-  Romo.setStyle(this.popupElem, 'left', placeX+'px');
-  Romo.setStyle(this.popupElem, 'top',  placeY+'px');
-
-  Romo.trigger(this.elem, "romoModal:dragMove", [placeX, placeY, this]);
-}
-
 RomoModal.prototype._onMouseUp = function(e) {
   this._dragStop(e);
   return false;
-}
-
-RomoModal.prototype._dragStop = function(e) {
-  Romo.addClass(this.dragElems, 'romo-modal-grab');
-  Romo.removeClass(this.dragElems, 'romo-modal-grabbing');
-
-  Romo.rmStyle(this.popupElem, 'width');
-  Romo.rmStyle(this.popupElem, 'height');
-
-  Romo.off(window, 'mousemove', Romo.proxy(this._onMouseMove, this));
-  Romo.off(window, 'mouseup',   Romo.proxy(this._onMouseUp, this));
-  delete this._dragDiffX;
-  delete this._dragDiffY;
-
-  Romo.trigger(this.elem, "romoModal:dragStop", [this]);
 }
 
 RomoModal.prototype._onElemKeyUp = function(e) {
@@ -374,5 +376,7 @@ RomoModal.prototype._onResizeWindow = function(e) {
   this.doPlacePopupElem();
   return true;
 }
+
+// init
 
 Romo.addElemsInitSelector('[data-romo-modal-auto="true"]', RomoModal);

--- a/assets/js/romo/modal_form.js
+++ b/assets/js/romo/modal_form.js
@@ -110,4 +110,8 @@ RomoModalForm.prototype._bindForm = function() {
   }
 }
 
+// event functions
+
+// init
+
 Romo.addElemsInitSelector('[data-romo-modalForm-auto="true"]', RomoModalForm);

--- a/assets/js/romo/onkey.js
+++ b/assets/js/romo/onkey.js
@@ -19,12 +19,6 @@ RomoOnkey.prototype.doInit = function() {
 
 // private
 
-RomoOnkey.prototype._onTrigger = function(e) {
-  if (Romo.hasClass(this.elem, 'disabled') === false) {
-    this._doTrigger(e);
-  }
-}
-
 RomoOnkey.prototype._doTrigger = function(triggerEvent) {
   clearTimeout(this.delayTimeout);
   this.delayTimeout = setTimeout(
@@ -34,5 +28,15 @@ RomoOnkey.prototype._doTrigger = function(triggerEvent) {
     Romo.data(this.elem, 'romo-onkey-delay-ms') || this.defaultDelayMs
   );
 }
+
+// event functions
+
+RomoOnkey.prototype._onTrigger = function(e) {
+  if (Romo.hasClass(this.elem, 'disabled') === false) {
+    this._doTrigger(e);
+  }
+}
+
+// init
 
 Romo.addElemsInitSelector('[data-romo-onkey-auto="true"]', RomoOnkey);

--- a/assets/js/romo/option_list_dropdown.js
+++ b/assets/js/romo/option_list_dropdown.js
@@ -384,116 +384,6 @@ RomoOptionListDropdown.prototype._selectHighlightedItem = function() {
   }
 }
 
-RomoOptionListDropdown.prototype._onPopupOpen = function(e) {
-  if (Romo.hasClass(this.elem, 'disabled') === false) {
-    this._highlightItem(this.selectedItemElem());
-    this._scrollTopToItem(this.selectedItemElem());
-  }
-  Romo.on(Romo.f('body')[0], 'keydown', Romo.proxy(this._onPopupOpenBodyKeyDown, this));
-}
-
-RomoOptionListDropdown.prototype._onPopupClose = function(e) {
-  this._highlightItem(undefined);
-  Romo.off(Romo.f('body')[0], 'keydown', Romo.proxy(this._onPopupOpenBodyKeyDown, this));
-}
-
-RomoOptionListDropdown.prototype._onItemEnter = function(e) {
-  this._highlightItem(e.target);
-  return false;
-}
-
-RomoOptionListDropdown.prototype._onItemClick = function(e) {
-  if (this.blurTimeoutId !== undefined) {
-    clearTimeout(this.blurTimeoutId);
-    this.blurTimeoutId = undefined;
-  }
-  this._selectHighlightedItem();
-  return false;
-}
-
-RomoOptionListDropdown.prototype._onPopupMouseDown = function(e) {
-  this.popupMouseDown = true;
-}
-
-RomoOptionListDropdown.prototype._onPopupMouseUp = function(e) {
-  this.popupMouseDown = false;
-}
-
-RomoOptionListDropdown.prototype._onPopupOpenBodyKeyDown = function(e) {
-  e.stopPropagation();
-
-  var scrollElem   = this.romoDropdown.bodyElem;
-  var scrollOffset = Romo.offset(scrollElem);
-  var scrollHeight = parseInt(Romo.css(scrollElem, 'height'), 10);
-
-  if (e.keyCode === 38 /* Up */) {
-    var prevElem = this._prevListItem();
-    if(prevElem === undefined){ return false; }
-
-    var prevOffset = Romo.offset(prevElem);
-
-    this._highlightItem(prevElem);
-
-    if (scrollOffset.top > prevOffset.top) {
-      this._scrollTopToItem(prevElem);
-    } else if ((scrollOffset.top + scrollHeight) < prevOffset.top) {
-      this._scrollTopToItem(prevElem);
-    }
-
-    return false;
-  } else if(e.keyCode === 40 /* Down */) {
-    var nextElem = this._nextListItem();
-    if(nextElem === undefined){ return false; }
-
-    var nextOffset = Romo.offset(nextElem);
-    var nextHeight = parseInt(Romo.css(nextElem, 'height'), 10);
-
-    this._highlightItem(nextElem);
-
-    if ((scrollOffset.top + scrollHeight) < (nextOffset.top + nextHeight)) {
-      this._scrollBottomToItem(nextElem);
-    } else if (scrollOffset.top > nextOffset.top) {
-      this._scrollTopToItem(nextElem);
-    }
-
-    return false;
-  } else if (e.keyCode === 13 /* Enter */ ) {
-    this._selectHighlightedItem();
-    return false;
-  } else if (e.keyCode === 9 /* Tab */ ) {
-    e.preventDefault();
-    return false;
-  } else {
-    return true;
-  }
-}
-
-RomoOptionListDropdown.prototype._onElemKeyDown = function(e) {
-  if (Romo.hasClass(this.elem, 'disabled') === false) {
-    if (this.romoDropdown.popupClosed()) {
-      if (e.keyCode === 40 /* Down */  || e.keyCode === 38 /* Up */) {
-        this.romoDropdown.doPopupOpen();
-        return false;
-      } else if (this.optionFilterElem !== undefined &&
-                 Romo.nonInputTextKeyCodes().indexOf(e.keyCode) === -1 /* Input Text */)  {
-        // don't prevent default on Cmd-* keys (preserve Cmd-R refresh, etc)
-        if (e.metaKey === false) {
-          e.preventDefault();
-          if (e.keyCode !== 8) { /* Backspace */
-            this.optionFilterElem.value = e.key;
-          }
-          this.romoDropdown.doPopupOpen();
-        }
-        e.stopPropagation();
-        return true;
-      } else {
-        return true;
-      }
-    }
-  }
-  return true;
-}
-
 RomoOptionListDropdown.prototype._scrollTopToItem = function(itemElem) {
   if (itemElem !== undefined) {
     var scrollElem = this.romoDropdown.bodyElem;
@@ -618,5 +508,119 @@ RomoOptionListDropdown.prototype._highlightItem = function(itemElem) {
 RomoOptionListDropdown.prototype._getHighlightedItemElem = function() {
   return Romo.find(this.romoDropdown.bodyElem, 'LI.romo-option-list-dropdown-highlight')[0];
 }
+
+// event functions
+
+RomoOptionListDropdown.prototype._onPopupOpen = function(e) {
+  if (Romo.hasClass(this.elem, 'disabled') === false) {
+    this._highlightItem(this.selectedItemElem());
+    this._scrollTopToItem(this.selectedItemElem());
+  }
+  Romo.on(Romo.f('body')[0], 'keydown', Romo.proxy(this._onPopupOpenBodyKeyDown, this));
+}
+
+RomoOptionListDropdown.prototype._onPopupClose = function(e) {
+  this._highlightItem(undefined);
+  Romo.off(Romo.f('body')[0], 'keydown', Romo.proxy(this._onPopupOpenBodyKeyDown, this));
+}
+
+RomoOptionListDropdown.prototype._onItemEnter = function(e) {
+  this._highlightItem(e.target);
+  return false;
+}
+
+RomoOptionListDropdown.prototype._onItemClick = function(e) {
+  if (this.blurTimeoutId !== undefined) {
+    clearTimeout(this.blurTimeoutId);
+    this.blurTimeoutId = undefined;
+  }
+  this._selectHighlightedItem();
+  return false;
+}
+
+RomoOptionListDropdown.prototype._onPopupMouseDown = function(e) {
+  this.popupMouseDown = true;
+}
+
+RomoOptionListDropdown.prototype._onPopupMouseUp = function(e) {
+  this.popupMouseDown = false;
+}
+
+RomoOptionListDropdown.prototype._onPopupOpenBodyKeyDown = function(e) {
+  e.stopPropagation();
+
+  var scrollElem   = this.romoDropdown.bodyElem;
+  var scrollOffset = Romo.offset(scrollElem);
+  var scrollHeight = parseInt(Romo.css(scrollElem, 'height'), 10);
+
+  if (e.keyCode === 38 /* Up */) {
+    var prevElem = this._prevListItem();
+    if(prevElem === undefined){ return false; }
+
+    var prevOffset = Romo.offset(prevElem);
+
+    this._highlightItem(prevElem);
+
+    if (scrollOffset.top > prevOffset.top) {
+      this._scrollTopToItem(prevElem);
+    } else if ((scrollOffset.top + scrollHeight) < prevOffset.top) {
+      this._scrollTopToItem(prevElem);
+    }
+
+    return false;
+  } else if(e.keyCode === 40 /* Down */) {
+    var nextElem = this._nextListItem();
+    if(nextElem === undefined){ return false; }
+
+    var nextOffset = Romo.offset(nextElem);
+    var nextHeight = parseInt(Romo.css(nextElem, 'height'), 10);
+
+    this._highlightItem(nextElem);
+
+    if ((scrollOffset.top + scrollHeight) < (nextOffset.top + nextHeight)) {
+      this._scrollBottomToItem(nextElem);
+    } else if (scrollOffset.top > nextOffset.top) {
+      this._scrollTopToItem(nextElem);
+    }
+
+    return false;
+  } else if (e.keyCode === 13 /* Enter */ ) {
+    this._selectHighlightedItem();
+    return false;
+  } else if (e.keyCode === 9 /* Tab */ ) {
+    e.preventDefault();
+    return false;
+  } else {
+    return true;
+  }
+}
+
+RomoOptionListDropdown.prototype._onElemKeyDown = function(e) {
+  if (Romo.hasClass(this.elem, 'disabled') === false) {
+    if (this.romoDropdown.popupClosed()) {
+      if (e.keyCode === 40 /* Down */  || e.keyCode === 38 /* Up */) {
+        this.romoDropdown.doPopupOpen();
+        return false;
+      } else if (this.optionFilterElem !== undefined &&
+                 Romo.nonInputTextKeyCodes().indexOf(e.keyCode) === -1 /* Input Text */)  {
+        // don't prevent default on Cmd-* keys (preserve Cmd-R refresh, etc)
+        if (e.metaKey === false) {
+          e.preventDefault();
+          if (e.keyCode !== 8) { /* Backspace */
+            this.optionFilterElem.value = e.key;
+          }
+          this.romoDropdown.doPopupOpen();
+        }
+        e.stopPropagation();
+        return true;
+      } else {
+        return true;
+      }
+    }
+  }
+  return true;
+}
+
+// init
 
 Romo.addElemsInitSelector('[data-romo-option-list-dropdown-auto="true"]', RomoOptionListDropdown);

--- a/assets/js/romo/picker.js
+++ b/assets/js/romo/picker.js
@@ -370,13 +370,6 @@ RomoPicker.prototype._refreshUI = function() {
   }
 }
 
-RomoPicker.prototype._onCaretClick = function(e) {
-  if (this.elem.disabled === false) {
-    this.romoOptionListDropdown.doFocus();
-    Romo.trigger(this.elem, 'romoPicker:triggerPopupOpen');
-  }
-}
-
 RomoPicker.prototype._getCaretPaddingPx = function() {
   return (
     Romo.data(this.elem, 'romo-picker-caret-padding-px') ||
@@ -397,5 +390,16 @@ RomoPicker.prototype._getCaretPosition = function() {
     this.defaultCaretPosition
   );
 }
+
+// event functions
+
+RomoPicker.prototype._onCaretClick = function(e) {
+  if (this.elem.disabled === false) {
+    this.romoOptionListDropdown.doFocus();
+    Romo.trigger(this.elem, 'romoPicker:triggerPopupOpen');
+  }
+}
+
+// init
 
 Romo.addElemsInitSelector('[data-romo-picker-auto="true"]', RomoPicker);

--- a/assets/js/romo/select.js
+++ b/assets/js/romo/select.js
@@ -301,13 +301,6 @@ RomoSelect.prototype._refreshUI = function() {
   }
 }
 
-RomoSelect.prototype._onCaretClick = function(e) {
-  if (this.elem.disabled === false) {
-    this.romoSelectDropdown.doFocus();
-    Romo.trigger(this.elem, 'romoSelect:triggerPopupOpen');
-  }
-}
-
 RomoSelect.prototype._getCaretPaddingPx = function() {
   return (
     Romo.data(this.elem, 'romo-select-caret-padding-px') ||
@@ -328,5 +321,16 @@ RomoSelect.prototype._getCaretPosition = function() {
     this.defaultCaretPosition
   );
 }
+
+// event functions
+
+RomoSelect.prototype._onCaretClick = function(e) {
+  if (this.elem.disabled === false) {
+    this.romoSelectDropdown.doFocus();
+    Romo.trigger(this.elem, 'romoSelect:triggerPopupOpen');
+  }
+}
+
+// init
 
 Romo.addElemsInitSelector('[data-romo-select-auto="true"]', RomoSelect);

--- a/assets/js/romo/select_dropdown.js
+++ b/assets/js/romo/select_dropdown.js
@@ -253,4 +253,8 @@ RomoSelectDropdown.prototype._buildCustomOptionItem = function(value) {
   };
 }
 
+// event functions
+
+// init
+
 Romo.addElemsInitSelector('[data-romo-select-dropdown-auto="true"]', RomoSelectDropdown);

--- a/assets/js/romo/selected_options_list.js
+++ b/assets/js/romo/selected_options_list.js
@@ -128,17 +128,6 @@ RomoSelectedOptionsList.prototype._getItemValues = function() {
   return this.items.map(function(item) { return item.value; });
 }
 
-RomoSelectedOptionsList.prototype._onItemClick = function(e) {
-  var itemElem = e.target;
-  if (!Romo.hasClass(itemElem, 'romo-selected-options-list-item')) {
-    var itemElem = Romo.closest(itemElem, '.romo-selected-options-list-item');
-  }
-  if (itemElem !== undefined) {
-    var value = Romo.data(itemElem, 'romo-selected-options-list-value');
-    Romo.trigger(this.elem, 'romoSelectedOptionsList:itemClick', [value, this]);
-  }
-}
-
 RomoSelectedOptionsList.prototype._scrollListTopToItem = function(itemElem) {
   if (itemElem !== undefined) {
     var scrollElem = this.elem;
@@ -149,5 +138,18 @@ RomoSelectedOptionsList.prototype._scrollListTopToItem = function(itemElem) {
     var selOffset       = parseInt(Romo.css(itemElem, 'height'), 10) / 2;
 
     scrollElem.scrollTop = selOffsetTop - scrollOffsetTop - selOffset;
+  }
+}
+
+// event functions
+
+RomoSelectedOptionsList.prototype._onItemClick = function(e) {
+  var itemElem = e.target;
+  if (!Romo.hasClass(itemElem, 'romo-selected-options-list-item')) {
+    var itemElem = Romo.closest(itemElem, '.romo-selected-options-list-item');
+  }
+  if (itemElem !== undefined) {
+    var value = Romo.data(itemElem, 'romo-selected-options-list-value');
+    Romo.trigger(this.elem, 'romoSelectedOptionsList:itemClick', [value, this]);
   }
 }

--- a/assets/js/romo/sortable.js
+++ b/assets/js/romo/sortable.js
@@ -87,6 +87,18 @@ RomoSortable.prototype._bindDraggableElems = function(draggableElems) {
   this._resetGrabClasses();
 }
 
+RomoSortable.prototype._resetGrabClasses = function() {
+  this.draggableElems.forEach(Romo.proxy(function(draggableElem) {
+    handleElem = Romo.find(draggableElem, this.handleSelector)[0];
+    if(handleElem === undefined){ handleElem = draggableElem; }
+
+    Romo.addClass(handleElem, 'romo-sortable-grab');
+    Romo.removeClass(handleElem, 'romo-sortable-grabbing');
+  }, this));
+}
+
+// event functions
+
 RomoSortable.prototype._onBindDraggableElems = function(e, draggableElems) {
   this._bindDraggableElems(draggableElems);
 }
@@ -259,14 +271,6 @@ RomoSortable.prototype._onWindowBodyMouseUp = function(e) {
   this._resetGrabClasses();
 }
 
-RomoSortable.prototype._resetGrabClasses = function() {
-  this.draggableElems.forEach(Romo.proxy(function(draggableElem) {
-    handleElem = Romo.find(draggableElem, this.handleSelector)[0];
-    if(handleElem === undefined){ handleElem = draggableElem; }
-
-    Romo.addClass(handleElem, 'romo-sortable-grab');
-    Romo.removeClass(handleElem, 'romo-sortable-grabbing');
-  }, this));
-}
+// init
 
 Romo.addElemsInitSelector('[data-romo-sortable-auto="true"]', RomoSortable);

--- a/assets/js/romo/spinner.js
+++ b/assets/js/romo/spinner.js
@@ -87,6 +87,8 @@ RomoSpinner.prototype._bindElem = function() {
   }
 }
 
+// event functions
+
 RomoSpinner.prototype._onStart = function(e, basisSize) {
   this.doStart(basisSize);
 }
@@ -94,5 +96,7 @@ RomoSpinner.prototype._onStart = function(e, basisSize) {
 RomoSpinner.prototype._onStop = function(e) {
   this.doStop();
 }
+
+// init
 
 Romo.addElemsInitSelector('[data-romo-spinner-auto="true"]', RomoSpinner);

--- a/assets/js/romo/tooltip.js
+++ b/assets/js/romo/tooltip.js
@@ -271,6 +271,43 @@ RomoTooltip.prototype._loadBodyError = function(xhr) {
   Romo.trigger(this.elem, 'romoTooltip:loadBodyError', [xhr, this]);
 }
 
+RomoTooltip.prototype._getPopupMaxAvailableHeight = function(position) {
+  var maxHeight = undefined;
+
+  switch (position) {
+    case 'top':
+      var elemTop = this.elem.getBoundingClientRect().top;
+      maxHeight = elemTop - this._getPopupMaxHeightDetectPad(position);
+      break;
+    case 'bottom':
+      var viewportHeight = document.documentElement.clientHeight;
+      var elemBottom     = this.elem.getBoundingClientRect().bottom;
+      maxHeight = viewportHeight - elemBottom - this._getPopupMaxHeightDetectPad(position);
+      break;
+  }
+
+  return maxHeight;
+}
+
+RomoTooltip.prototype._getPopupMaxHeightDetectPad = function(position) {
+  return (
+    Romo.data(this.elem, 'romo-tooltip-max-height-detect-pad-'+position) ||
+    Romo.data(this.elem, 'romo-tooltip-max-height-detect-pad')           ||
+    10
+  );
+}
+
+RomoTooltip.prototype._setBodyHtml = function(content) {
+  var contentElems = Romo.elems(content);
+  if (contentElems.length !== 0) {
+    Romo.update(this.bodyElem, contentElems);
+  } else {
+    Romo.updateText(this.bodyElem, content || '');
+  }
+}
+
+// event functions
+
 RomoTooltip.prototype._onToggleEnter = function(e) {
   this.hoverState = 'in';
   if (Romo.hasClass(this.elem, 'disabled') === false) {
@@ -322,39 +359,6 @@ RomoTooltip.prototype._onResizeWindow = function(e) {
   return true;
 }
 
-RomoTooltip.prototype._getPopupMaxAvailableHeight = function(position) {
-  var maxHeight = undefined;
-
-  switch (position) {
-    case 'top':
-      var elemTop = this.elem.getBoundingClientRect().top;
-      maxHeight = elemTop - this._getPopupMaxHeightDetectPad(position);
-      break;
-    case 'bottom':
-      var viewportHeight = document.documentElement.clientHeight;
-      var elemBottom     = this.elem.getBoundingClientRect().bottom;
-      maxHeight = viewportHeight - elemBottom - this._getPopupMaxHeightDetectPad(position);
-      break;
-  }
-
-  return maxHeight;
-}
-
-RomoTooltip.prototype._getPopupMaxHeightDetectPad = function(position) {
-  return (
-    Romo.data(this.elem, 'romo-tooltip-max-height-detect-pad-'+position) ||
-    Romo.data(this.elem, 'romo-tooltip-max-height-detect-pad')           ||
-    10
-  );
-}
-
-RomoTooltip.prototype._setBodyHtml = function(content) {
-  var contentElems = Romo.elems(content);
-  if (contentElems.length !== 0) {
-    Romo.update(this.bodyElem, contentElems);
-  } else {
-    Romo.updateText(this.bodyElem, content || '');
-  }
-}
+// init
 
 Romo.addElemsInitSelector('[data-romo-tooltip-auto="true"]', RomoTooltip);


### PR DESCRIPTION
This is prep for reworking the event handler functions using a
new event function and component API.  This api will allow having
event handler functions that are specific to instances of
components.  This makes them safe to use with `Romo.off` calls.
Only the instance's function will unbound, not all components.

This just reorganizes the event handler functions so they are all
at the bottom of their component files.  I don't want the noise
of this to affect the diff when I apply the new API in a coming
effort.

@jcredding ready for review.