### PR TITLE
Update dropdowns/modals/tooltips to set max-height then position

### DIFF
--- a/assets/js/romo/dropdown.js
+++ b/assets/js/romo/dropdown.js
@@ -38,23 +38,12 @@ RomoDropdown.prototype.doPopupClose = function() {
 }
 
 RomoDropdown.prototype.doPlacePopupElem = function() {
-  var elemRect   = this.elem.getBoundingClientRect();
-  var elemOffset = Romo.offset(this.elem);
-
-  var elemHeight = elemRect.height;
-  var elemWidth  = elemRect.width;
-  var elemTop    = elemOffset.top;
-  var elemLeft   = elemOffset.left
-
-  var popupOffsetHeight = this.popupElem.offsetHeight;
-  var popupOffsetWidth  = this.popupElem.offsetWidth;
-
   var configHeight = Romo.data(this.elem, 'romo-dropdown-height') ||
                      Romo.data(this.elem, 'romo-dropdown-max-height');
   var configPosition = this.popupPosition;
 
   if (configHeight === 'detect') {
-    var popupHeight       = parseInt(Romo.css(this.popupElem, 'height'), 10);
+    var popupHeight       = this.popupElem.offsetHeight;
     var topAvailHeight    = this._getPopupMaxAvailableHeight('top');
     var bottomAvailHeight = this._getPopupMaxAvailableHeight('bottom');
 
@@ -71,13 +60,20 @@ RomoDropdown.prototype.doPlacePopupElem = function() {
 
     // remove any height difference between the popup and content elems
     // assumes popup height always greater than or equal to content height
-    var contentMaxHeight = configHeight - (popupOffsetHeight - this.contentElem.offsetHeight);
+    var contentMaxHeight = configHeight - (popupHeight - this.contentElem.offsetHeight);
     Romo.setStyle(this.contentElem, 'max-height', contentMaxHeight.toString() + 'px');
   }
 
-  if(popupOffsetHeight > configHeight) {
-    popupOffsetHeight = configHeight;
-  }
+  var elemRect   = this.elem.getBoundingClientRect();
+  var elemOffset = Romo.offset(this.elem);
+
+  var elemHeight = elemRect.height;
+  var elemWidth  = elemRect.width;
+  var elemTop    = elemOffset.top;
+  var elemLeft   = elemOffset.left
+
+  var popupOffsetHeight = this.popupElem.offsetHeight;
+  var popupOffsetWidth  = this.popupElem.offsetWidth;
 
   var posTop = undefined;
   switch (configPosition) {

--- a/assets/js/romo/modal.js
+++ b/assets/js/romo/modal.js
@@ -38,11 +38,23 @@ RomoModal.prototype.doPopupClose = function() {
 }
 
 RomoModal.prototype.doPlacePopupElem = function() {
+  var viewportHeight = document.documentElement.clientHeight;
+  var viewportWidth  = document.documentElement.clientWidth;
+
+  if (Romo.data(this.elem, 'romo-modal-max-height') === 'detect') {
+    var pad           = Romo.data(this.elem, 'romo-modal-max-height-detect-pad') || 10;
+    var contentTop    = this.contentElem.getBoundingClientRect().top;
+    var contentBottom = this.contentElem.getBoundingClientRect().bottom;
+    var bodyBottom    = this.bodyElem.getBoundingClientRect().bottom;
+    var padBottom     = bodyBottom - contentBottom;
+
+    var maxHeight = viewportHeight - contentTop - padBottom - pad;
+    Romo.setStyle(this.contentElem, 'max-height', maxHeight.toString() + 'px');
+  }
+
   var popupOffsetHeight = this.popupElem.offsetHeight;
   var popupOffsetWidth  = this.popupElem.offsetWidth;
   var minHeightWidth    = 75;
-  var viewportHeight    = document.documentElement.clientHeight;
-  var viewportWidth     = document.documentElement.clientWidth;
   var centerTop         = (viewportHeight / 2) - (popupOffsetHeight / 2);
   var centerLeft        = (viewportWidth  / 2) - (popupOffsetWidth / 2);
 
@@ -55,17 +67,6 @@ RomoModal.prototype.doPlacePopupElem = function() {
 
   Romo.setStyle(this.popupElem, 'top',  offsetTop + 'px');
   Romo.setStyle(this.popupElem, 'left', offsetLeft + 'px');
-
-  if (Romo.data(this.elem, 'romo-modal-max-height') === 'detect') {
-    var pad           = Romo.data(this.elem, 'romo-modal-max-height-detect-pad') || 10;
-    var contentTop    = this.contentElem.getBoundingClientRect().top;
-    var contentBottom = this.contentElem.getBoundingClientRect().bottom;
-    var bodyBottom    = this.bodyElem.getBoundingClientRect().bottom;
-    var padBottom     = bodyBottom - contentBottom;
-
-    var maxHeight = viewportHeight - contentTop - padBottom - pad;
-    Romo.setStyle(this.contentElem, 'max-height', maxHeight.toString() + 'px');
-  }
 }
 
 // private

--- a/assets/js/romo/tooltip.js
+++ b/assets/js/romo/tooltip.js
@@ -50,25 +50,12 @@ RomoTooltip.prototype.doPopupClose = function() {
 }
 
 RomoTooltip.prototype.doPlacePopupElem = function() {
-  var elemRect   = this.elem.getBoundingClientRect();
-  var elemOffset = Romo.offset(this.elem);
-
-  var elemHeight = elemRect.height;
-  var elemWidth  = elemRect.width;
-  var elemTop    = elemOffset.top;
-  var elemLeft   = elemOffset.left
-
-  var popupOffsetHeight = this.popupElem.offsetHeight;
-  var popupOffsetWidth  = this.popupElem.offsetWidth;
-
-  var pad = 6 + 1; // arrow size + spacing
-
   var configHeight = Romo.data(this.elem, 'romo-tooltip-height') ||
                      Romo.data(this.elem, 'romo-tooltip-max-height');
   var configPosition = this.popupPosition;
 
   if (configHeight === 'detect' && (configPosition === 'top' || configPosition === 'bottom')) {
-    var popupHeight       = parseInt(Romo.css(this.popupElem, 'height'), 10);
+    var popupHeight       = this.popupElem.offsetHeight;
     var topAvailHeight    = this._getPopupMaxAvailableHeight('top');
     var bottomAvailHeight = this._getPopupMaxAvailableHeight('bottom');
 
@@ -86,11 +73,20 @@ RomoTooltip.prototype.doPlacePopupElem = function() {
     Romo.setStyle(this.bodyElem, 'max-height', configHeight.toString() + 'px');
   }
 
-  Romo.setData(this.popupElem, 'romo-tooltip-arrow-position', configPosition);
+  var elemRect   = this.elem.getBoundingClientRect();
+  var elemOffset = Romo.offset(this.elem);
 
-  if(popupOffsetHeight > configHeight) {
-    popupOffsetHeight = configHeight;
-  }
+  var elemHeight = elemRect.height;
+  var elemWidth  = elemRect.width;
+  var elemTop    = elemOffset.top;
+  var elemLeft   = elemOffset.left
+
+  var popupOffsetHeight = this.popupElem.offsetHeight;
+  var popupOffsetWidth  = this.popupElem.offsetWidth;
+
+  var pad = 6 + 1; // arrow size + spacing
+
+  Romo.setData(this.popupElem, 'romo-tooltip-arrow-position', configPosition);
 
   var posTop  = undefined;
   var posLeft = undefined;


### PR DESCRIPTION
This updates dropdowns/modals/tooltips to first set their content
`max-height` and then read their height and calculate their new
position. This is to fix an issue with dropdowns not always
positioning themselves correctly particularly when their content
continously changed. This specifically happened with a picker that
because of the number of results being returned would switch from
showing its results on top to the bottom of the picker. This
caused the dropdowns to sometimes not correclty position the
results above the picker and it would instead appear ontop of the
picker (as if it was stopped while moving to the top of the
picker).

This fixes the issue by changing how dropdowns place their elem.
Now, they first handle detecting their max height, then they
re-read their new height based on the max height that was just
set on the popup content and use it to calculate their position.
This ensures the last call to `doPlacePopupElem` properly uses
the latest height of the popup elem.

This also switches to using the `offsetHeight` instead of
parsing the css height as an integer when determining the max
height for a dropdown's/tooltip's content. The offset height is
the height of the elem including padding and borders which is
the same as the css height because we use border-box box sizing.
This switches to offset height because it's simpler and doesn't
require using `parseInt`.

This also changes the modal and tooltip to do the same change
even though there wasn't an issue seen with them. This keeps all
of the components as consistent as possible so they can all make
use of any fixes found with one of the others.

@kellyredding - Ready for review.