### PR TITLE
update picker/select components to emit "multiple change" events

### DIFF
--- a/assets/js/romo/picker.js
+++ b/assets/js/romo/picker.js
@@ -118,6 +118,13 @@ RomoPicker.prototype._bindSelectedOptionsList = function() {
         }
         this.romoSelectedOptionsList.doRemoveItem(itemValue);
         this._refreshUI();
+
+        Romo.trigger(this.elem, 'change');
+        Romo.trigger(
+          this.elem,
+          'romoPicker:multipleChange',
+          [currentValues, itemValue, this]
+        );
       }, this)
     );
     Romo.on(
@@ -209,7 +216,15 @@ RomoPicker.prototype._bindOptionListDropdown = function() {
     'romoOptionListDropdown:change',
     Romo.proxy(function(e, newValue, prevValue, optionListDropdown) {
       Romo.trigger(this.elem, 'change');
-      Romo.trigger(this.elem, 'romoPicker:change', [newValue, prevValue, this]);
+      if (this.romoSelectedOptionsList !== undefined) {
+        Romo.trigger(
+          this.elem,
+          'romoPicker:multipleChange',
+          [this._elemValues(), newValue, this]
+        );
+      } else {
+        Romo.trigger(this.elem, 'romoPicker:change', [newValue, prevValue, this]);
+      }
     }, this)
   );
 }

--- a/assets/js/romo/select.js
+++ b/assets/js/romo/select.js
@@ -98,6 +98,13 @@ RomoSelect.prototype._bindSelectedOptionsList = function() {
         }
         this.romoSelectedOptionsList.doRemoveItem(itemValue);
         this._refreshUI();
+
+        Romo.trigger(this.elem, 'change');
+        Romo.trigger(
+          this.elem,
+          'romoSelect:multipleChange',
+          [currentValues, itemValue, this]
+        );
       }, this)
     );
     Romo.on(
@@ -172,7 +179,15 @@ RomoSelect.prototype._bindSelectDropdown = function() {
     'romoSelectDropdown:change',
     Romo.proxy(function(e, newValue, prevValue, romoSelectDropdown) {
       Romo.trigger(this.elem, 'change');
-      Romo.trigger(this.elem, 'romoSelect:change', [newValue, prevValue, this]);
+      if (this.romoSelectedOptionsList !== undefined) {
+        Romo.trigger(
+          this.elem,
+          'romoSelect:multipleChange',
+          [this._elemValues(), newValue, this]
+        );
+      } else {
+        Romo.trigger(this.elem, 'romoSelect:change', [newValue, prevValue, this]);
+      }
     }, this)
   );
 }


### PR DESCRIPTION
I noticed this while working on the coming "color select"
component.  I noticed that if you clicked on a multiple selected
option, the value was removed but no change events were emitted.
This causes any handling meant to run on "change" to not fire when
removing multi items.

This updates the select/picker to emit "multiple change" events
when they add/remove items from their selected options list.
This is similar to how they proxy the option list dropdown's change
events.

The events emitted are the standard "change" event but also emit
the "multiple change" custom events.  These events are only
emitted when using the multiple option.  They emit with the
full set of items and either the item being added or removed
depending on the scenario.

@jcredding ready for review.