### PR TITLE
Add a `Romo.height` and `Romo.width`, fix height/width calc in IE

### DIFF
--- a/assets/js/romo/base.js
+++ b/assets/js/romo/base.js
@@ -242,6 +242,14 @@ Romo.prototype.hide = function(elems) {
   });
 }
 
+Romo.prototype.height = function(elem) {
+  return elem.getBoundingClientRect().height;
+}
+
+Romo.prototype.width = function(elem) {
+  return elem.getBoundingClientRect().width;
+}
+
 Romo.prototype.offset = function(elem) {
   var elemRect = elem.getBoundingClientRect();
   var bodyRect = document.body.getBoundingClientRect();

--- a/assets/js/romo/datepicker.js
+++ b/assets/js/romo/datepicker.js
@@ -100,7 +100,7 @@ RomoDatepicker.prototype._bindDropdown = function() {
   if (Romo.data(this.elem, 'romo-dropdown-width') === undefined) {
     Romo.setData(this.elem, 'romo-dropdown-width', 'elem');
   }
-  if (parseInt(Romo.css(this.elem, 'width'), 10) < 175) {
+  if (Romo.width(this.elem) < 175) {
     Romo.setData(this.elem, 'romo-dropdown-width', '175px');
   }
   this.romoDropdown = new RomoDropdown(this.elem);

--- a/assets/js/romo/dropdown.js
+++ b/assets/js/romo/dropdown.js
@@ -64,11 +64,10 @@ RomoDropdown.prototype.doPlacePopupElem = function() {
     Romo.setStyle(this.contentElem, 'max-height', contentMaxHeight.toString() + 'px');
   }
 
-  var elemRect   = this.elem.getBoundingClientRect();
   var elemOffset = Romo.offset(this.elem);
 
-  var elemHeight = elemRect.height;
-  var elemWidth  = elemRect.width;
+  var elemHeight = Romo.height(this.elem);
+  var elemWidth  = Romo.width(this.elem);
   var elemTop    = elemOffset.top;
   var elemLeft   = elemOffset.left
 
@@ -225,7 +224,7 @@ RomoDropdown.prototype._bindBody = function() {
   }
 
   if (Romo.data(this.elem, 'romo-dropdown-width') === 'elem') {
-    Romo.setStyle(this.popupElem, 'width', Romo.css(this.elem, 'width'));
+    Romo.setStyle(this.popupElem, 'width', Romo.width(this.elem)+'px');
   } else {
     Romo.setStyle(this.contentElem, 'min-width', Romo.data(this.elem, 'romo-dropdown-min-width'));
     Romo.setStyle(this.contentElem, 'max-width', Romo.data(this.elem, 'romo-dropdown-max-width'));

--- a/assets/js/romo/indicator_text_input.js
+++ b/assets/js/romo/indicator_text_input.js
@@ -88,7 +88,7 @@ RomoIndicatorTextInput.prototype._bindElem = function() {
 
 RomoIndicatorTextInput.prototype._placeIndicatorElem = function() {
   if (this.indicatorElem !== undefined) {
-    Romo.setStyle(this.indicatorElem, 'line-height', Romo.css(this.elem, 'height'));
+    Romo.setStyle(this.indicatorElem, 'line-height', Romo.height(this.elem)+'px');
     if (this.elem.disabled === true) {
       Romo.addClass(this.indicatorElem, 'disabled');
     }
@@ -121,7 +121,7 @@ RomoIndicatorTextInput.prototype._getIndicatorPaddingPx = function() {
 RomoIndicatorTextInput.prototype._getIndicatorWidthPx = function() {
   return (
     Romo.data(this.elem, 'romo-indicator-text-input-indicator-width-px') ||
-    parseInt(Romo.css(this.indicatorElem, "width"), 10)
+    Romo.width(this.indicatorElem)
   );
 }
 

--- a/assets/js/romo/modal.js
+++ b/assets/js/romo/modal.js
@@ -228,8 +228,8 @@ RomoModal.prototype._dragStart = function(e) {
 
   Romo.popupStack.closeTo(this.popupElem);
 
-  Romo.setStyle(this.popupElem, 'width',  Romo.css(this.popupElem, 'width'));
-  Romo.setStyle(this.popupElem, 'height', Romo.css(this.popupElem, 'height'));
+  Romo.setStyle(this.popupElem, 'width',  Romo.width(this.popupElem)+'px');
+  Romo.setStyle(this.popupElem, 'height', Romo.height(this.popupElem)+'px');
 
   this._dragDiffX = e.clientX - this.popupElem.offsetLeft;
   this._dragDiffY = e.clientY - this.popupElem.offsetTop;

--- a/assets/js/romo/option_list_dropdown.js
+++ b/assets/js/romo/option_list_dropdown.js
@@ -164,7 +164,7 @@ RomoOptionListDropdown.prototype._bindElem = function() {
     Romo.trigger(
       this.optionFilterElem,
       'romoIndicatorTextInput:triggerSpinnerStart',
-      [Romo.css(this.optionFilterElem, "height")]
+      [Romo.height(this.optionFilterElem)+'px']
     );
   }, this));
   Romo.on(this.elem, 'romoOptionListDropdown:triggerFilterSpinnerStop', Romo.proxy(function(e) {
@@ -393,7 +393,7 @@ RomoOptionListDropdown.prototype._scrollTopToItem = function(itemElem) {
 
     var scrollOffsetTop = Romo.offset(scrollElem).top;
     var selOffsetTop    = Romo.offset(itemElem).top;
-    var selOffset       = parseInt(Romo.css(itemElem, 'height'), 10) / 2;
+    var selOffset       = Romo.height(itemElem) / 2;
 
     scrollElem.scrollTop = selOffsetTop - scrollOffsetTop - selOffset;
   }
@@ -406,7 +406,7 @@ RomoOptionListDropdown.prototype._scrollBottomToItem = function(itemElem) {
 
     var scrollOffsetTop = Romo.offset(scrollElem).top;
     var selOffsetTop    = Romo.offset(itemElem).top;
-    var selOffset       = scrollElem.offsetHeight - parseInt(Romo.css(itemElem, 'height'), 10);
+    var selOffset       = scrollElem.offsetHeight - Romo.height(itemElem);
 
     scrollElem.scrollTop = selOffsetTop - scrollOffsetTop - selOffset;
   }
@@ -555,7 +555,7 @@ RomoOptionListDropdown.prototype.romoEvFn._onPopupOpenBodyKeyDown = function(e) 
 
   var scrollElem   = this.romoDropdown.bodyElem;
   var scrollOffset = Romo.offset(scrollElem);
-  var scrollHeight = parseInt(Romo.css(scrollElem, 'height'), 10);
+  var scrollHeight = Romo.height(scrollElem);
 
   if (e.keyCode === 38 /* Up */) {
     var prevElem = this._prevListItem();
@@ -577,7 +577,7 @@ RomoOptionListDropdown.prototype.romoEvFn._onPopupOpenBodyKeyDown = function(e) 
     if(nextElem === undefined){ return false; }
 
     var nextOffset = Romo.offset(nextElem);
-    var nextHeight = parseInt(Romo.css(nextElem, 'height'), 10);
+    var nextHeight = Romo.height(nextElem);
 
     this._highlightItem(nextElem);
 

--- a/assets/js/romo/picker.js
+++ b/assets/js/romo/picker.js
@@ -218,7 +218,7 @@ RomoPicker.prototype._buildOptionListDropdownElem = function() {
   if (Romo.attr(this.elem, 'style') !== undefined) {
     Romo.setAttr(romoOptionListDropdownElem, 'style', Romo.attr(this.elem, 'style'));
   }
-  Romo.setStyle(romoOptionListDropdownElem, 'width', Romo.css(this.elem, 'width'));
+  Romo.setStyle(romoOptionListDropdownElem, 'width', Romo.width(this.elem)+'px');
   if (Romo.attr(this.elem, 'disabled') !== undefined) {
     Romo.setAttr(this.romoOptionListDropdown.elem, 'disabled', Romo.attr(this.elem, 'disabled'));
   }
@@ -238,7 +238,7 @@ RomoPicker.prototype._buildOptionListDropdownElem = function() {
   var caretClass = Romo.data(this.elem, 'romo-picker-caret') || this.defaultCaretClass;
   if (caretClass !== undefined && caretClass !== 'none') {
     this.caretElem = Romo.elems('<i class="romo-picker-caret '+caretClass+'"></i>')[0];
-    Romo.setStyle(this.caretElem, 'line-height', parseInt(Romo.css(romoOptionListDropdownElem, "line-height"), 10)+'px');
+    Romo.setStyle(this.caretElem, 'line-height', Romo.css(romoOptionListDropdownElem, 'line-height'));
     Romo.on(this.caretElem, 'click', Romo.proxy(this._onCaretClick, this));
     Romo.append(romoOptionListDropdownElem, this.caretElem);
 
@@ -381,7 +381,7 @@ RomoPicker.prototype._getCaretPosition = function() {
 }
 
 RomoPicker.prototype._parseCaretWidthPx = function() {
-  var widthPx = parseInt(Romo.css(this.caretElem, "width"), 10);
+  var widthPx = Romo.width(this.caretElem);
   if (isNaN(widthPx)) {
     widthPx = this.defaultCaretWidthPx;
   }

--- a/assets/js/romo/select.js
+++ b/assets/js/romo/select.js
@@ -190,7 +190,7 @@ RomoSelect.prototype._buildSelectDropdownElem = function() {
   if (Romo.attr(this.elem, 'style') !== undefined) {
     Romo.setAttr(romoSelectDropdownElem, 'style', Romo.attr(this.elem, 'style'));
   }
-  Romo.setStyle(romoSelectDropdownElem, 'width', Romo.css(this.elem, 'width'));
+  Romo.setStyle(romoSelectDropdownElem, 'width', Romo.width(this.elem)+'px');
   if (Romo.attr(this.elem, 'disabled') !== undefined) {
     Romo.setAttr(this.romoSelectDropdown.elem, 'disabled', Romo.attr(this.elem, 'disabled'));
   }
@@ -210,7 +210,7 @@ RomoSelect.prototype._buildSelectDropdownElem = function() {
   var caretClass = Romo.data(this.elem, 'romo-select-caret') || this.defaultCaretClass;
   if (caretClass !== undefined && caretClass !== 'none') {
     this.caretElem = Romo.elems('<i class="romo-select-caret '+caretClass+'"></i>')[0];
-    Romo.setStyle(this.caretElem, 'line-height', parseInt(Romo.css(romoSelectDropdownElem, "line-height"), 10)+'px');
+    Romo.setStyle(this.caretElem, 'line-height', Romo.css(romoSelectDropdownElem, 'line-height'));
     Romo.on(this.caretElem, 'click', Romo.proxy(this._onCaretClick, this));
     Romo.append(romoSelectDropdownElem, this.caretElem);
 
@@ -312,7 +312,7 @@ RomoSelect.prototype._getCaretPosition = function() {
 }
 
 RomoSelect.prototype._parseCaretWidthPx = function() {
-  var widthPx = parseInt(Romo.css(this.caretElem, "width"), 10);
+  var widthPx = Romo.width(this.caretElem);
   if (isNaN(widthPx)) {
     widthPx = this.defaultCaretWidthPx;
   }

--- a/assets/js/romo/selected_options_list.js
+++ b/assets/js/romo/selected_options_list.js
@@ -59,7 +59,7 @@ RomoSelectedOptionsList.prototype.doRefreshUI = function() {
     var addElem = this._buildItemElem(addItem);
     uiListElem.append(addElem);
 
-    var listWidth       = parseInt(Romo.css(uiListElem, "width"), 10);
+    var listWidth       = Romo.width(uiListElem);
     var listLeftPad     = parseInt(Romo.css(uiListElem, "padding-left"), 10);
     var listRightPad    = parseInt(Romo.css(uiListElem, "padding-right"), 10);
     var itemBorderWidth = 1;
@@ -68,14 +68,14 @@ RomoSelectedOptionsList.prototype.doRefreshUI = function() {
     Romo.setStyle(Romo.find(addElem, 'DIV')[0], 'max-width', String(listWidth-listLeftPad-listRightPad-(2*itemBorderWidth)-itemLeftPad-itemRightPad)+'px');
   }, this));
 
-  var focusElemWidth = parseInt(Romo.css(this.focusElem, "width"), 10);
+  var focusElemWidth = Romo.width(this.focusElem);
   Romo.setStyle(this.elem, 'width', String(focusElemWidth)+'px');
 
   var maxRows           = undefined;
-  var uiListElemHeight  = parseInt(Romo.css(uiListElem, "height"), 10);
+  var uiListElemHeight  = Romo.height(uiListElem);
   var firstItemElem = Romo.find(uiListElem, '.romo-selected-options-list-item')[0];
   if (firstItemElem !== undefined) {
-    var itemHeight       = parseInt(Romo.css(firstItemElem, "height"), 10);
+    var itemHeight       = Romo.height(firstItemElem);
     var itemMarginBottom = parseInt(Romo.css(firstItemElem, "margin-bottom"), 10);
     var itemBorderWidth  = 1;
     var listTopPad       = parseInt(Romo.css(uiListElem, "padding-top"), 10);
@@ -131,7 +131,7 @@ RomoSelectedOptionsList.prototype._scrollListTopToItem = function(itemElem) {
 
     var scrollOffsetTop = Romo.offset(scrollElem).top;
     var selOffsetTop    = Romo.offset(itemElem).top;
-    var selOffset       = parseInt(Romo.css(itemElem, 'height'), 10) / 2;
+    var selOffset       = Romo.height(itemElem) / 2;
 
     scrollElem.scrollTop = selOffsetTop - scrollOffsetTop - selOffset;
   }

--- a/assets/js/romo/sortable.js
+++ b/assets/js/romo/sortable.js
@@ -130,7 +130,7 @@ RomoSortable.prototype.romoEvFn._onDragStart = function(e) {
   var elems = Romo.children(Romo.parent(this.draggedElem));
   this.draggedIndex = elems.indexOf(this.draggedElem);
 
-  Romo.setStyle(this.placeholderElem, 'height', Romo.css(this.draggedElem, 'height'));
+  Romo.setStyle(this.placeholderElem, 'height', Romo.height(this.draggedElem)+'px');
 
   Romo.trigger(this.elem, 'romoSortable:dragStart', [this.draggedElem, this]);
 }

--- a/assets/js/romo/spinner.js
+++ b/assets/js/romo/spinner.js
@@ -14,7 +14,7 @@ RomoSpinner.prototype.doStart = function(customBasisSize) {
   var basisSize = (
     customBasisSize                                 ||
     Romo.data(this.elem, 'romo-spinner-basis-size') ||
-    Math.min(parseInt(Romo.css(this.elem, "width"), 10), parseInt(Romo.css(this.elem, "height"), 10))
+    Math.min(Romo.width(this.elem), Romo.height(this.elem))
   );
 
   var spinnerOpts = {
@@ -41,8 +41,8 @@ RomoSpinner.prototype.doStart = function(customBasisSize) {
   this.elemStyle = Romo.attr(this.elem, 'style');
 
   Romo.setStyle(this.elem, 'position', 'relative');
-  Romo.setStyle(this.elem, 'width',    Romo.css(this.elem, 'width'));
-  Romo.setStyle(this.elem, 'height',   Romo.css(this.elem, 'height'));
+  Romo.setStyle(this.elem, 'width',    Romo.width(this.elem)+'px');
+  Romo.setStyle(this.elem, 'height',   Romo.height(this.elem)+'px');
 
   Romo.updateHtml(this.elem, '');
   this.spinner.spin(this.elem);

--- a/assets/js/romo/tooltip.js
+++ b/assets/js/romo/tooltip.js
@@ -73,11 +73,10 @@ RomoTooltip.prototype.doPlacePopupElem = function() {
     Romo.setStyle(this.bodyElem, 'max-height', configHeight.toString() + 'px');
   }
 
-  var elemRect   = this.elem.getBoundingClientRect();
   var elemOffset = Romo.offset(this.elem);
 
-  var elemHeight = elemRect.height;
-  var elemWidth  = elemRect.width;
+  var elemHeight = Romo.height(this.elem);
+  var elemWidth  = Romo.width(this.elem);
   var elemTop    = elemOffset.top;
   var elemLeft   = elemOffset.left
 


### PR DESCRIPTION
This fixes issues in Internet Explorer with trying to calculate
the height/width of an element. This is part of an effort to
update romo to support later versions of IE. IE's
`getComputedStyle` for height and width isn't consistent with the
other browsers when the element is using border-box box sizing.
This causes many things to not be sized correctly.

This fixes the issue by using `getBoundingClientRect` to get the
height or width of an element. This is abstracted behind the
`Romo.height` and `Romo.width` helpers which will allow us to
switch to a different method for getting the height or width if
the need arises.

This updates any usage of `Romo.css` with width or height to
instead use the new helpers. For some logic this also required
adding `px` to the numbers returned by the width and height
helpers particularly when setting an element's style.

This also updates some manual usage of `getBoundingClientRect`
in the dropdown and tooltip components to also switch to the
`Romo.width` and `Romo.height` helpers. This is to centralize
this logic and if we need to change how we calculate height/width
then we can change it in one place for all of romo.

This also simplifies the picker and select setting the line-height
of their caret element. We were previously parsing the line-height
to an integer and then re-adding the `px` to it to set the style.
In this case we can just directly read the style from one elem
and set the style from the other elem and not worry about parsing
it into an integer.

@kellyredding - Ready for review.