### PR TITLE
fix dropdown/tooltip placement in scrollable UI

### DIFF
--- a/assets/js/romo/base.js
+++ b/assets/js/romo/base.js
@@ -71,6 +71,16 @@ Romo.prototype.parents = function(childElem, selector) {
   }
 }
 
+Romo.prototype.scrollableParents = function(childElem, selector) {
+  return Romo.parents(childElem, selector).filter(function(parentElem) {
+    return (
+      Romo._overflowScrollableRegex.test(Romo.css(parentElem, 'overflow'))   ||
+      Romo._overflowScrollableRegex.test(Romo.css(parentElem, 'overflow-y')) ||
+      Romo._overflowScrollableRegex.test(Romo.css(parentElem, 'overflow-x'))
+    );
+  });
+}
+
 Romo.prototype.closest = function(fromElem, selector) {
   if (fromElem.closest) {
     return fromElem.closest(selector);
@@ -855,7 +865,8 @@ Romo.prototype._deserializeValue = function(value) {
   }
 }
 
-Romo.prototype._elemsTagNameRegEx = /<([a-z-]+)[\s\/>]+/i;
+Romo.prototype._overflowScrollableRegex = /(auto|scroll)/;
+Romo.prototype._elemsTagNameRegEx       = /<([a-z-]+)[\s\/>]+/i;
 
 Romo.prototype._elemsWrapMap = {
   'caption':  [1, "<table>",            "</table>"],
@@ -921,6 +932,7 @@ RomoPopupStack.prototype.doInit = function(styleClass) {
   Romo.on(this.bodyElem, 'click',  Romo.proxy(this._onBodyClick,    this));
   Romo.on(this.bodyElem, 'keyup',  Romo.proxy(this._onBodyKeyUp,    this));
   Romo.on(window,        'resize', Romo.proxy(this._onWindowResize, this));
+  Romo.on(window,        'scroll', Romo.proxy(this._onWindowScroll, this));
 }
 
 RomoPopupStack.prototype.addStyleClass = function(styleClass) {
@@ -955,6 +967,14 @@ RomoPopupStack.prototype.closeTo = function(popupElem) {
       this._closeTop();
     }
   }
+}
+
+RomoPopupStack.prototype.placeAllPopups = function(includingFixed) {
+  this.items.filter(function(item) {
+    return includingFixed || Romo.css(item.popupElem, 'position') !== 'fixed';
+  }).forEach(function(item){
+    item.placeFn();
+  });
 }
 
 // private
@@ -1011,7 +1031,11 @@ RomoPopupStack.prototype._onBodyKeyUp = function(e) {
 }
 
 RomoPopupStack.prototype._onWindowResize = function(e) {
-  this.items.forEach(function(item){ item.placeFn(); });
+  this.placeAllPopups(true);
+}
+
+RomoPopupStack.prototype._onWindowScroll = function(e) {
+  this.placeAllPopups();
 }
 
 // RomoParentChildElems

--- a/assets/js/romo/dropdown.js
+++ b/assets/js/romo/dropdown.js
@@ -34,6 +34,8 @@ RomoDropdown.prototype.doPopupOpen = function() {
 }
 
 RomoDropdown.prototype._openPopup = function() {
+  Romo.on(Romo.scrollableParents(this.elem), 'scroll', this._onScrollableParentsScroll);
+
   if (Romo.data(this.elem, 'romo-dropdown-content-elem') !== undefined) {
     var contentElem = Romo.elems(Romo.data(this.elem, 'romo-dropdown-content-elem'))[0];
     this._loadBodySuccess(contentElem.outerHTML);
@@ -53,6 +55,7 @@ RomoDropdown.prototype.doPopupClose = function() {
 
 RomoDropdown.prototype._closePopup = function() {
   Romo.removeClass(this.popupElem, 'romo-dropdown-open');
+  Romo.off(Romo.scrollableParents(this.elem), 'scroll', this._onScrollableParentsScroll);
 
   if (Romo.data(this.elem, 'romo-dropdown-clear-content') === true) {
     Romo.updateHtml(this.contentElem, '');
@@ -63,14 +66,7 @@ RomoDropdown.prototype._closePopup = function() {
 
 RomoDropdown.prototype.doPlacePopupElem = function() {
   var elemRect   = this.elem.getBoundingClientRect();
-  var elemOffset = undefined;
-
-  if (Romo.parents(this.elem, '.romo-modal-popup').length !== 0) {
-    Romo.setStyle(this.popupElem, 'position', 'fixed');
-    elemOffset = elemRect;
-  } else {
-    elemOffset = Romo.offset(this.elem);
-  }
+  var elemOffset = Romo.offset(this.elem);
 
   var elemHeight = elemRect.height;
   var elemWidth  = elemRect.width;
@@ -334,6 +330,10 @@ RomoDropdown.prototype.romoEvFn._onPopupClose = function(e) {
   if (Romo.hasClass(this.elem, 'disabled') === false && this.popupOpen()) {
     setTimeout(Romo.proxy(this.doPopupClose, this), 1);
   }
+}
+
+RomoDropdown.prototype.romoEvFn._onScrollableParentsScroll = function(e) {
+  Romo.popupStack.placeAllPopups();
 }
 
 // init

--- a/assets/js/romo/tooltip.js
+++ b/assets/js/romo/tooltip.js
@@ -16,6 +16,9 @@ RomoTooltip.prototype.popupClosed = function() {
 }
 
 RomoTooltip.prototype.doPopupOpen = function() {
+  var scrollParentElems = Romo.scrollableParents(this.elem).concat([window]);
+  Romo.on(scrollParentElems, 'scroll', Romo.proxy(this._onScrollableParentsScroll, this));
+
   if (this.romoAjax !== undefined) {
     this.romoAjax.doInvoke();
   } else {
@@ -24,11 +27,9 @@ RomoTooltip.prototype.doPopupOpen = function() {
   Romo.addClass(this.popupElem, 'romo-tooltip-open');
   this.doPlacePopupElem();
 
-  if (Romo.parents(this.elem, '.romo-modal-popup').length !== 0) {
-    var bodyElem = Romo.f('body')[0];
-    Romo.on(bodyElem, 'romoModal:mousemove',       Romo.proxy(this._onModalPopupChange, this));
-    Romo.on(bodyElem, 'romoPopupStack:popupClose', Romo.proxy(this._onModalPopupChange, this));
-  }
+  var bodyElem = Romo.f('body')[0];
+  Romo.on(bodyElem, 'romoModal:mousemove',       Romo.proxy(this._onModalPopupChange, this));
+  Romo.on(bodyElem, 'romoPopupStack:popupClose', Romo.proxy(this._onModalPopupChange, this));
   Romo.on(window, 'resize', Romo.proxy(this._onResizeWindow, this));
 
   Romo.trigger(this.elem, 'romoTooltip:popupOpen', [this]);
@@ -37,11 +38,12 @@ RomoTooltip.prototype.doPopupOpen = function() {
 RomoTooltip.prototype.doPopupClose = function() {
   Romo.removeClass(this.popupElem, 'romo-tooltip-open');
 
-  if (Romo.parents(this.elem, '.romo-modal-popup').length !== 0) {
-    var bodyElem = Romo.f('body')[0];
-    Romo.off(bodyElem, 'romoModal:mousemove',       Romo.proxy(this._onModalPopupChange, this));
-    Romo.off(bodyElem, 'romoPopupStack:popupClose', Romo.proxy(this._onModalPopupChange, this));
-  }
+  var scrollParentElems = Romo.scrollableParents(this.elem).concat([window]);
+  Romo.off(scrollParentElems, 'scroll', Romo.proxy(this._onScrollableParentsScroll, this));
+
+  var bodyElem = Romo.f('body')[0];
+  Romo.off(bodyElem, 'romoModal:mousemove',       Romo.proxy(this._onModalPopupChange, this));
+  Romo.off(bodyElem, 'romoPopupStack:popupClose', Romo.proxy(this._onModalPopupChange, this));
   Romo.off(window, 'resize', Romo.proxy(this._onResizeWindow, this));
 
   Romo.trigger(this.elem, 'romoTooltip:popupClose', [this]);
@@ -49,14 +51,7 @@ RomoTooltip.prototype.doPopupClose = function() {
 
 RomoTooltip.prototype.doPlacePopupElem = function() {
   var elemRect   = this.elem.getBoundingClientRect();
-  var elemOffset = undefined;
-
-  if (Romo.parents(this.elem, '.romo-modal-popup').length !== 0) {
-    Romo.setStyle(this.popupElem, 'position', 'fixed');
-    elemOffset = elemRect;
-  } else {
-    elemOffset = Romo.offset(this.elem);
-  }
+  var elemOffset = Romo.offset(this.elem);
 
   var elemHeight = elemRect.height;
   var elemWidth  = elemRect.width;
@@ -348,6 +343,10 @@ RomoTooltip.prototype.romoEvFn._onModalPopupChange = function(e) {
 
 RomoTooltip.prototype.romoEvFn._onSetContent = function(e, value) {
   this.doSetContent(value);
+}
+
+RomoTooltip.prototype.romoEvFn._onScrollableParentsScroll = function(e) {
+  this.doPopupClose();
 }
 
 RomoTooltip.prototype.romoEvFn._onResizeWindow = function(e) {


### PR DESCRIPTION
The current implementation didn't fully account for placing
popups correctly and keeping them placed correctly in UI that is
scrollable.  Previously, dropdowns/tooltips had checks to see if
they were nested in modals (which are position fixed) to make them
fixed as well.  This works for immediate child popups of modals
but doesn't work for granchild+ popups.  It also doesn't work if
the modal content overflows and can scroll.  It also doesn't work
for dropdowns/tootips in other non-modal but fixed UI.

This corrects these issues by adding more robust scroll behavior
and awaremess to dropdowns/tooltips:

* The popup stack now places all popups on both window resize and
  window scroll.  A new `placeAllPopups` function has been added
  to the stack to commonize the logic.  This method is also  aware
  of fixed popups.  By default it doesn't place fixed popups (ie
  modals).  You can,  However, you can pass in an options to force
  it to also place fixed popups.  The window resize event forces
  all popups while the scroll only places non-fixed popup.  This
  keeps modals that have been custom dragged in their custom
  position while scrolling.
* Romo base now has a `scrollableParents` method that returns all
  parents that can possibly be scrolled.  The dropdowns and
  tooltips use this method to attach scroll events to their
  scrollable parent elems.
* Tooltips now just close their popups on scroll to any of their
  scrollable parents or window.  The window has to be included
  since tooltips aren't part of the popup stack.  Closing is
  preferrable to dealing with edge-cases allowing tooltips to
  stay open and scroll as it is an equally viable behavior choice.
* Dropdowns tell the popup stack to place all popups on scroll to
  any of their scrollable parents.  Like the window scroll event
  the stack handles, this keeps the popups placed correctly as
  non window UI is scrolled.  This covers the case where a modal
  has dropdowns but also overflows its content and scrolls.

Finally, this also removes all hard-coded modal handling in the
dropdown/tooltip open popup logic.  The changes above mean that
these are no longer needed or apply whether in a modal or not.

@jcredding ready for review.