### PR TITLE
restore option list dropdown focusing when closed by esc key

### DIFF
--- a/assets/js/romo/base.js
+++ b/assets/js/romo/base.js
@@ -994,10 +994,14 @@ RomoPopupStack.prototype._buildItemClass = function() {
 }
 
 RomoPopupStack.prototype._closeTop = function() {
+  var item;
   if (this.items.length > 0) {
-    this.items.pop().closeFn();
-    Romo.trigger(this.bodyElem, 'romoPopupStack:popupClose');
+    item = this.items.pop();
+    item.closeFn();
+    Romo.trigger(this.bodyElem,  'romoPopupStack:popupClose', [item.popupElem, this]);
+    Romo.trigger(item.popupElem, 'romoPopupStack:popupClose', [this]);
   }
+  return item;
 }
 
 RomoPopupStack.prototype._closeAll = function() {
@@ -1028,8 +1032,10 @@ RomoPopupStack.prototype._onBodyClick = function(e) {
 }
 
 RomoPopupStack.prototype._onBodyKeyUp = function(e) {
+  var popupElem;
   if (e.keyCode === 27 /* Esc */) {
-    this._closeTop();
+    popupElem = this._closeTop().popupElem;
+    Romo.trigger(popupElem, 'romoPopupStack:popupClosedByEsc', [this]);
   }
 }
 

--- a/assets/js/romo/dropdown.js
+++ b/assets/js/romo/dropdown.js
@@ -183,8 +183,11 @@ RomoDropdown.prototype._bindPopup = function() {
   setTimeout(Romo.proxy(function() {
     Romo.parentChildElems.add(this.elem, [this.popupElem]);
   }, this), 1);
-  Romo.on(this.popupElem, 'romoParentChildElems:childRemoved', Romo.proxy(function(childElem) {
+  Romo.on(this.popupElem, 'romoParentChildElems:childRemoved', Romo.proxy(function(e, childElem) {
     Romo.popupStack.closeThru(this.popupElem);
+  }, this));
+  Romo.on(this.popupElem, 'romoPopupStack:popupClosedByEsc', Romo.proxy(function(e, romoPopupStack) {
+    Romo.trigger(this.elem, 'romoDropdown:popupClosedByEsc', [this]);
   }, this));
 }
 

--- a/assets/js/romo/modal.js
+++ b/assets/js/romo/modal.js
@@ -132,9 +132,13 @@ RomoModal.prototype._bindPopup = function() {
   setTimeout(Romo.proxy(function() {
     Romo.parentChildElems.add(this.elem, [this.popupElem]);
   }, this), 1);
-  Romo.on(this.popupElem, 'romoParentChildElems:childRemoved', Romo.proxy(function(childElem) {
+  Romo.on(this.popupElem, 'romoParentChildElems:childRemoved', Romo.proxy(function(e, childElem) {
     Romo.popupStack.closeThru(this.popupElem);
   }, this));
+  Romo.on(this.popupElem, 'romoPopupStack:popupClosedByEsc', Romo.proxy(function(e, romoPopupStack) {
+    Romo.trigger(this.elem, 'romoModal:popupClosedByEsc', [this]);
+  }, this));
+
 }
 
 RomoModal.prototype._bindAjax = function() {


### PR DESCRIPTION
I accidentally removed this behavior when I switched to using the
new popup stack to manage popups in PR 240.  This updates the
popup stack to now emit closed by esc events that the option list
dropdown eventually can detect.  Here are some notes on the
changes and how I restored the behavior:

* I wanted the popup stack to handle this b/c it was already
  handling/detecting the esc key.  I didn't see the point in
  adding extra dropdown logic to duplicate detecting the esc key
  and emitting the original event.  Plus, if the popup stack
  handled it, all popups (dropdowns AND modals) can emit closed
  by esc events.
* I chose to emit the event from the popup stack on the popup elem
  itself.  The stack already only has the popup elem to trigger
  events on and I didn't want to add the overhead of having the
  stack know about the elem.  Plus, from the stack's point of
  view, this is a popup event.  The side-effect is that stack
  components have to catch the event and proxy it as their own.
* I updated how the stack triggers its closed event.  I updated it
  to not only trigger on the body elem (which is great for generic
  use cases) but to also trigger on the popup since, like the
  closed by esc event, this event is a popup event.
* The closed event on the body is now triggered with the popup
  elem as an arg for thoroughness.

Finally, this update the event handlers for the parent child
removed events to properly specify their event args.  This wasn't
erroring - just incorrect.

@jcredding ready for review.