### PR TITLE
pickers/selects: update to properly calc caret width/padding

### DIFF
--- a/assets/js/romo/picker.js
+++ b/assets/js/romo/picker.js
@@ -3,6 +3,7 @@ var RomoPicker = RomoComponent(function(elem) {
 
   this.defaultCaretClass     = undefined;
   this.defaultCaretPaddingPx = 5;
+  this.defaultCaretWidthPx   = 18;
   this.defaultCaretPosition  = 'right'
   this.defaultValuesDelim    = ',';
 
@@ -246,7 +247,7 @@ RomoPicker.prototype._buildOptionListDropdownElem = function() {
     var caretPosition  = this._getCaretPosition();
 
     // add a pixel to account for the default input border
-    Romo.setStyle(this.caretElem, caretPosition, caretPaddingPx+1);
+    Romo.setStyle(this.caretElem, caretPosition, caretPaddingPx+1+'px');
 
     // left-side padding
     // + caret width
@@ -368,7 +369,7 @@ RomoPicker.prototype._getCaretPaddingPx = function() {
 RomoPicker.prototype._getCaretWidthPx = function() {
   return (
     Romo.data(this.elem, 'romo-picker-caret-width-px') ||
-    parseInt(Romo.css(this.caretElem, "width"), 10)
+    this._parseCaretWidthPx()
   );
 }
 
@@ -377,6 +378,14 @@ RomoPicker.prototype._getCaretPosition = function() {
     Romo.data(this.elem, 'romo-picker-caret-position') ||
     this.defaultCaretPosition
   );
+}
+
+RomoPicker.prototype._parseCaretWidthPx = function() {
+  var widthPx = parseInt(Romo.css(this.caretElem, "width"), 10);
+  if (isNaN(widthPx)) {
+    widthPx = this.defaultCaretWidthPx;
+  }
+  return widthPx;
 }
 
 // event functions

--- a/assets/js/romo/select.js
+++ b/assets/js/romo/select.js
@@ -3,6 +3,7 @@ var RomoSelect = RomoComponent(function(elem) {
 
   this.defaultCaretClass     = undefined;
   this.defaultCaretPaddingPx = 5;
+  this.defaultCaretWidthPx   = 18;
   this.defaultCaretPosition  = 'right'
 
   this.doInit();
@@ -218,7 +219,7 @@ RomoSelect.prototype._buildSelectDropdownElem = function() {
     var caretPosition  = this._getCaretPosition();
 
     // add a pixel to account for the default input border
-    Romo.setStyle(this.caretElem, caretPosition, caretPaddingPx+1);
+    Romo.setStyle(this.caretElem, caretPosition, caretPaddingPx+1+'px');
 
     // left-side padding
     // + caret width
@@ -299,7 +300,7 @@ RomoSelect.prototype._getCaretPaddingPx = function() {
 RomoSelect.prototype._getCaretWidthPx = function() {
   return (
     Romo.data(this.elem, 'romo-select-caret-width-px') ||
-    parseInt(Romo.css(this.caretElem, "width"), 10)
+    this._parseCaretWidthPx()
   );
 }
 
@@ -308,6 +309,14 @@ RomoSelect.prototype._getCaretPosition = function() {
     Romo.data(this.elem, 'romo-select-caret-position') ||
     this.defaultCaretPosition
   );
+}
+
+RomoSelect.prototype._parseCaretWidthPx = function() {
+  var widthPx = parseInt(Romo.css(this.caretElem, "width"), 10);
+  if (isNaN(widthPx)) {
+    widthPx = this.defaultCaretWidthPx;
+  }
+  return widthPx;
 }
 
 // event functions


### PR DESCRIPTION
There were some bugs from the port to Romo js in previous efforts.
These went unnoticed b/c they positioned fairly close to what it
should be with the errors.

This switches setting the caret padding to include the 'px' in the
`Romo.setStyle` call.  JQuery was previously taking care of this
for us and we missed this in the port.

This also updates both components to have a default caret width.
In very edge-case scenarios the width of the caret elem can't be
determined.  This came up in our app b/c the parent of the select
was `display:none`.  This breaks Romo's and jQuery's width calcs.
This adds a default to fall back to in the case you can't parse
the width.  I chose 18px b/c this is close to FontAwesome's
`fa-fw` width with Romo's default font size.  In the case this
isn't a suitable default, you can always fallback to setting the
`data-romo-{picker|select}-caret-width-px` data attr.

@jcredding ready for review.