### PR TITLE
Add `RomoDate.daysDiff` helper

### DIFF
--- a/assets/js/romo/date.js
+++ b/assets/js/romo/date.js
@@ -78,6 +78,12 @@ var RomoDate = {
     return RomoDate.daysInMonth(d) - d.getDate() + 1;
   },
 
+  daysDiff: function(firstDate, secondDate) {
+    var fd = RomoDate.date(firstDate);
+    var sd = RomoDate.date(secondDate);
+    return Math.round((fd.getTime() - sd.getTime()) / 864e5); // 1000 * 60 * 60 * 24
+  },
+
   isoWeekNum: function(weekDate) {
     var d = RomoDate.date(weekDate)
 


### PR DESCRIPTION
This adds a helper for calculating the number of days between
two dates. The helper converts the dates to their millisecond
time values, subtracts them, and then converts the difference to
a number of days by dividing it by the number of milliseconds in
a day. The helper rounds the difference to get an integer of the
days.

@kellyredding - Ready for review.