### PR TITLE
Fix select bug with Safari, set `selected` prop before setting attr

### DIFF
--- a/assets/js/romo/select.js
+++ b/assets/js/romo/select.js
@@ -366,23 +366,22 @@ RomoSelect.prototype._setValues = function(newValues) {
   var unsetValues = currentValues.filter(function(value) {
     return newValues.indexOf(value) === -1;
   });
-  var setValues = newValues.filter(function(value) {
-    return currentValues.indexOf(value) === -1;
-  });
   var unsetElems = unsetValues.map(Romo.proxy(function(value) {
     return Romo.find(this.elem, 'OPTION[value="'+value+'"]')[0];
   }, this));
-  var setElems = setValues.map(Romo.proxy(function(value) {
+  var setElems = newValues.map(Romo.proxy(function(value) {
     return Romo.find(this.elem, 'OPTION[value="'+value+'"]')[0];
   }, this));
 
+  // set the property before modifying the DOM, Safari has a bug where it won't
+  // allow setting the property if the DOM is updated first
   unsetElems.forEach(Romo.proxy(function(unsetElem) {
-    Romo.rmAttr(unsetElem, 'selected');
     unsetElem.selected = false;
+    Romo.rmAttr(unsetElem, 'selected');
   }, this));
   setElems.forEach(Romo.proxy(function(setElem) {
-    Romo.setAttr(setElem, 'selected', 'selected');
     setElem.selected = true;
+    Romo.setAttr(setElem, 'selected', 'selected');
   }, this));
 }
 


### PR DESCRIPTION
This updates the select component's logic to fix a bug with
setting values in Safari. The previous logic would remove or set
the `selected` attribute and then set the `selected` property.
This worked fine in Chrome/Firefox but in Safari it wouldn't
honor setting the `selected` property to false. This fixes the
issue by first setting the property and then setting that
attribute. This showed up because non multiple selects would have
multiple values because they didn't properly unset the previously
selected value.

This also fixes a minor issue with setting the selected values in
the `_setValues` function. The function was trying to be efficient
and not mark options as selected if it had already marked them
selected but this caused it to never mark the first option as
selected. Essentially when the romo select initializes it sets its
values based on the options markup. So, it would try to set its
initial value but it would see that its already one of its current
values and would never run the logic to set its `selected`
property or attribute. This ensures it always sets it by always
setting the property and attribute for any new values. This
exasperated the previously mentioned fix because it left selects
with only their `selected` property set (by the browser) and
no attribute set which Safari would then deny setting the
`selected` property to false.

@kellyredding - Ready for review.