### PR TITLE
Update multi selects/pickers/color-selects to work with integer values

### DIFF
--- a/assets/js/romo/selected_options_list.js
+++ b/assets/js/romo/selected_options_list.js
@@ -172,7 +172,7 @@ RomoSelectedOptionsList.prototype.romoEvFn._onItemClick = function(e) {
     var itemElem = Romo.closest(itemElem, '.romo-selected-options-list-item');
   }
   if (itemElem !== undefined) {
-    var value = Romo.data(itemElem, 'romo-selected-options-list-value');
+    var value = Romo.data(itemElem, 'romo-selected-options-list-value').toString();
     Romo.trigger(this.elem, 'romoSelectedOptionsList:itemClick', [value, this]);
   }
 }


### PR DESCRIPTION
This fixes a bug where multi selects, pickers, and color selects
don't work correctly with integer values. The issue is the
components end up trying to compare integers to strings. This
manifests by not being able to unselect items and allowing
selecting the same item multiple times.

To fix the issue, this updates the `SelectedOptionsList` to cast
the selected option list value data attr to a string. The
`Romo.data` helper will cast data values into non string values
when it can so options with integer values get their values
converted to integers and not strings. When selects, pickers,
and color selects get their current selected values (via their
`_elemValues` functions) though they are strings. This means the
component can't reliably detect if its already selected or how to 
remove it. Selects get their currently selected values by reading
the `value` attribute from their `OPTION` elems. Pickers and
color selects split the `value` of their `INPUT` elem. In both of
these cases, the values will always be strings so the selected
options list should do the same and ensure it always uses strings.

@kellyredding - Ready for review.