### PR TITLE
Update `Romo.param` to use `encodeURIComponent` on keys and values

### DIFF
--- a/assets/js/romo/base.js
+++ b/assets/js/romo/base.js
@@ -604,7 +604,10 @@ Romo.prototype.param = function(data, opts) {
   var processKeyValue = function(keyValues, key, value, opts) {
     var v = String(value);
     if (!opts || !opts.removeEmpty || v !== '') {
-      keyValues.push([key, v]);
+      keyValues.push([
+        encodeURIComponent(key),
+        encodeURIComponent(v)
+      ]);
     }
   }
 


### PR DESCRIPTION
This updates the `Romo.param` method to use `encodeURIComponent`
on the param strings keys and values. This fixes an issue with
characters being ignored by browsers because they weren't encoded.
This was specifically noticed because we had newlines that were
being ignored because they were being included in a URL.

The `encodeURIComponent` converts characters to their escaped
values (`%20` for a space for example). This is consistent with
the jquery `param` method that Romo previously used before the
jquery dependency was removed. This makes the `Romo.param`
properly encode characters so they are sent to the server. The
decode param logic that the `Romo.param` helper also works with
this change and properly decodes a safe set of values that
`encodeURIComponent` aggressively encodes.

@kellyredding - Ready for review.