### PR TITLE
Update form to allow event submitting

### DIFF
--- a/assets/js/romo/dropdown_form.js
+++ b/assets/js/romo/dropdown_form.js
@@ -89,6 +89,9 @@ RomoDropdownForm.prototype._bindForm = function() {
     Romo.on(formElem, 'romoForm:browserSubmit', Romo.proxy(function(e, romoForm) {
       Romo.trigger(this.elem, 'romoDropdownForm:romoForm:browserSubmit', [romoForm, this]);
     }, this));
+    Romo.on(formElem, 'romoForm:eventSubmit', Romo.proxy(function(e, formValues, romoForm) {
+      Romo.trigger(this.elem, 'romoDropdownForm:romoForm:eventSubmit', [formValues, romoForm, this]);
+    }, this));
 
     var submitElems  = Romo.find(this.romoDropdown.popupElem, '[data-romo-form-submit]');
     var spinnerElems = Romo.find(this.romoDropdown.popupElem, '[data-romo-spinner-auto="true"]');

--- a/assets/js/romo/form.js
+++ b/assets/js/romo/form.js
@@ -77,19 +77,27 @@ RomoForm.prototype._submit = function() {
 
   if(Romo.data(this.elem, 'romo-form-browser-submit') === true) {
     this._browserSubmit();
+  } else if (Romo.data(this.elem, 'romo-form-event-submit') === true) {
+    this._eventSubmit();
   } else if (Romo.attr(this.elem, 'method').toUpperCase() === 'GET') {
-    this._nonBrowserGetSubmit();
+    this._ajaxGetSubmit();
   } else {
-    this._nonBrowserNonGetSubmit();
+    this._ajaxNonGetSubmit();
   }
 }
 
 RomoForm.prototype._browserSubmit = function() {
-  this.elem.submit();
   Romo.trigger(this.elem, 'romoForm:browserSubmit', [this]);
+  this.elem.submit();
 }
 
-RomoForm.prototype._nonBrowserGetSubmit = function() {
+RomoForm.prototype._eventSubmit = function() {
+  var formValues = this._getFormValues({ includeFiles: true });
+  Romo.trigger(this.elem, 'romoForm:eventSubmit', [formValues, this]);
+  this._completeSubmit();
+}
+
+RomoForm.prototype._ajaxGetSubmit = function() {
   var formValues = this._getFormValues({ includeFiles: false });
 
   if (Romo.data(this.elem, 'romo-form-redirect-page') === true) {
@@ -107,7 +115,7 @@ RomoForm.prototype._nonBrowserGetSubmit = function() {
   }
 }
 
-RomoForm.prototype._nonBrowserNonGetSubmit = function() {
+RomoForm.prototype._ajaxNonGetSubmit = function() {
   var formValues = this._getFormValues({ includeFiles: true });
 
   this._ajaxSubmit(formValues);

--- a/assets/js/romo/inline_form.js
+++ b/assets/js/romo/inline_form.js
@@ -85,6 +85,12 @@ RomoInlineForm.prototype._bindForm = function() {
     Romo.on(formElem, 'romoForm:submitError', Romo.proxy(function(e, xhr, romoForm) {
       Romo.trigger(this.elem, 'romoInlineForm:romoForm:submitError', [xhr, romoForm, this]);
     }, this));
+    Romo.on(formElem, 'romoForm:browserSubmit', Romo.proxy(function(e, romoForm) {
+      Romo.trigger(this.elem, 'romoInlineForm:romoForm:browserSubmit', [romoForm, this]);
+    }, this));
+    Romo.on(formElem, 'romoForm:eventSubmit', Romo.proxy(function(e, formValues, romoForm) {
+      Romo.trigger(this.elem, 'romoInlineForm:romoForm:eventSubmit', [formValues, romoForm, this]);
+    }, this));
 
     var submitElems  = Romo.find(this.elem, '[data-romo-form-submit]');
     var spinnerElems = Romo.find(this.elem, '[data-romo-spinner-auto="true"]');

--- a/assets/js/romo/modal_form.js
+++ b/assets/js/romo/modal_form.js
@@ -98,6 +98,9 @@ RomoModalForm.prototype._bindForm = function() {
     Romo.on(formElem, 'romoForm:browserSubmit', Romo.proxy(function(e, romoForm) {
       Romo.trigger(this.elem, 'romoModalForm:romoForm:browserSubmit', [romoForm, this]);
     }, this));
+    Romo.on(formElem, 'romoForm:eventSubmit', Romo.proxy(function(e, formValues, romoForm) {
+      Romo.trigger(this.elem, 'romoModalForm:romoForm:eventSubmit', [formValues, romoForm, this]);
+    }, this));
 
     var submitElems  = Romo.find(this.romoModal.popupElem, '[data-romo-form-submit]');
     var spinnerElems = Romo.find(this.romoModal.popupElem, '[data-romo-spinner-auto="true"]');


### PR DESCRIPTION
This updates the form component to allow configuring it to do an
event submit instead of a browser or ajax submit. The goal is to
provide a way to use romo form but not have it make a request to
the server (either as an standard HTTP request or as an ajax
request).

This adds a data attr for event submitting and checks it whenever
the form is submitted (either via a click or the trigger event).
The event submit simply builds the form values the same as an
ajax submit then triggers an event submit event with the form
values. This will allow listening for the event and then using the
form values as needed. This also proxies the event in the dropdown
form, inline form, and modal form so it can be used with those
components as well.

This also renames the non-browser submit methods to use ajax
instead of non-browser. Since the submit logic is no longer a
binary between browser or non-browser this makes for a better
name (because event submitting is also non-browser submitting).
This also matches the other private method that is already
named `_ajaxSubmit`.

Finally, this also moves the browser submit event before
submitting the form. This is because submitting the form reloads
the page so an event after it can't really be used. This allows
the event to be used before the page reloads.

@kellyredding - Ready for review.