### PR TITLE
Allow appending popups (dropdowns/modals/tooltips) to a specific elem

### DIFF
--- a/assets/js/romo/color_select.js
+++ b/assets/js/romo/color_select.js
@@ -318,6 +318,20 @@ RomoColorSelect.prototype._buildOptionListDropdownElem = function() {
       Romo.data(this.elem, 'romo-color-select-dropdown-height')
     );
   }
+  if (Romo.data(this.elem, 'romo-color-select-dropdown-append-to-closest') !== undefined) {
+    Romo.setData(
+      romoOptionListDropdownElem,
+      'romo-dropdown-append-to-closest',
+      Romo.data(this.elem, 'romo-color-select-dropdown-append-to-closest')
+    );
+  }
+  if (Romo.data(this.elem, 'romo-color-select-dropdown-append-to') !== undefined) {
+    Romo.setData(
+      romoOptionListDropdownElem,
+      'romo-dropdown-append-to',
+      Romo.data(this.elem, 'romo-color-select-dropdown-append-to')
+    );
+  }
   if (Romo.data(this.elem, 'romo-color-select-filter-placeholder') !== undefined) {
     Romo.setData(
       romoOptionListDropdownElem,

--- a/assets/js/romo/dropdown.js
+++ b/assets/js/romo/dropdown.js
@@ -149,12 +149,20 @@ RomoDropdown.prototype._bindElem = function() {
 
 RomoDropdown.prototype._bindPopup = function() {
   this.popupElem = Romo.elems(
-    '<div class="romo-dropdown-popup"><div class="romo-dropdown-body"></div></div>'
+    '<div class="romo-dropdown-popup">' +
+      '<div class="romo-dropdown-body"></div>' +
+    '</div>'
   )[0];
-  var popupParentElem = Romo.closest(
-    this.elem,
-    Romo.data(this.elem, 'romo-dropdown-append-to-closest') || 'body'
-  );
+
+  var popupParentElem;
+  var appendToClosestSel = Romo.data(this.elem, 'romo-dropdown-append-to-closest');
+  if (appendToClosestSel !== undefined) {
+    popupParentElem = Romo.closest(this.elem, appendToClosestSel);
+  } else {
+    popupParentElem = Romo.f(
+      Romo.data(this.elem, 'romo-dropdown-append-to') || 'BODY'
+    )[0];
+  }
   Romo.append(popupParentElem, this.popupElem);
 
   this.bodyElem = Romo.children(this.popupElem, '.romo-dropdown-body')[0];

--- a/assets/js/romo/modal.js
+++ b/assets/js/romo/modal.js
@@ -109,9 +109,22 @@ RomoModal.prototype._bindElem = function() {
 }
 
 RomoModal.prototype._bindPopup = function() {
-  this.popupElem = Romo.elems('<div class="romo-modal-popup"><div class="romo-modal-body"></div></div>')[0];
-  var popupParentElem = Romo.closest(this.elem, Romo.data(this.elem, 'romo-dropdown-append-to-closest') || 'body');
-  Romo.append(popupParentElem, this.popupElem)
+  this.popupElem = Romo.elems(
+    '<div class="romo-modal-popup">' +
+      '<div class="romo-modal-body"></div>' +
+    '</div>'
+  )[0];
+
+  var popupParentElem;
+  var appendToClosestSel = Romo.data(this.elem, 'romo-modal-append-to-closest');
+  if (appendToClosestSel !== undefined) {
+    popupParentElem = Romo.closest(this.elem, appendToClosestSel);
+  } else {
+    popupParentElem = Romo.f(
+      Romo.data(this.elem, 'romo-modal-append-to') || 'BODY'
+    )[0];
+  }
+  Romo.append(popupParentElem, this.popupElem);
 
   this.bodyElem = Romo.children(this.popupElem, '.romo-modal-body')[0];
   if (Romo.data(this.elem, 'romo-modal-style-class') !== undefined) {

--- a/assets/js/romo/picker.js
+++ b/assets/js/romo/picker.js
@@ -279,6 +279,20 @@ RomoPicker.prototype._buildOptionListDropdownElem = function() {
       Romo.data(this.elem, 'romo-picker-dropdown-height')
     );
   }
+  if (Romo.data(this.elem, 'romo-picker-dropdown-append-to-closest') !== undefined) {
+    Romo.setData(
+      romoOptionListDropdownElem,
+      'romo-dropdown-append-to-closest',
+      Romo.data(this.elem, 'romo-picker-dropdown-append-to-closest')
+    );
+  }
+  if (Romo.data(this.elem, 'romo-picker-dropdown-append-to') !== undefined) {
+    Romo.setData(
+      romoOptionListDropdownElem,
+      'romo-dropdown-append-to',
+      Romo.data(this.elem, 'romo-picker-dropdown-append-to')
+    );
+  }
   if (Romo.data(this.elem, 'romo-picker-filter-placeholder') !== undefined) {
     Romo.setData(
       romoOptionListDropdownElem,

--- a/assets/js/romo/select.js
+++ b/assets/js/romo/select.js
@@ -237,6 +237,20 @@ RomoSelect.prototype._buildSelectDropdownElem = function() {
       Romo.data(this.elem, 'romo-select-dropdown-height')
     );
   }
+  if (Romo.data(this.elem, 'romo-select-dropdown-append-to-closest') !== undefined) {
+    Romo.setData(
+      romoOptionListDropdownElem,
+      'romo-dropdown-append-to-closest',
+      Romo.data(this.elem, 'romo-select-dropdown-append-to-closest')
+    );
+  }
+  if (Romo.data(this.elem, 'romo-select-dropdown-append-to') !== undefined) {
+    Romo.setData(
+      romoOptionListDropdownElem,
+      'romo-dropdown-append-to',
+      Romo.data(this.elem, 'romo-select-dropdown-append-to')
+    );
+  }
   if (Romo.data(this.elem, 'romo-select-filter-placeholder') !== undefined) {
     Romo.setData(
       romoSelectDropdownElem,

--- a/assets/js/romo/tooltip.js
+++ b/assets/js/romo/tooltip.js
@@ -158,8 +158,22 @@ RomoTooltip.prototype._bindElem = function() {
 }
 
 RomoTooltip.prototype._bindPopup = function() {
-  this.popupElem = Romo.elems('<div class="romo-tooltip-popup"><div class="romo-tooltip-arrow"></div><div class="romo-tooltip-body"></div></div>')[0];
-  var popupParentElem = Romo.closest(this.elem, Romo.data(this.elem, 'romo-tooltip-append-to-closest') || 'body');
+  this.popupElem = Romo.elems(
+    '<div class="romo-tooltip-popup">' +
+      '<div class="romo-tooltip-arrow"></div>' +
+      '<div class="romo-tooltip-body"></div>' +
+    '</div>'
+  )[0];
+
+  var popupParentElem;
+  var appendToClosestSel = Romo.data(this.elem, 'romo-tooltip-append-to-closest');
+  if (appendToClosestSel !== undefined) {
+    popupParentElem = Romo.closest(this.elem, appendToClosestSel);
+  } else {
+    popupParentElem = Romo.f(
+      Romo.data(this.elem, 'romo-tooltip-append-to') || 'BODY'
+    )[0];
+  }
   Romo.append(popupParentElem, this.popupElem);
 
   this.bodyElem = Romo.children(this.popupElem, '.romo-tooltip-body')[0];


### PR DESCRIPTION
This updates the dropdown, modal, and tooltip components to allow
appending their popups to a specific element. They already had
logic to append their popups to a different ancestor element but
this updates to allow them to append to any element on the page.
The main use for this is to allow mixing romo CSS and javascript
logic with legacy CSS and javascript. The popups can be appended
to a popup container elem that has the `romo` class instead of
having to add the `romo` class to the body elem which affects the
styles for the entire page.

This also updates the picker, select, and color select components
to allow using this option as well. They look for a component
specific data attr and write the dropdown append to data attr to
the dropdown elem they build. This allows their popups to be
appended to a special container the same as a regular dropdown,
modal, or tooltip.

@kellyredding - Ready for review.