### PR TITLE
Update `doStart` and `doStop` to methods in Spinner js

### DIFF
--- a/assets/js/romo/spinner.js
+++ b/assets/js/romo/spinner.js
@@ -11,6 +11,10 @@ var RomoSpinner = RomoComponent(function(elem) {
 });
 
 RomoSpinner.prototype.doStart = function(customBasisSize) {
+  if (this.spinner !== undefined) {
+    return;
+  }
+
   var basisSize = (
     customBasisSize                                 ||
     Romo.data(this.elem, 'romo-spinner-basis-size') ||
@@ -51,6 +55,10 @@ RomoSpinner.prototype.doStart = function(customBasisSize) {
 }
 
 RomoSpinner.prototype.doStop = function() {
+  if (this.spinner === undefined) {
+    return;
+  }
+
   if (this.spinner !== undefined) {
     this.spinner.stop();
     this.spinner = undefined;


### PR DESCRIPTION
This updates the `doStart` and `doStop` methods in the Spinner js
to include undefined checks before any of their specific logic
is run. This allows for calling start on an already started spinner
and stop on an already stopped spinner. This would error in some
cases when the same spinner elems were triggered to start/stop
multiple times.

@redding Ready for review.