### PR TITLE
option list dropdown: don't open on focus on clicks

### DIFF
--- a/assets/js/romo/option_list_dropdown.js
+++ b/assets/js/romo/option_list_dropdown.js
@@ -274,6 +274,12 @@ RomoOptionListDropdown.prototype._bindDropdownOptionFilter = function() {
   this.romoIndicatorTextInput = new RomoIndicatorTextInput(this.optionFilterElem);
   new RomoOnkey(this.optionFilterElem);
 
+  Romo.on(this.romoDropdown.elem, 'mousedown', Romo.proxy(function(e) {
+    // don't open on focus because this focus is from a click
+    // so the click will handle opening the popup
+    this.openOnFocus = false;
+  }, this));
+
   Romo.on(this.romoDropdown.elem, 'focus', Romo.proxy(function(e) {
     if (this.blurTimeoutId !== undefined) {
       clearTimeout(this.blurTimeoutId);


### PR DESCRIPTION
The open on focus logic caused dropdown to not open when clicked
while being closed.  The focus event triggers first and opens the
dropdown.  Then the click event triggers and toggles the dropdown
which closes it.

This fixes the bug by adding a `mousedown` event.  This event
triggers before `focus`.  On mousedown, we now always set the
open on focus state var to false as this is a click and the
click will handle opening the dropdown.

@jcredding ready for review.