### PR TITLE
Fix form submit click checking if its submit is disabled or a confirm

### DIFF
--- a/assets/js/romo/form.js
+++ b/assets/js/romo/form.js
@@ -211,7 +211,12 @@ RomoForm.prototype._getXhrDataType = function() {
 RomoForm.prototype.romoEvFn._onSubmitClick = function(e) {
   e.preventDefault();
 
-  var submitElem = e.target;
+  var submitElem;
+  if (Romo.is(e.target, '[data-romo-form-submit]')) {
+    submitElem = e.target;
+  } else {
+    submitElem = Romo.closest(e.target, '[data-romo-form-submit]');
+  }
   if (!Romo.hasClass(submitElem, 'disabled')) {
     if (Romo.data(submitElem, 'romo-form-submit') === 'confirm') {
       Romo.trigger(this.elem, 'romoForm:confirmSubmit', [this]);


### PR DESCRIPTION
This fixes the form submit click checking if the submit elem is
disabled or if its supposed to trigger a confirm. This sometimes
worked depending on if there were elements within the submit
elem. If elements were withing the submit elem sometimes the
`e.target` would be one of the elems within the submit instead of
the submit. This fixes the issue by checking if the target is a
submit and if not finding the closet submit. This ensures the form
correctly sees if a submit is disabled or a confirm.

@kellyredding - Ready for review.