### PR TITLE
add API for defining RomoComponents

### DIFF
--- a/assets/js/romo/base.js
+++ b/assets/js/romo/base.js
@@ -1,5 +1,4 @@
-var Romo = function() {
-}
+var Romo = function() {}
 
 Romo.prototype.doInit = function() {
   this.parentChildElems = new RomoParentChildElems();
@@ -879,6 +878,28 @@ Romo.prototype._elemsInitTrigger = function(onElems) {
 Romo.prototype._elemsInitFind = function(onElems, selector) {
   var elems = onElems.filter(function(onElem){ return Romo.is(onElem, selector); });
   return elems.concat(Romo.find(onElems, selector));;
+}
+
+// RomoComponent
+
+var RomoComponent = function(constructorFn) {
+  var component = function() {
+    RomoComponent.addEventFunctions(this);
+    constructorFn.apply(this, arguments);
+  }
+  component.prototype.romoEvFn = {};
+  component.prototype.doInit = function() {} // override as needed
+  return component;
+}
+
+RomoComponent.addEventFunctions = function(klassInstance) {
+  for(var name in klassInstance.romoEvFn) {
+    klassInstance[name] = RomoComponent.eventProxyFn(klassInstance.romoEvFn[name]);
+  }
+}
+
+RomoComponent.eventProxyFn = function(fn) {
+  return function(){ fn.apply(this, arguments); };
 }
 
 // RomoParentChildElems

--- a/assets/js/romo/dropdown.js
+++ b/assets/js/romo/dropdown.js
@@ -1,11 +1,11 @@
-var RomoDropdown = function(elem) {
+var RomoDropdown = RomoComponent(function(elem) {
   this.elem = elem;
 
   this.doInit();
   this._bindElem();
 
   Romo.trigger(this.elem, 'romoDropdown:ready', [this]);
-}
+});
 
 RomoDropdown.prototype.popupOpen = function() {
   return Romo.hasClass(this.popupElem, 'romo-dropdown-open') === true;
@@ -13,10 +13,6 @@ RomoDropdown.prototype.popupOpen = function() {
 
 RomoDropdown.prototype.popupClosed = function() {
   return Romo.hasClass(this.popupElem, 'romo-dropdown-open') === false;
-}
-
-RomoDropdown.prototype.doInit = function() {
-  // override as needed
 }
 
 RomoDropdown.prototype.doToggle = function() {
@@ -369,7 +365,7 @@ RomoDropdown.prototype._roundPosOffsetVal = function(value) {
 
 // event functions
 
-RomoDropdown.prototype._onToggle = function(e) {
+RomoDropdown.prototype.romoEvFn._onToggle = function(e) {
   e.preventDefault();
 
   if (
@@ -380,19 +376,19 @@ RomoDropdown.prototype._onToggle = function(e) {
   }
 }
 
-RomoDropdown.prototype._onPopupOpen = function(e) {
+RomoDropdown.prototype.romoEvFn._onPopupOpen = function(e) {
   if (Romo.hasClass(this.elem, 'disabled') === false && this.popupClosed()) {
     setTimeout(Romo.proxy(this.doPopupOpen, this), 1);
   }
 }
 
-RomoDropdown.prototype._onPopupClose = function(e) {
+RomoDropdown.prototype.romoEvFn._onPopupClose = function(e) {
   if (Romo.hasClass(this.elem, 'disabled') === false && this.popupOpen()) {
     setTimeout(Romo.proxy(this.doPopupClose, this), 1);
   }
 }
 
-RomoDropdown.prototype._onElemKeyUp = function(e) {
+RomoDropdown.prototype.romoEvFn._onElemKeyUp = function(e) {
   if (Romo.hasClass(this.elem, 'disabled') === false) {
     if (this.popupOpen()) {
       if(e.keyCode === 27 /* Esc */ ) {
@@ -409,7 +405,7 @@ RomoDropdown.prototype._onElemKeyUp = function(e) {
   return true;
 }
 
-RomoDropdown.prototype._onWindowBodyClick = function(e) {
+RomoDropdown.prototype.romoEvFn._onWindowBodyClick = function(e) {
   // if not clicked on the popup elem or the elem
   if (e !== undefined) {
     var parentPopupElems = Romo.parents(e.target, '.romo-dropdown-popup');
@@ -428,7 +424,7 @@ RomoDropdown.prototype._onWindowBodyClick = function(e) {
   return true;
 }
 
-RomoDropdown.prototype._onWindowBodyKeyUp = function(e) {
+RomoDropdown.prototype.romoEvFn._onWindowBodyKeyUp = function(e) {
   if (e.keyCode === 27 /* Esc */) {
     this.doPopupClose();
     Romo.trigger(this.elem, 'romoDropdown:popupClosedByEsc', [this]);
@@ -436,7 +432,7 @@ RomoDropdown.prototype._onWindowBodyKeyUp = function(e) {
   return true;
 }
 
-RomoDropdown.prototype._onResizeWindow = function(e) {
+RomoDropdown.prototype.romoEvFn._onResizeWindow = function(e) {
   this.doPlacePopupElem();
   return true;
 }


### PR DESCRIPTION
This is a new class that commonizes logic that should be available
to all romo component objects.  This includes the standard
`doInit` constructor extension function definition and a new
"event function" api.

This goal here is to reduce the boilerplate code in each component
class definition and to provide common logic needed by all
components.

The new event function api allows defining event functions that
will be unique per instance of the class (even though they are
defined in our more typical style on the component's prototype.
We are choosing to provide this UI for just functions that are
used as event handlers.  This allows them to work properly with
`Romo.off` making it so you can unbind a single instances event
handler (when there are multiple on the page.

This new API is especially useful for dropdowns as it can be
common to have dropdowns open other dropdowns or have multiple
on the page at once.  Being able to unbind a single instances
event handler is powerful for these components.  It is similarly
powerful, although less commonly needed, for modals as well.

This includes the base API changes plus reworks to the dropdown
component for evaluation.  If we like this API, I'll update the
other components in a follow-up effort.

@jcredding ready for review