### PR TITLE
Fix "ddd" `RomoDate.format` for the 11th, 12th, and 13th of the month

### DIFF
--- a/assets/js/romo/date.js
+++ b/assets/js/romo/date.js
@@ -250,20 +250,16 @@ RomoDate.Formatter.prototype.dateString = function(forDate) {
       case    "M":
         return RomoDate.Utils.monthAbbrevs[d.getMonth()]
       case  "ddd":
-        var ds = day.toString();
-        switch (ds.slice(-1)) {
-          case '1':
-            ds += 'st';
-            break;
-          case '2':
-            ds += 'nd'
-            break;
-          case '3':
-            ds += 'rd';
-            break;
-          default:
-            ds += 'th';
-            break;
+        var ds         = day.toString();
+        var dayLastNum = ds.slice(-1);
+        if (dayLastNum === '1' && ds !== '11') {
+          ds += 'st';
+        } else if (dayLastNum === '2' && ds !== '12') {
+          ds += 'nd'
+        } else if (dayLastNum === '3' && ds !== '13') {
+          ds += 'rd';
+        } else {
+          ds += 'th';
         }
         return ds;
       case   "dd":


### PR DESCRIPTION
This updates the `RomoData.format` function to better handle the
"ddd" format string when the day is the 11th, 12th, or 13th of the
month. They are currently converting these days to the 11st, 12nd,
and 13rd. This fixes the issue by expliciting checking if the
day is 11, 12, or 13 and if so not applying the normal suffix
rules when the lasy day number is 1, 2, or 3.

@kellyredding - Ready for review.