### PR TITLE
update word boundary filter to use "items" api instead of "elems"

### DIFF
--- a/assets/js/romo/select_dropdown.js
+++ b/assets/js/romo/select_dropdown.js
@@ -134,8 +134,8 @@ RomoSelectDropdown.prototype._bindElem = function() {
       return elem.textContent.replace(/\W/g, ' ');
     });
 
-    Romo.removeClass(wbFilter.matchingElems, this.filterHiddenClass);
-    Romo.addClass(wbFilter.notMatchingElems, this.filterHiddenClass);
+    Romo.removeClass(wbFilter.matchingItems, this.filterHiddenClass);
+    Romo.addClass(wbFilter.notMatchingItems, this.filterHiddenClass);
     this._setListItems();
 
     if (filterValue !== '') {

--- a/assets/js/romo/word_boundary_filter.js
+++ b/assets/js/romo/word_boundary_filter.js
@@ -1,14 +1,14 @@
-var RomoWordBoundaryFilter = function(filterString, setElems, getElemTextContentCallback) {
+var RomoWordBoundaryFilter = function(filterString, setItems, getItemTextContentCallback) {
   this.boundaryCharsRegex = /[\s-_]+/;
-  this.matchingElems      = [];
-  this.notMatchingElems   = [];
+  this.matchingItems      = [];
+  this.notMatchingItems   = [];
   this.filters            = filterString
                               .trim()
                               .toLowerCase()
                               .split(this.boundaryCharsRegex);
 
-  Romo.array(setElems).forEach(Romo.proxy(function(elem) {
-    var contentStack = getElemTextContentCallback(elem)
+  Romo.array(setItems).forEach(Romo.proxy(function(item) {
+    var contentStack = getItemTextContentCallback(item)
                          .trim()
                          .toLowerCase()
                          .split(this.boundaryCharsRegex).reverse();
@@ -33,9 +33,13 @@ var RomoWordBoundaryFilter = function(filterString, setElems, getElemTextContent
     }, this), true);
 
     if (match === true) {
-      this.matchingElems.push(elem);
+      this.matchingItems.push(item);
     } else {
-      this.notMatchingElems.push(elem);
+      this.notMatchingItems.push(item);
     }
   }, this));
+
+  // TODO: backwards compatible, remove later on
+  this.matchingElems    = this.matchingItems;
+  this.notMatchingElems = this.notMatchingItems;
 }


### PR DESCRIPTION
This is more appropriate b/c the filter works with more than just
elems - any set of objects can be filtered using this.  Therefore
we switch to the more generic "items" interface and variable names.

This would be a breaking change, but I've kept the legacy
`.{matching|notMatching}Elems` methods for backwards compatibility.
Once we've migrated everything that uses this, we'll remove these
in a breaking change.

@jcredding ready for review.