### PR TITLE
Update romo ajax, don't send empty form data

### DIFF
--- a/assets/js/romo/base.js
+++ b/assets/js/romo/base.js
@@ -652,7 +652,7 @@ Romo.prototype.ajax = function(settings) {
   var httpMethod = (settings.type || 'GET').toUpperCase();
   var xhrUrl     = settings.url || window.location.toString();
   var xhrData    = settings.data ? settings.data : undefined
-  if (xhrData) {
+  if (xhrData && Object.keys(xhrData).length > 0) {
     if (httpMethod === 'GET') {
       var xhrQuery = Romo.param(xhrData);
       if (xhrQuery !== '') {
@@ -668,6 +668,8 @@ Romo.prototype.ajax = function(settings) {
       }
       xhrData = formData;
     }
+  } else {
+    xhrData = undefined;
   }
 
   var xhr = new XMLHttpRequest();


### PR DESCRIPTION
This updates the `Romo.ajax` function to check if the xhr data
it was passed is empty and if so the function won't try to use
it to build a query string or build a `FormData`. This
specifically fixes an issue with a `POST` sending empty `FormData`
and an HTTP server erroring because the request was invalid but
this also avoids attempting unnecessary logic to build a query
string that isn't needed.

Note: The error with sending empty `FormData` was only seen with
`POST` requests but didn't occur with `PUT` or `DELETE` requests.

@kellyredding - Ready for review.