### PR TITLE
add base js `.removeChildren` method

### DIFF
--- a/assets/js/romo/base.js
+++ b/assets/js/romo/base.js
@@ -375,6 +375,15 @@ Romo.prototype.remove = function(elems) {
   });
 }
 
+Romo.prototype.removeChildren = function(parentElems) {
+  return Romo.array(parentElems).map(function(parentElem) {
+    Romo.children(parentElem).forEach(function(childElem) {
+      parentElem.removeChild(childElem);
+    });
+    return parentElem;
+  });
+}
+
 Romo.prototype.replace = function(elem, replacementElem) {
   elem.parentNode.replaceChild(replacementElem, elem);
   return replacementElem;


### PR DESCRIPTION
This is similar to jQuery's `.empty` method.  We debated about
reproducing that method in Romo and ultimately decided against it
b/c of not being sold on the name and edge-cases with removing
both child nodes and text.

I'm proposing this implementation as it only handles the child
nodes case and is named explicitly as such.  This compliments the
`.updateText` method where you update it to empty string to clear
the text.

@jcredding proposing this method instead of an `.empty` method.  What do you think?  I'm wanting this for one of our apps where I want to clear the UI before updating it, btw.  Does this implementation flow with the other base js methods and the API overall?