### PR TITLE
make add child elems to parents always run in a pushFn call

### DIFF
--- a/assets/js/romo/base.js
+++ b/assets/js/romo/base.js
@@ -1078,7 +1078,12 @@ RomoParentChildElems.prototype.doInit = function(parentElem, childElems) {
 }
 
 RomoParentChildElems.prototype.add = function(parentElem, childElems) {
-  Romo.setData(parentElem, this.attrName, this._push(childElems, Romo.data(parentElem, this.attrName)));
+  // delay adding b/c the parent elem may be manipulated in the DOM resulting in the parent elem
+  // being removed and then re-added to the DOM.  if the child elems are associated immediately,
+  // any "remove" from DOM manipulation would incorrectly remove the popup.
+  Romo.pushFn(Romo.proxy(function() {
+    Romo.setData(parentElem, this.attrName, this._push(childElems, Romo.data(parentElem, this.attrName)));
+  }, this));
 }
 
 RomoParentChildElems.prototype.remove = function(elemNode) {

--- a/assets/js/romo/dropdown.js
+++ b/assets/js/romo/dropdown.js
@@ -175,14 +175,7 @@ RomoDropdown.prototype._bindPopup = function() {
 
   this.doSetPopupZIndex(this.elem);
 
-  // the popup should be treated like a child elem.  add it to Romo's
-  // parent-child elems so it will be removed when the elem is removed.
-  // delay adding it b/c other components may `append` generated dropdowns
-  // meaning the dropdown is removed and then re-added.  if added immediately
-  // the "remove" part will incorrectly remove the popup.
-  Romo.pushFn(Romo.proxy(function() {
-    Romo.parentChildElems.add(this.elem, [this.popupElem]);
-  }, this));
+  Romo.parentChildElems.add(this.elem, [this.popupElem]);
   Romo.on(this.popupElem, 'romoParentChildElems:childRemoved', Romo.proxy(function(e, childElem) {
     Romo.popupStack.closeThru(this.popupElem);
   }, this));

--- a/assets/js/romo/indicator_text_input.js
+++ b/assets/js/romo/indicator_text_input.js
@@ -41,15 +41,7 @@ RomoIndicatorTextInput.prototype._bindElem = function() {
 
   Romo.before(this.elem, elemWrapper);
   Romo.append(elemWrapper, this.elem);
-
-  // the elem wrapper should be treated like a child elem.  add it to Romo's
-  // parent-child elems so it will be removed when the elem (input) is removed.
-  // delay adding it b/c the `append` statement above is not a "move", it is
-  // a "remove" and "add" so if added immediately the "remove" part will
-  // incorrectly remove the wrapper.
-  Romo.pushFn(Romo.proxy(function() {
-    Romo.parentChildElems.add(this.elem, [elemWrapper]);
-  }, this));
+  Romo.parentChildElems.add(this.elem, [elemWrapper]);
 
   this.indicatorElem = undefined;
   var indicatorClass = Romo.data(this.elem, 'romo-indicator-text-input-indicator') || this.defaultIndicatorClass;

--- a/assets/js/romo/modal.js
+++ b/assets/js/romo/modal.js
@@ -124,14 +124,7 @@ RomoModal.prototype._bindPopup = function() {
   this.closeElems  = [];
   this.dragElems   = [];
 
-  // the popup should be treated like a child elem.  add it to Romo's
-  // parent-child elems so it will be removed when the elem is removed.
-  // delay adding it b/c other components may `append` generated modals
-  // meaning the modal is removed and then re-added.  if added immediately
-  // the "remove" part will incorrectly remove the popup.
-  Romo.pushFn(Romo.proxy(function() {
-    Romo.parentChildElems.add(this.elem, [this.popupElem]);
-  }, this));
+  Romo.parentChildElems.add(this.elem, [this.popupElem]);
   Romo.on(this.popupElem, 'romoParentChildElems:childRemoved', Romo.proxy(function(e, childElem) {
     Romo.popupStack.closeThru(this.popupElem);
   }, this));

--- a/assets/js/romo/picker.js
+++ b/assets/js/romo/picker.js
@@ -231,15 +231,7 @@ RomoPicker.prototype._buildOptionListDropdownElem = function() {
   }
   Romo.before(romoOptionListDropdownElem, this.elemWrapper);
   Romo.append(this.elemWrapper, romoOptionListDropdownElem);
-
-  // the elem wrapper should be treated like a child elem.  add it to Romo's
-  // parent-child elems so it will be removed when the elem (picker input) is removed.
-  // delay adding it b/c other components may `append` generated pickers
-  // meaning the picker is removed and then re-added.  if added immediately
-  // the "remove" part will incorrectly remove the wrapper.
-  Romo.pushFn(Romo.proxy(function() {
-    Romo.parentChildElems.add(this.elem, [this.elemWrapper]);
-  }, this));
+  Romo.parentChildElems.add(this.elem, [this.elemWrapper]);
 
   this.caretElem = undefined;
   var caretClass = Romo.data(this.elem, 'romo-picker-caret') || this.defaultCaretClass;

--- a/assets/js/romo/select.js
+++ b/assets/js/romo/select.js
@@ -203,15 +203,7 @@ RomoSelect.prototype._buildSelectDropdownElem = function() {
   }
   Romo.before(romoSelectDropdownElem, this.elemWrapper);
   Romo.append(this.elemWrapper, romoSelectDropdownElem);
-
-  // the elem wrapper should be treated like a child elem.  add it to Romo's
-  // parent-child elems so it will be removed when the elem (select) is removed.
-  // delay adding it b/c other components may `append` generated selects
-  // meaning the select is removed and then re-added.  if added immediately
-  // the "remove" part will incorrectly remove the wrapper.
-  Romo.pushFn(Romo.proxy(function() {
-    Romo.parentChildElems.add(this.elem, [this.elemWrapper]);
-  }, this));
+  Romo.parentChildElems.add(this.elem, [this.elemWrapper]);
 
   this.caretElem = undefined;
   var caretClass = Romo.data(this.elem, 'romo-select-caret') || this.defaultCaretClass;

--- a/assets/js/romo/tooltip.js
+++ b/assets/js/romo/tooltip.js
@@ -184,14 +184,7 @@ RomoTooltip.prototype._bindPopup = function() {
     e.stopPropagation();
   })
 
-  // the popup should be treated like a child elem.  add it to Romo's
-  // parent-child elems so it will be removed when the elem is removed.
-  // delay adding it b/c other components may `append` generated tooltips
-  // meaning the tooltip is removed and then re-added.  if added immediately
-  // the "remove" part will incorrectly remove the popup.
-  Romo.pushFn(Romo.proxy(function() {
-    Romo.parentChildElems.add(this.elem, [this.popupElem]);
-  }, this));
+  Romo.parentChildElems.add(this.elem, [this.popupElem]);
 }
 
 RomoTooltip.prototype._bindAjax = function() {


### PR DESCRIPTION
This pattern was done in every usage of this API.  Instead of
repeating this (and the comments describing the purpose of it),
this commonizes the pattern in the RomoParentChildElems api.

There are no behavior changes here - just updates to remove some
code duplication.

@jcredding ready for review.