### PR TITLE
Update Modal and DropDown `openPopup`

### DIFF
--- a/assets/js/romo/dropdown.js
+++ b/assets/js/romo/dropdown.js
@@ -111,8 +111,8 @@ RomoDropdown.prototype._openPopup = function() {
   Romo.on(Romo.scrollableParents(this.elem), 'scroll', this._onScrollableParentsScroll);
 
   if (Romo.data(this.elem, 'romo-dropdown-content-elem') !== undefined) {
-    var contentElem = Romo.elems(Romo.data(this.elem, 'romo-dropdown-content-elem'))[0];
-    this._loadBodySuccess(contentElem.outerHTML);
+    var contentElem = Romo.f(Romo.data(this.elem, 'romo-dropdown-content-elem'))[0];
+    this._loadBodySuccess(contentElem.innerHTML);
   } else {
     this.romoAjax.doInvoke();
   }

--- a/assets/js/romo/modal.js
+++ b/assets/js/romo/modal.js
@@ -73,8 +73,8 @@ RomoModal.prototype.doPlacePopupElem = function() {
 
 RomoModal.prototype._openPopup = function() {
   if (Romo.data(this.elem, 'romo-modal-content-elem') !== undefined) {
-    var contentElem = Romo.elems(Romo.data(this.elem, 'romo-modal-content-elem'))[0];
-    this._loadBodySuccess(contentElem.outerHTML);
+    var contentElem = Romo.f(Romo.data(this.elem, 'romo-modal-content-elem'))[0];
+    this._loadBodySuccess(contentElem.innerHTML);
   } else {
     this.romoAjax.doInvoke();
   }


### PR DESCRIPTION
This updates the `openPopup` method in both the Modal and
Dropdown js. In both cases, the `contenElem` was undefined,
thereby erroring when `outerHTML` was being called on it. This
is erroring live in an app. This is now updated to correctly find 
the `contentElem`.

Also, I changed the `outerHTML` call on the `contentElem` to
`innerHtml`. With the "outer" call, nothing was being returned
as the standard mark-up for this situation has a `romo-display-none`
class. Changing to `innerHTML` fixed this issue.

This method, in both the Modal and Dropdown js, were updated in a
previous effort to get the `RomoModal` component to stop using
jquery. For reference see: 1e9381e

@redding  Ready for review. 