### PR TITLE
fix a bug when adding popup stack elems

### DIFF
--- a/assets/js/romo/base.js
+++ b/assets/js/romo/base.js
@@ -967,11 +967,12 @@ RomoPopupStack.prototype.addStyleClass = function(styleClass) {
 }
 
 RomoPopupStack.prototype.addElem = function(popupElem, boundOpenFn, boundCloseFn, boundPlaceFn) {
-  this.items.push(new this.itemClass(popupElem, boundCloseFn, boundPlaceFn));
-
   // allow any body click events to propagate and run first.  This ensures
   // any existing stack is in the appropriate state before opening a new popup.
-  Romo.pushFn(boundOpenFn);
+  Romo.pushFn(Romo.proxy(function() {
+    this.items.push(new this.itemClass(popupElem, boundCloseFn, boundPlaceFn));
+    boundOpenFn();
+  }, this));
 }
 
 RomoPopupStack.prototype.closeThru = function(popupElem) {


### PR DESCRIPTION
Previously, this added the item to the stack and then allowed
the body click to propagate before opening the item.  In certain
scenarios, the body click could cause the stack to purge all items
thinking the click was a close all operation.

This switches to delay adding the item to the stack until after
the body click has propagated.  This should have been done before
and is a better design.  Now the item is added and immediately
opened - all after the body click has propagated.

@jcredding ready for review.

@nweathersbee FYI.