### PR TITLE
add a RomoPopupStack helper for managing modal/dropdown/etc popups

### DIFF
--- a/assets/js/romo/tooltip.js
+++ b/assets/js/romo/tooltip.js
@@ -26,8 +26,8 @@ RomoTooltip.prototype.doPopupOpen = function() {
 
   if (Romo.parents(this.elem, '.romo-modal-popup').length !== 0) {
     var bodyElem = Romo.f('body')[0];
-    Romo.on(bodyElem, 'romoModal:mousemove',  Romo.proxy(this._onModalPopupChange, this));
-    Romo.on(bodyElem, 'romoModal:popupclose', Romo.proxy(this._onModalPopupChange, this));
+    Romo.on(bodyElem, 'romoModal:mousemove',       Romo.proxy(this._onModalPopupChange, this));
+    Romo.on(bodyElem, 'romoPopupStack:popupClose', Romo.proxy(this._onModalPopupChange, this));
   }
   Romo.on(window, 'resize', Romo.proxy(this._onResizeWindow, this));
 
@@ -39,8 +39,8 @@ RomoTooltip.prototype.doPopupClose = function() {
 
   if (Romo.parents(this.elem, '.romo-modal-popup').length !== 0) {
     var bodyElem = Romo.f('body')[0];
-    Romo.off(bodyElem, 'romoModal:mousemove',  Romo.proxy(this._onModalPopupChange, this));
-    Romo.off(bodyElem, 'romoModal:popupclose', Romo.proxy(this._onModalPopupChange, this));
+    Romo.off(bodyElem, 'romoModal:mousemove',       Romo.proxy(this._onModalPopupChange, this));
+    Romo.off(bodyElem, 'romoPopupStack:popupClose', Romo.proxy(this._onModalPopupChange, this));
   }
   Romo.off(window, 'resize', Romo.proxy(this._onResizeWindow, this));
 


### PR DESCRIPTION
This came out of frustration with the previous implementation.
After we updated modal/dropdown to the new Romo js API, we were
noticing a bunch of edge-case type bugs with the popups.  Things
that worked with the same implementation in jQuery were no longer
working.

The previous implementation had individual event handlers added
by each component that would test for edge-cases.  In addition,
dropdowns would manually check for being in modals and the
componenets would manually stop propagation of close events as
needed.  It was really confusing and hard to follow.

In debugging these issue, Collin had the idea to just let all
events that might close a popup get to the body and deal with it
all in one place.  This is the result of that idea.  We now init
a `RomoPopupStack` that handles off popup related events and
provides an API for the components to interact with the stack.
They use this API to add their popup elems to the stack and to
close popups as needed.  The stack implementation works nicely
b/c it is an accurate abstraction of what is going on: we stack
popup elems and close things one at a time top-down.

There were a few non-obvious things that had to be udated to get
this working:

* I had to update the do init logic a bit.  I had to make
  `Romo.popupStack` available before `Romo.doInit` is called.
  This is so components can add their style classes on eval.
  However, the stack can't be fully init unit `Romo.doInit` is
  called.  I updated `RomoParentChildElems` to be consistent.
* In addition to the popup elem, the components give functions
  for opening, closing, and placing the popups.  This allows the
  stack to fully operate the popups.  This is needed b/c we have
  to let the body process all events and get the stack in the
  appropriate stack before opening/closing popups.  For example,
  if you have a stack open and you click an elem to open a new
  dropdown on a nested popup, you first have to close the stack
  down to the nested popup before opening the new dropdown.
  Similarly, if you click a close elem on a nested popup, you
  first need to close down to that nested popup before closing the
  nested popup.  We do this be calling the functions in a timeout.
  This let's the body process all of its events first.  The place
  function is needed more for performance: we add a single event
  on window resize that places all of the popups in the stack.
  This saves from the components having to add/remove individual
  event handlers on open/close.
* I had to update the parent child elems helper to trigger events
  on each elem it removes.  This is so the popup elems can listen
  for this event and close themselves down when removed.  Without
  this, if a popup gets removed without being "closed", the stack
  is left in a bad state.
* I updated the tooltip to no longer listen for the modals popup
  close event and instead listen for a stack popup close event.
  This logic immediately closes tooltips when a modal is closed.
  Now we just close tooltips whenever *anything* in the stack is
  closed.  This is a simpler implementation and allows the logic
  to work with anything in the stack - not just modals.

@jcredding ready for review.